### PR TITLE
DS-8911 Update some Getting Started modules for use downstream

### DIFF
--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -1,14 +1,14 @@
 :_module-type: PROCEDURE
 
-[id='disabling-applications-connected-to-open-data-hub_{context}']
-= Disabling applications connected to Open Data Hub
+[id='disabling-applications_{context}']
+= Disabling applications connected to {productname-short}
 
 [role='_abstract']
 You can disable applications and components so that they do not appear on the {productname-short} dashboard when you no longer want to use them, for example, when data scientists no longer use an application or when the application's license expires.
 
 Disabling unused applications allows your data scientists to manually remove these application cards from their {productname-short} dashboard so that they can focus on the applications that they are most likely to use.
 ifndef::upstream[]
-See link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/disabling-applications-connected-to-openshift-data-science_get-started#removing-disabled-applications_get-started[Removing disabled applications from OpenShift Data Science] for more information about manually removing application cards.
+See link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/disabling-applications_get-started#removing-disabled-applications_get-started[Removing disabled applications from OpenShift Data Science] for more information about manually removing application cards.
 endif::[]
 
 [IMPORTANT]
@@ -58,14 +58,14 @@ ifdef::upstream[]
 . Change into the `odh` project.
 endif::[]
 . Click *Operators* -> *Installed Operators*.
-. Click on the operator that you want to uninstall. You can enter a keyword into the *Filter by name* field to help you find the operator faster.
-. Delete any operator resources or instances by using the tabs in the operator interface.
+. Click on the Operator that you want to uninstall. You can enter a keyword into the *Filter by name* field to help you find the Operator faster.
+. Delete any Operator resources or instances by using the tabs in the Operator interface.
 +
-During installation, some operators require the administrator to create resources or start process instances using tabs in the operator interface. These must be deleted before the operator can uninstall correctly.
+During installation, some Operators require the administrator to create resources or start process instances using tabs in the Operator interface. These must be deleted before the Operator can uninstall correctly.
 . On the *Operator Details* page, click the *Actions* drop-down menu and select *Uninstall Operator*.
 +
 An *Uninstall Operator?* dialog box is displayed.
-. Select *Uninstall* to uninstall the operator, operator deployments, and pods. After this is complete, the operator stops running and no longer receives updates.
+. Select *Uninstall* to uninstall the Operator, Operator deployments, and pods. After this is complete, the Operator stops running and no longer receives updates.
 
 [IMPORTANT]
 ====
@@ -75,7 +75,7 @@ Removing an Operator does not remove any custom resource definitions or managed 
 .Verification
 * The Operator is uninstalled from its target clusters.
 * The Operator no longer appears on the *Installed Operators* page.
-* The disabled application is no longer available for your data scientists to use, and is marked as `Disabled` on the *Enabled* page of the {productname-short} dashboard. This action may take a few minutes to occur following the removal of the operator.
+* The disabled application is no longer available for your data scientists to use, and is marked as `Disabled` on the *Enabled* page of the {productname-short} dashboard. This action may take a few minutes to occur following the removal of the Operator.
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -17,8 +17,10 @@ endif::[]
 Do not follow this procedure when disabling the following applications:
 
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
-ifndef::self-managed[]
-* Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
+ifndef::upstream[]
+    ifndef::self-managed[]
+    * Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
+    endif::[]
 endif::[]
 ====
 
@@ -30,17 +32,18 @@ ifdef::upstream[]
 * You have installed or configured the service on your {productname-short} cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
-ifndef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-* You are part of the `cluster-admins` user group in {openshift-platform}.
-* You have installed or configured the service on your {openshift-platform} cluster.
+ifndef::upstream[]
+    ifndef::self-managed[]
+    * You have logged in to the {openshift-platform} web console.
+    * You are part of the `cluster-admins` user group in {openshift-platform}.
+    * You have installed or configured the service on your {openshift-platform} cluster.
+    endif::[]
+    ifdef::self-managed[]
+    * You have logged in to the {openshift-platform} web console.
+    * You are assigned the `cluster-admin` role  in {openshift-platform}.
+    * You have installed or configured the service on your {openshift-platform} cluster.
+    endif::[]
 endif::[]
