### PR TITLE
DS-9994 adding missing references to the pipelines user interface ele…

### DIFF
--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -66,6 +66,10 @@ The *Enable* button is visible only if an application does not require an OpenSh
 
 Data science projects:: The *Data science projects* page allows you to organize your data science work into a single project. From this page, you can create and manage data science projects. You can also enhance the capabilities of your data science project by adding workbenches, adding storage to your project's cluster, adding data connections, and adding model servers.
 
+Data Science Pipelines -> Pipelines:: The *Pipelines* page allows you to import, manage, track, and view data science pipelines. Using {productname-long} pipelines, you can standardize and automate machine learning workflows to enable you to develop and deploy your data science models.
+
+Data Science Pipelines -> Runs:: The *Runs* page allows you to define, manage, and track executions of a data science pipeline. A pipeline run is a single execution of a data science pipeline. You can also view a record of previously executed and scheduled runs for your data science project.
+
 Model Serving:: The *Model Serving* page allows you to manage and view the status of your deployed models. You can use this page to deploy data science models to serve intelligent applications, or to view existing deployed models. You can also determine the inference endpoint of a deployed model.
 
 Resources:: The *Resources* page displays learning resources such as documentation, how-to material, and quick start tours. You can filter visible resources using the options displayed on the left, or enter terms into the search bar.


### PR DESCRIPTION
…ments to the UI module

References to Data Science Pipelines UI components were previously not mentioned in the "Side navigation" section in the "Open Data Hub user interface" module.

## Description
I have added references to Data Science Pipelines UI components, pipelines and runs, that were previously not mentioned in the "Side navigation" section in the "Open Data Hub user interface" module.

## How Has This Been Tested?
Compared content to the user interface in an ODH build

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
