### PR TITLE
RHODS-12521: Correcting sentence in 4.2.3

### DIFF
--- a/modules/cloning-a-scheduled-pipeline-run.adoc
+++ b/modules/cloning-a-scheduled-pipeline-run.adoc
@@ -33,7 +33,7 @@ The *Clone* page opens.
 . To configure the run type for the run that you are cloning, in the *Run type* section, perform one of the following sets of actions:
 * Select *Run once immediately after create* to specify the run that you are cloning executes once, and immediately after its creation. If you selected this option, skip to step 10.
 * Select *Schedule recurring run* to schedule the run that you are cloning to recur.
-. If you selected *Schedule recurring run* in the previous step, configure the trigger type for the run, perform one of the following actions:
+. If you selected *Schedule recurring run* in the previous step, to configure the trigger type for the run, perform one of the following actions:
 * Select *Periodic* and select the execution frequency from the *Run every* list.
 * Select *Cron* to specify the execution schedule in `cron` format. This creates a cron job to execute the run. Click the *Copy* button (image:images/osd-copy.png[]) to copy the cron job schedule to the clipboard. The field furthest to the left represents seconds. For more information about scheduling tasks using the supported `cron` format, see link:https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format[Cron Expression Format].
 . If you selected *Schedule recurring run* in step 7, configure the duration for the run that you are cloning.


### PR DESCRIPTION
Added the word 'to' under 4.2.3. Cloning a scheduled pipeline run, step 8.

    If you selected Schedule recurring run in the previous step, to configure the trigger type for the run, perform one of the following actions: 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