-ifdef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-* You are assigned the `cluster-admin` role  in {openshift-platform}.
-* You have installed or configured the service on your {openshift-platform} cluster.
-endif::[]
-
 .Procedure
 
 . In the {openshift-platform} web console, change into the *Administrator* perspective.

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -1,4 +1,5 @@
 :_module-type: PROCEDURE
+:upstream:
 
 [id='disabling-applications-connected-to-open-data-hub_{context}']
 = Disabling applications connected to Open Data Hub
@@ -16,16 +17,29 @@ endif::[]
 Do not follow this procedure when disabling the following applications:
 
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
-ifdef::managed[]
+ifndef::self-managed[]
 * Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
 endif::[]
 ====
 
 .Prerequisites
+ifdef::upstream[]
 * You have logged in to the {productname-short} web console.
+* The application or component that you want to disable is enabled and appears on the *Enabled* page.
 * You are part of the `cluster-admins` user group in {openshift-platform}.
 * You have installed or configured the service on your {productname-short} cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
+endif::[]
+ifndef::self-managed[]
+* You have logged in to the {openshift-platform} web console.
+* You are part of the `cluster-admins` user group in {openshift-platform}.
+* You have installed or configured the service on your {openshift-platform} cluster.
+endif::[]
+ifdef::self-managed[]
+* You have logged in to the {openshift-platform} web console.
+* You are assigned the `cluster-admin` role  in {openshift-platform}.
+* You have installed or configured the service on your {openshift-platform} cluster.
+endif::[]
 
 .Procedure
 

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -8,7 +8,7 @@ You can disable applications and components so that they do not appear on the {p
 
 Disabling unused applications allows your data scientists to manually remove these application cards from their {productname-short} dashboard so that they can focus on the applications that they are most likely to use.
 ifndef::upstream[]
-See link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/disabling-applications-connected-to-openshift-data-science_get-started#removing-disabled-applications-from-openshift-data-science_get-started[Removing disabled applications from OpenShift Data Science] for more information about manually removing application cards.
+See link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/disabling-applications-connected-to-openshift-data-science_get-started#removing-disabled-applications_get-started[Removing disabled applications from OpenShift Data Science] for more information about manually removing application cards.
 endif::[]
 
 [IMPORTANT]
@@ -18,9 +18,6 @@ Do not follow this procedure when disabling the following applications:
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
 ifdef::managed[]
 * Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
-endif::[]
-ifndef::upstream[]
-* Red Hat OpenShift Streams for Apache Kafka.
 endif::[]
 ====
 

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -1,5 +1,4 @@
 :_module-type: PROCEDURE
-:upstream:
 
 [id='disabling-applications-connected-to-open-data-hub_{context}']
 = Disabling applications connected to Open Data Hub
@@ -18,32 +17,37 @@ Do not follow this procedure when disabling the following applications:
 
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
 ifndef::upstream[]
-    ifndef::self-managed[]
-    * Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
-    endif::[]
+--
+ifndef::self-managed[]
+* Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
+endif::[]
+--
 endif::[]
 ====
 
 .Prerequisites
 ifdef::upstream[]
 * You have logged in to the {productname-short} web console.
-* The application or component that you want to disable is enabled and appears on the *Enabled* page.
 * You are part of the `cluster-admins` user group in {openshift-platform}.
 * You have installed or configured the service on your {productname-short} cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
+
 ifndef::upstream[]
-    ifndef::self-managed[]
-    * You have logged in to the {openshift-platform} web console.
-    * You are part of the `cluster-admins` user group in {openshift-platform}.
-    * You have installed or configured the service on your {openshift-platform} cluster.
-    endif::[]
-    ifdef::self-managed[]
-    * You have logged in to the {openshift-platform} web console.
-    * You are assigned the `cluster-admin` role  in {openshift-platform}.
-    * You have installed or configured the service on your {openshift-platform} cluster.
-    endif::[]
+--
+ifndef::self-managed[]
+* You have logged in to the {openshift-platform} web console.
+* You are part of the `cluster-admins` user group in {openshift-platform}.
+* You have installed or configured the service on your {openshift-platform} cluster.
 endif::[]
+ifdef::self-managed[]
+* You have logged in to the {openshift-platform} web console.
+* You are assigned the `cluster-admin` role  in {openshift-platform}.
+* You have installed or configured the service on your {openshift-platform} cluster.
+endif::[]
+--
+endif::[]
+
 .Procedure
 
 . In the {openshift-platform} web console, change into the *Administrator* perspective.
@@ -65,12 +69,12 @@ An *Uninstall Operator?* dialog box is displayed.
 
 [IMPORTANT]
 ====
-Removing an operator does not remove any of that operator's custom resource definitions or managed resources. Custom resource definitions and managed resources still exist and must be cleaned up manually. Any applications deployed by your operator and any configured off-cluster resources continue to run and must be cleaned up manually.
+Removing an Operator does not remove any custom resource definitions or managed resources for the Operator. Custom resource definitions and managed resources still exist and must be cleaned up manually. Any applications deployed by your Operator and any configured off-cluster resources continue to run and must be cleaned up manually.
 ====
 
 .Verification
-* The operator is uninstalled from its target clusters.
-* The operator no longer appears on the *Installed Operators* page.
+* The Operator is uninstalled from its target clusters.
+* The Operator no longer appears on the *Installed Operators* page.
 * The disabled application is no longer available for your data scientists to use, and is marked as `Disabled` on the *Enabled* page of the {productname-short} dashboard. This action may take a few minutes to occur following the removal of the operator.
 
 //[role="_additional-resources"]

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -8,8 +8,8 @@ You must enable SaaS-based services, such as Anaconda Professional Edition, befo
 
 Typically, you can install services, or enable services connected to {productname-short} using one of the following methods:
 
-* Enabling the service from the *Explore* page on the {productname-short} dashboard, as documented in this procedure.
-* Installing the service's operator from OperatorHub. OperatorHub is a web console for cluster administrators to discover and select Operators to install on their cluster. It is deployed by default in OpenShift Container Platform (link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/operators/administrator-tasks#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console]).
+* Enabling the service from the *Explore* page on the {productname-short} dashboard, as documented in the following procedure.
+* Installing the Operator for the service from OperatorHub. OperatorHub is a web console for cluster administrators to discover and select Operators to install on their cluster. It is deployed by default in OpenShift Container Platform (link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/operators/administrator-tasks#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console]).
 +
 ifndef::upstream[]
 [NOTE]
@@ -17,24 +17,24 @@ ifndef::upstream[]
 Deployments containing operators installed from OperatorHub may not be fully supported by Red Hat.
 ====
 endif::[]
-* Installing the service's operator from Red Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install operators]).
+* Installing the Operator for the service from Red Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install operators]).
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/4.12/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 
-For most services, the service endpoint is available on the service's tile on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
+For most services, the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
 
 ifdef::managed[]
 Some independent software vendor (ISV) applications must be installed in specific OpenShift Data Science Add-on namespaces. However, do not install ISV applications in namespaces associated with OpenShift Data Science Add-ons unless you are specifically directed to do so on the application’s card on the dashboard.
 endif::[]
 
 ifdef::self-managed[]
