### PR TITLE
RHODS-5452: Adding delete trash note.

### DIFF
--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -125,7 +125,7 @@ endif::[]
 
 [NOTE]
 --
-When you delete files using the JupyterLab file explorer, the files move to your local trash folder. To free up storage space for notebooks, you must permanently delete these files.
+When you delete files using the JupyterLab file explorer, the files move to the trash folder on your computer. To free up storage space for notebooks, you must permanently delete these files.
 -- 
 
 // [role='_additional-resources']

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -125,7 +125,7 @@ endif::[]
 
 [NOTE]
 --
-When you delete files using the JupyterLab file explorer, the files move to the trash folder on your computer. To free up storage space for notebooks, you must permanently delete these files.
+When you delete files using the JupyterLab file explorer, the files move to the hidden `/opt/app-root/src/.local/share/Trash/files` folder. To free up storage space for notebooks, you must permanently delete these files.
 -- 
 
 // [role='_additional-resources']

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -125,7 +125,7 @@ endif::[]
 
 [NOTE]
 --
-When you delete files using the JupyterLab file explorer, the files move to the hidden `/opt/app-root/src/.local/share/Trash/files` folder in the PVC for the notebook. To free up storage space for notebooks, you must permanently delete these files.
+When you delete files using the JupyterLab file explorer, the files move to the hidden `/opt/app-root/src/.local/share/Trash/files` folder in the persistent storage for the notebook. To free up storage space for notebooks, you must permanently delete these files.
 -- 
 
 // [role='_additional-resources']

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -125,7 +125,7 @@ endif::[]
 
 [NOTE]
 --
-When you delete files using the JupyterLab file explorer, the files move to the hidden `/opt/app-root/src/.local/share/Trash/files` folder. To free up storage space for notebooks, you must permanently delete these files.
+When you delete files using the JupyterLab file explorer, the files move to the hidden `/opt/app-root/src/.local/share/Trash/files` folder in the PVC for the notebook. To free up storage space for notebooks, you must permanently delete these files.
 -- 
 
 // [role='_additional-resources']

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -123,6 +123,10 @@ endif::[]
 
 * Work with the user to identify files that can be deleted from the `/opt/app-root/src` directory on their notebook server to free up their existing storage space.
 
+[NOTE]
+--
+When you delete files using the JupyterLab file explorer, the files move to your local trash folder. To free up storage space for notebooks, you must permanently delete these files.
+-- 
 
 // [role='_additional-resources']
 // == Additional resources


### PR DESCRIPTION
When files are deleted using the JupyterLab file explorer, they're actually moved to the user's local trash folder. This change adds a note advising users to delete the files from their local trash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
