### PR TITLE
RHODS-12364: Removing sentence on notification messages.

### DIFF
--- a/modules/notifications-in-open-data-hub.adoc
+++ b/modules/notifications-in-open-data-hub.adoc
@@ -6,8 +6,6 @@
 [role='_abstract']
 {productname-long} displays notifications when important events happen in the cluster.
 
-Notification messages are displayed in the lower left corner of the {productname-long} interface when they are triggered.
-
 If you miss a notification message, click the *Notifications* button (image:images/rhods-notifications-icon.png[Notifications icon]) to open the *Notifications* drawer and view unread messages.
 
 .The Notifications drawer


### PR DESCRIPTION
Per team discussion, removing the following line from notifications-in-open-data-hub:

> Notification messages are displayed in the lower left corner of the Red Hat OpenShift Data Science interface when they are triggered.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