-Some independent software vendor (ISV) applications must be installed in specific OpenShift Data Science Operator namespaces. However, do not install ISV applications in namespaces associated with OpenShift Data Science Operators unless you are specifically directed to do so on the application’s card on the dashboard.
+Some independent software vendor (ISV) applications must be installed in specific OpenShift Data Science Operator namespaces. However, do not install ISV applications in namespaces associated with OpenShift Data Science Operators unless you are specifically directed to do so on the card for the application’s card on the dashboard.
 endif::[]
 
 ifdef::upstream[]
 Some independent software vendor (ISV) applications must be installed in specific {productname-short} Operator namespaces. However, do not install ISV applications in namespaces associated with {productname-short} Operators unless you are specifically directed to do so on the application’s card on the dashboard.
 endif::[]
 
-To help you get started quickly, you can access the service's learning resources and documentation on the **Resources** page, or by clicking the relevant link on the service's tile on the **Enabled** page.
+To help you get started quickly, you can access the service's learning resources and documentation on the **Resources** page, or by clicking the relevant link on the tile for the service on the **Enabled** page.
 
 .Prerequisites
 * You have logged in to {productname-short}.
@@ -52,7 +52,7 @@ The *Explore* page opens.
 
 .Verification
 * The service that you enabled appears on the *Enabled* page.
-* The service endpoint is displayed on the service's tile on the *Enabled* page
+* The service endpoint is displayed on the tile for the service on the *Enabled* page.
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -1,10 +1,10 @@
 :_module-type: PROCEDURE
 
