### PR TITLE
Updated working on data science page to show how to differentiate bet…

### DIFF
--- a/assemblies/working-on-data-science-projects.adoc
+++ b/assemblies/working-on-data-science-projects.adoc
@@ -12,7 +12,7 @@ ifdef::context[:parent-context: {context}]
 As a data scientist, you can organize your data science work into a single project. A data science project in {productname-short} can consist of the following components:
 
 Workbenches:: Creating a workbench allows you to add a Jupyter notebook to your project.
-Cluster storage:: For data science projects that require data to be retained, you can add cluster storage to the project.
+Cluster storage:: For data science projects that require data retention, you can add cluster storage to the project.
 Data connections:: Adding a data connection to your project allows you to connect data inputs to your workbenches.
 Models and model servers:: Deploy a trained data science model to serve intelligent applications. Your model is deployed with an endpoint that allows applications to send requests to the model.
 
@@ -22,6 +22,13 @@ endif::[]
 ifdef::self-managed[]
 Model serving is currently available as a Technology Preview. For further information on the scope of Technology Preview status, and the associated support implications, refer to link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 endif::[]
+
+[IMPORTANT]
+====
+If you create an OpenShift project outside of the {productname-short} user interface, the project is not shown on the *Data science projects* page. In addition, you cannot use features exclusive to {productname-short}, such as workbenches and model serving, with a standard OpenShift project.
+
+To classify your OpenShift project as a data science project, and to make available features exclusive to {productname-short}, you must add the label `opendatahub.io/dashboard: 'true'` to the project namespace. After you add this label, your project is subsequently shown on the *Data science projects* page.
+====
 
 //[IMPORTANT]
 //====


### PR DESCRIPTION
…ween an openshift project and a data science project

I have added an important note to the "Working with data science projects" explaining how to change a standard OpenShift project into a data science project. 

## Description
For projects created from outside of the ODH user interface, that is, created using an OpenShift instance, they are not classified as data science projects, and therefore do not have access to ODH features. The change instructs the user to add a label to the YAML code of the namespace of their OpenShift project. This label classifies the OpenShift project as a data science project. As a result their project appears on the Data science projects page in ODH, and gains access to ODH features. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
