### PR TITLE
install-guide-remove-warning

### DIFF
--- a/modules/launching-jupyter-and-starting-a-notebook-server.adoc
+++ b/modules/launching-jupyter-and-starting-a-notebook-server.adoc
@@ -72,9 +72,6 @@ After the server starts, you see one of the following behaviors:
 +
 The JupyterLab interface opens according to your selection.
 --
-+
-WARNING: You can be logged in to Jupyter for a maximum of 24 hours. After 24 hours, your user credentials expire, you are logged out of Jupyter, and your notebook server pod is stopped and deleted regardless of any work running in the notebook server. To help mitigate this, your administrator can configure OAuth tokens to expire after a set period of inactivity. See link:https://docs.openshift.com/container-platform/4.9/authentication/configuring-internal-oauth.html[Configuring the internal OAuth server] for more information.
-
 
 .Verification
 * The JupyterLab interface opens.


### PR DESCRIPTION
removed obsolete warning from the getting started guide

## Description
In the Launching Jupyter and starting a notebook server, removed the warning note at the end of the procedure.

## How Has This Been Tested?
while investigating on https://issues.redhat.com/browse/RHODS-7718 they confirmed that this is not the case anymore.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