-[id='enabling-services-connected-to-open-data-hub_{context}']
-= Enabling services connected to Open Data Hub
+[id='enabling-services_{context}']
+= Enabling services connected to {productname-short}
 
 [role='_abstract']
-You must enable SaaS-based services, such as Red OpenShift Streams for Apache Kafka and Anaconda, before using them with {productname-long}. On-cluster services are enabled automatically.
+You must enable SaaS-based services, such as Anaconda Professional Edition, before using them with {productname-long}. On-cluster services are enabled automatically.
 
 Typically, you can install services, or enable services connected to {productname-short} using one of the following methods:
 
@@ -20,7 +20,7 @@ endif::[]
 * Installing the service's operator from Red Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install operators]).
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/4.12/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 
-For most services, the service endpoint is available on the service's tile on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, for services such as OpenShift Streams for Apache Kafka, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
+For most services, the service endpoint is available on the service's tile on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
 
 ifdef::managed[]
 Some independent software vendor (ISV) applications must be installed in specific OpenShift Data Science Add-on namespaces. However, do not install ISV applications in namespaces associated with OpenShift Data Science Add-ons unless you are specifically directed to do so on the application’s card on the dashboard.
@@ -45,13 +45,7 @@ To help you get started quickly, you can access the service's learning resources
 +
 The *Explore* page opens.
 
-ifdef::kafka[]
-. Click the card for *Red Hat OpenShift Streams for Apache Kafka*.
-endif::[]
-ifndef::kafka[]
 . Click the card of the service that you want to enable.
-endif::[]
-
 . Click *Enable* on the drawer for the service.
 . If prompted, enter the service's key and click *Connect*.
 . Click *Enable* to confirm that you are enabling the service.

--- a/modules/launching-jupyter-and-starting-a-notebook-server.adoc
+++ b/modules/launching-jupyter-and-starting-a-notebook-server.adoc
@@ -48,8 +48,6 @@ Using GPUs to accelerate workloads is only supported with the PyTorch, TensorFlo
 --
 .. Optional: Select and specify values for any new *Environment variables*.
 +
-For example, if you plan to integrate with Red Hat OpenShift Streams for Apache Kafka, create environment variables to store your Kafka bootstrap server and the service account username and password here.
-+
 The interface stores these variables so that you only need to enter them once. Example variable names for common environment variables are automatically provided for frequently integrated environments and frameworks, such as Amazon Web Services (AWS).
 +
 [IMPORTANT]

--- a/modules/launching-jupyter-and-starting-a-notebook-server.adoc
+++ b/modules/launching-jupyter-and-starting-a-notebook-server.adoc
@@ -44,7 +44,7 @@ When a new version of a notebook image is released, the previous version remains
 +
 [IMPORTANT]
 --
-Using GPUs to accelerate workloads is only supported with the PyTorch, TensorFlow, and CUDA notebook server images.
+Using GPUs to accelerate workloads is only supported with the PyTorch, TensorFlow, and CUDA notebook server images. In addition, you can specify the number of GPUs required for your notebook server only if GPUs are enabled on your cluster.
 --
 .. Optional: Select and specify values for any new *Environment variables*.
 +
@@ -63,7 +63,7 @@ WARNING: You can be logged in to Jupyter for a maximum of 24 hours. After 24 hou
 
 
 .Verification
-* The JupyterLab interface opens in a new tab.
+* The JupyterLab interface opens.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/logging-in-to-open-data-hub.adoc
+++ b/modules/logging-in-to-open-data-hub.adoc
@@ -1,23 +1,32 @@
 :_module-type: PROCEDURE
 
-[id='logging-in-to-openshift-data-science_{context}']
-= Logging in to Open Data Hub
+[id='logging-in_{context}']
+= Logging in to {productname-short}
 
 [role='_abstract']
 Log in to {productname-short} from a browser for easy access to Jupyter and your data science projects.
 
 .Procedure
 . Browse to the {productname-short} instance URL and click *Log in with OpenShift*.
+ifdef::upstream[]
 ** If you are a data scientist user, your administrator must provide you with the {productname-short} instance URL, for example, `https:://odh-dashboard-odh.apps.ocp4.example.com`.
