### PR TITLE
get-start-remove-login-note

### DIFF
--- a/modules/logging-in-to-open-data-hub.adoc
+++ b/modules/logging-in-to-open-data-hub.adoc
@@ -18,15 +18,6 @@ endif::[]
 
 . Click the name of your identity provider, for example, `GitHub`.
 . Enter your credentials and click *Log in* (or equivalent for your identity provider).
-+
-ifdef::upstream[]
-If you have not previously authorized the `odh-dashboard` service account to access your account, the *Authorize Access* page appears prompting you to provide authorization.
-Inspect the permissions selected by default, and click the *Allow selected permissions* button.
-endif::[]
-ifndef::upstream[]
-If you have not previously authorized the `rhods-dashboard` service account to access your account, the *Authorize Access* page appears prompting you to provide authorization.
-Inspect the permissions selected by default, and click the *Allow selected permissions* button.
-endif::[]
 
 .Verification
 * {productname-short} opens on the *Enabled applications* page.


### PR DESCRIPTION
remove obsolete note from Getting Started guide 

## Description
removed note about authorization from the Logging in to OpenShift Data Science section
 as per RHODS-8024
