### PR TITLE
DS-12413: Correcting product name attribute.

### DIFF
--- a/modules/overview-of-user-types-and-permissions.adoc
+++ b/modules/overview-of-user-types-and-permissions.adoc
@@ -51,7 +51,7 @@ endif::[]
 
 Optionally, if you want to restrict access to your {productname-short} deployment, you can create specialized user groups for users and administrators.
 
-If you decide to restrict access, and you already have user groups defined in your configured identity provider, you can add these user groups to your {productname-short} deployment. If you decide to use specialized user groups without adding these groups from an identity provider, you must create the groups in {productname-short} and then add the appropriate users to them.
+If you decide to restrict access, and you already have user groups defined in your configured identity provider, you can add these user groups to your {productname-short} deployment. If you decide to use specialized user groups without adding these groups from an identity provider, you must create the groups in {openshift-platform} and then add the appropriate users to them.
 
 ifndef::self-managed[]
 The user groups configured in {openshift-platform}, `cluster-admins` and `dedicated-admins`, are separate to any specialized {productname-short} user groups. There are some operations relevant to {productname-short} that require the `cluster-admins` or `dedicated-admins` role. Those operations include:

--- a/modules/overview-of-user-types-and-permissions.adoc
+++ b/modules/overview-of-user-types-and-permissions.adoc
@@ -51,7 +51,7 @@ endif::[]
 
 Optionally, if you want to restrict access to your {productname-short} deployment, you can create specialized user groups for users and administrators.
 
-If you decide to restrict access, and you already have user groups defined in your configured identity provider, you can add these user groups to your {productname-short} deployment. If you decide to use specialized user groups without adding these groups from an identity provider, you must create the groups in {openshift-platform} and then add the appropriate users to them.
+If you decide to restrict access, and you already have user groups defined in your configured identity provider, you can add these user groups to your {productname-short} deployment. If you decide to use specialized user groups without adding these groups from an identity provider, you must create the groups in {openshift-platform} and then add users to them.
 
 ifndef::self-managed[]
 The user groups configured in {openshift-platform}, `cluster-admins` and `dedicated-admins`, are separate to any specialized {productname-short} user groups. There are some operations relevant to {productname-short} that require the `cluster-admins` or `dedicated-admins` role. Those operations include:


### PR DESCRIPTION
In the following sentence, 'OpenShift Data Science' is incorrect, and should just be OpenShift. 

>  If you decide to use specialized user groups without adding these groups from an identity provider, you must create the groups in OpenShift Data Science and then add the appropriate users to them. 

Checked with @chtyler, and replaced {productname-short}  with {openshift-platform}.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