+endif::[]
+ifndef::upstream[]
+** If you are a data scientist user, your administrator must provide you with the OpenShift Data Science instance URL, for example, `https://rhods-dashboard-redhat-ods-applications.apps.example.abc1.p1.openshiftapps.com/`
+endif::[]
 ** If you have access to {openshift-platform}, you can browse to the {openshift-platform} web console and click the *Application Launcher* (image:images/osd-app-launcher.png[The application launcher]) -> *{productname-long}*.
 
 . Click the name of your identity provider, for example, `GitHub`.
 . Enter your credentials and click *Log in* (or equivalent for your identity provider).
 +
-
+ifdef::upstream[]
 If you have not previously authorized the `odh-dashboard` service account to access your account, the *Authorize Access* page appears prompting you to provide authorization.
 Inspect the permissions selected by default, and click the *Allow selected permissions* button.
-
+endif::[]
+ifndef::upstream[]
+If you have not previously authorized the `rhods-dashboard` service account to access your account, the *Authorize Access* page appears prompting you to provide authorization.
+Inspect the permissions selected by default, and click the *Allow selected permissions* button.
+endif::[]
 
 .Verification
 * {productname-short} opens on the *Enabled applications* page.

--- a/modules/notifications-in-open-data-hub.adoc
+++ b/modules/notifications-in-open-data-hub.adoc
@@ -1,7 +1,7 @@
 :_module-type: CONCEPT
 
-[id="notifications-in-open-data-hub_{context}"]
-= Notifications in Open Data Hub
+[id="notifications_{context}"]
+= Notifications in {productname-short}
 
 [role='_abstract']
 {productname-long} displays notifications when important events happen in the cluster.
@@ -11,7 +11,13 @@ Notification messages are displayed in the lower left corner of the {productname
 If you miss a notification message, click the *Notifications* button (image:images/rhods-notifications-icon.png[Notifications icon]) to open the *Notifications* drawer and view unread messages.
 
 .The Notifications drawer
-image::images/odh-notifications-drawer.png[The Open Data Hub interface with the Notifications drawer visible]
+ifdef::upstream[]
+image::images/odh-notifications-drawer.png[The {productname-short} interface with the Notifications drawer visible]
+endif::[]
+ifdef::upstream[]
+image::images/rhods-notifications-drawer.png[The {productname-short} interface with the Notifications drawer visible]
+endif::[]
+
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/notifications-in-open-data-hub.adoc
+++ b/modules/notifications-in-open-data-hub.adoc
@@ -14,7 +14,7 @@ If you miss a notification message, click the *Notifications* button (image:imag
 ifdef::upstream[]
 image::images/odh-notifications-drawer.png[The {productname-short} interface with the Notifications drawer visible]
 endif::[]
-ifdef::upstream[]
+ifndef::upstream[]
 image::images/rhods-notifications-drawer.png[The {productname-short} interface with the Notifications drawer visible]
 endif::[]
 

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -8,44 +8,77 @@ When you start Jupyter for the first time, or after stopping your notebook serve
 
 The *Start a notebook server* page is divided into several sections:
 
-Notebook image:: Specifies the container image that your notebook server is based on. Different notebook images have different packages installed by default. See xref:notebook-image-options_{context}[Notebook image options] for details.
-
-Deployment size:: Specifies the compute resources available on your notebook server.
+Notebook image:: Specifies the container image that your notebook server is based on. Different notebook images have different packages installed by default. If the notebook image contains multiple versions, you can select the notebook image version to use from the *Versions* section.
 +
-*Container size* controls the number of CPUs, the amount of memory, and the minimum and maximum request capacity of the container.
-
-//See xref:container-size-options[Container size options] for details.
-// GPU content was re-added during the 1.5 release work. It was then delayed to 1.6 so commenting this out.
-//+
-//*Number of GPUs* specifies the number of graphics processing units attached to the container.
-
-Environment variables:: Specifies the name and value of variables to be set on the notebook server. Setting environment variables during server startup means that you do not need to define them in the body of your notebooks, or with the Jupyter command line interface. See xref:recommended-environment-variables_{context}[Recommended environment variables] for a list of reserved variable names for each item in the *Environment variables* list.
-
-[id="notebook-image-options_{context}"]
-
+ifdef::upstream[]
+[NOTE]
+--
+When a new version of a notebook image is released, the previous version remains available and supported on the cluster. This gives you time to migrate your work to the latest version of the notebook image.
+--
+endif::[]
+ifndef::upstream[]
+[NOTE]
+--
+Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. To use the latest package versions, Red Hat recommends that you use the most recently added notebook image.
+--
+endif::[]
++
+After you start a notebook image, you can check which Python packages are installed on your notebook server and which version of the package you have by running the `pip` tool in a notebook cell.
++
+The following table shows the package versions used in the notebook images:
++
 .Notebook image options
-[cols="1,3",header]
 |===
-| Image name | Preinstalled packages
+| Image name | Image version | Preinstalled packages
 
-| CUDA
+.2+| CUDA
+| 2 (Recommended)
+a| * Python 3.9
+* CUDA 11.8
+* JupyterLab 3.5
+* Notebook 6.5
+
+| 1
 a| * Python 3.8
-* CUDA 11
+* CUDA 11.4
 * JupyterLab 3.2
 * Notebook 6.4
 
-| Minimal Python (default)
+.2+| Minimal Python (default)
+| 2 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.5
+* Notebook 6.5
+
+| 1
 a| * Python 3.8
 * JupyterLab 3.2
 * Notebook 6.4
 
-| PyTorch
+
+.2+| PyTorch
+| 2 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.5
+* Notebook 6.5
+* PyTorch 1.13
+* CUDA 11.7
+* TensorBoard 2.11
+* Boto3 1.26
+* Kafka-Python 2.0
+* Matplotlib 3.6
+* Numpy 1.24
+* Pandas 1.5
+* Scikit-learn 1.2
+* SciPy 1.10
+
+| 1
 a| * Python 3.8
 * JupyterLab 3.2
 * Notebook 6.4
 * PyTorch 1.8
-* CUDA 11
-* TensorBoard 1.15
+* CUDA 10.2
+* TensorBoard 2.6
 * Boto3 1.17
 * Kafka-Python 2.0
 * Matplotlib 3.4
@@ -54,7 +87,20 @@ a| * Python 3.8
 * Scikit-learn 0.24
 * SciPy 1.6
 
-| Standard Data Science
+.2+| Standard Data Science
+| 2 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.5
+* Notebook 6.5
+* Boto3 1.26
+* Kafka-Python 2.0
+* Matplotlib 3.6
+* Pandas 1.5
+* Numpy 1.24
+* Scikit-learn 1.2
+* SciPy 1.10
+
+| 1
 a| * Python 3.8
 * JupyterLab 3.2
 * Notebook 6.4
@@ -66,13 +112,29 @@ a| * Python 3.8
 * Scikit-learn 0.24
 * SciPy 1.6
 
-| TensorFlow
+.2+| TensorFlow
+| 2 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.5
+* Notebook 6.5
+* TensorFlow 2.11
+* TensorBoard 2.11
+* CUDA 11.8
+* Boto3 1.26
+* Kafka-Python 2.0
+* Matplotlib 3.6
+* Numpy 1.24
+* Pandas 1.5
+* Scikit-learn 1.2
+* SciPy 1.10
+
+| 1
 a| * Python 3.8
 * JupyterLab 3.2
 * Notebook 6.4
 * TensorFlow 2.7
 * TensorBoard 2.6
-* CUDA 11
+* CUDA 11.4
 * Boto3 1.17
 * Kafka-Python 2.0
 * Matplotlib 3.4
@@ -81,11 +143,35 @@ a| * Python 3.8
 * Scikit-learn 0.24
 * SciPy 1.6
 
+| TrustyAI
+| 1
+a| * Python 3.9
+* JupyterLab 3.5
+* Notebook 6.5
+* TrustyAI 0.2
+* Boto3 1.26
+* Kafka-Python 2.0
+* Matplotlib 3.6
+* Numpy 1.24
+* Pandas 1.5
+* Scikit-learn 1.2
+* SciPy 1.10
+
 |===
 
+Deployment size:: Specifies the compute resources available on your notebook server.
++
+*Container size* controls the number of CPUs, the amount of memory, and the minimum and maximum request capacity of the container.
++
+ifdef::upstream[]
+*Number of GPUs* specifies the number of graphics processing units attached to the container.
+endif::[]
+ifndef::upstream[]
+*Number of GPUs* specifies the number of graphics processing units attached to the container. To learn how to enable GPU support, see link:{rhodsdocshome}{default-format-url}/managing_users_and_user_resources/enabling-gpu-support-in-openshift-data-science_user-mgmt[Enabling GPU support in OpenShift Data Science].
+endif::[]
 
-[id="recommended-environment-variables_{context}"]
-
+Environment variables:: Specifies the name and value of variables to be set on the notebook server. Setting environment variables during server startup means that you do not need to define them in the body of your notebooks, or with the Jupyter command line interface. Some recommended environment vairables are shown in the table.
++
 .Recommended environment variables
 [cols="1,4",header]
 |===
@@ -96,6 +182,7 @@ a| * `AWS_ACCESS_KEY_ID` specifies your Access Key ID for Amazon Web Services.
 * `AWS_SECRET_ACCESS_KEY` specifies your Secret access key for the account specified in `AWS_ACCESS_KEY_ID`.
 
 |===
+
 
 ifndef::upstream[]
 [role="_additional-resources"]

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -25,7 +25,7 @@ endif::[]
 +
 After you start a notebook image, you can check which Python packages are installed on your notebook server and which version of the package you have by running the `pip` tool in a notebook cell.
 +
-The following table shows the package versions used in the notebook images:
+The following table shows the package versions used in the available notebook images:
 +
 .Notebook image options
 |===

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -1,7 +1,7 @@
 :_module-type: PROCEDURE
 
-[id='removing-disabled-applications-from-open-data-hub_{context}']
-= Removing disabled applications from Open Data Hub
+[id='removing-disabled-applications_{context}']
+= Removing disabled applications from {productname-short}
 
 [role='_abstract']
 

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -15,13 +15,13 @@ After your administrator has disabled your unused applications, you can manually
 .Procedure
 . In the {productname-short} interface, click *Enabled*.
 +
-The *Enabled* page opens. Disabled applications are denoted with `Disabled` on the application's card.
+The *Enabled* page opens. Disabled applications are denoted with `Disabled` on the card for the application.
 
 . Click *Disabled* on the card of the application that you want to remove.
 . Click the link to remove the application card.
 
 .Verification
-* The disabled application's card no longer appears on the *Enabled* page.
+* The card for the disabled application no longer appears on the *Enabled* page.
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/supported-packages.adoc
+++ b/modules/supported-packages.adoc
@@ -4,12 +4,12 @@
 = Supported packages
 
 [role="_abstract"]
-Notebook server images in {productname-long} are installed with Python 3.8 by default.
+Notebook server images in {productname-long} are installed with Python 3.9 by default.
 ifndef::upstream[]
 See the table in link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#options-for-notebook-server-environments_get-started[Options for notebook server environments] for a complete list of packages and versions included in these images.
 endif::[]
 
-You can install packages that are compatible with Python 3.8 on any notebook server that has the binaries required by that package.
+You can install packages that are compatible with Python 3.9 on any notebook server that has the binaries required by that package.
 ifndef::upstream[]
 If the required binaries are not included on the notebook server image you want to use, contact Red Hat Support to request that the binary be considered for inclusion.
 endif::[]

--- a/modules/supported-services.adoc
+++ b/modules/supported-services.adoc
@@ -40,9 +40,6 @@ endif::[]
 | Red Hat OpenShift API Management
 | OpenShift API Management is a service that accelerates time-to-value and reduces the cost of delivering API-first, microservices-based applications.
 
-| Red Hat OpenShift Streams for Apache Kafka
-| OpenShift Streams for Apache Kafka is a service for streaming data that reduces the cost and complexity of delivering real-time applications.
-
 | OpenVINO
 | OpenVINO is an open-source toolkit to help optimize deep learning performance and deploy using an inference engine onto Intel hardware.
 

--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -1,7 +1,7 @@
 :_module-type: REFERENCE
 
-[id='the-open-data-hub-user-interface_{context}']
-= The Open Data Hub user interface
+[id='user-interface_{context}']
+= The {productname-short} user interface
 
 [role='_abstract']
 The {productname-long} interface is based on the OpenShift web console user interface.
@@ -11,17 +11,32 @@ The {productname-long} user interface is divided into several areas:
 * The global navigation bar, which provides access to useful controls, such as *Help* and *Notifications*.
 +
 .The global navigation bar
+ifdef::upstream[]
 image::images/odh-topnav.png[The global navigation bar]
+endif::[]
+ifndef::upstream[]
+image::images/rhods-topnav.png[The global navigation bar]
+endif::[]
 
 * The side navigation menu, which contains different categories of pages available in Open Data Hub.
 +
 .The side navigation menu
+ifdef::upstream[]
 image::images/odh-sidenav.png[The side navigation menu]
+endif::[]
+ifndef::upstream[]
+image::images/rhods-sidenav.png[The side navigation menu]
+endif::[]
 
 * The main display area, which displays the current page and shares space with any drawers currently displaying information, such as notifications or quick start guides. The main display area also displays the *Notebook server control panel* where you can launch Jupyter by starting and configuring a notebook server. Administrators can also use the *Notebook server control panel* to manage other users' notebook servers.
 +
 .The main display area
+ifdef::upstream[]
 image::images/odh-main-area.png[The main display area]
+endif::[]
+ifndef::upstream[]
+image::images/rhods-main-area.png[The main display area]
+endif::[]
 
 == Global navigation
 

--- a/modules/tutorials-for-data-scientists.adoc
+++ b/modules/tutorials-for-data-scientists.adoc
@@ -65,9 +65,6 @@ ifndef::upstream[]
 |===
 | Resource Name | Description
 
-| Connecting to Red Hat OpenShift Streams for Apache Kafka
-| Connect to Red Hat Streams for Apache Kafka from a Jupyter notebook.
-
 | Creating a Jupyter notebook
 | Create a Jupyter notebook in JupyterLab.
 

--- a/modules/updating-your-project-with-changes-from-a-remote-git-repository.adoc
+++ b/modules/updating-your-project-with-changes-from-a-remote-git-repository.adoc
@@ -1,5 +1,4 @@
 :_module-type: PROCEDURE
-//pv2hash: 7c7d5e0f-5303-40a0-a4d8-b59630aa166b
 
 [id='updating-your-project-with-changes-from-a-remote-git-repository_{context}']
 = Updating your project with changes from a remote Git repository

--- a/modules/uploading-an-existing-notebook-file-from-a-git-repository-using-jupyterlab.adoc
+++ b/modules/uploading-an-existing-notebook-file-from-a-git-repository-using-jupyterlab.adoc
@@ -1,5 +1,4 @@
 :_module-type: PROCEDURE
-//pv2hash: 082321fe-4727-408f-a324-13bf9b98ef6e
 
 [id='uploading-an-existing-notebook-file-from-a-git-repository-using-jupyterlab_{context}']
 = Uploading an existing notebook file from a Git repository using JupyterLab

--- a/modules/uploading-an-existing-notebook-file-from-a-git-repository-using-the-command-line-interface.adoc
+++ b/modules/uploading-an-existing-notebook-file-from-a-git-repository-using-the-command-line-interface.adoc
@@ -1,5 +1,4 @@
 :_module-type: PROCEDURE
-//pv2hash: baacb03c-45ab-4ef0-ae78-9c03b89ec1fe
 
 [id='uploading-an-existing-notebook-file-from-a-git-repository-using-the-command-line-interface_{context}']
 = Uploading an existing notebook file from a Git repository using the command line interface

--- a/modules/uploading-an-existing-notebook-file-from-local-storage.adoc
+++ b/modules/uploading-an-existing-notebook-file-from-local-storage.adoc
@@ -1,5 +1,4 @@
 :_module-type: PROCEDURE
-//pv2hash: 110f4c3e-bfb4-4535-bcb4-f211d3f6034c
 
 [id='uploading-an-existing-notebook-file-from-local-storage_{context}']
 = Uploading an existing notebook file from local storage


### PR DESCRIPTION
## Description

- This PR updates various modules in the _Getting started_ guide to make them suitable for downstream use in RHODS. 
- The primary updates were to:
-- Replace any direct references to "Open Data Hub" with a product name attribute (meaning that the name will be automatically replaced with "Red Hat OpenShift Data Science" downstream) 
-- Add conditional statements to control differences between ODH-only content and content for RHODS self-managed and cloud service. 
-- Update some module IDs to remove the ODH product name. If not, this appears in the URL and is unsuitable for use in RHODS.

## How Has This Been Tested?
- These updates have been verified by generating the ODH site locally and performing a side-by-side comparison of the updated content with the _Getting started_ guide currently published on the [Open Data Hub website](https://opendatahub.io/docs/getting-started-with-open-data-hub).

