### PR TITLE
RHODS-12779: Adding a non-breaking space to 'Red Hat'

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -4,7 +4,7 @@
 // conditional entities for RHODS
 //ifndef::self-managed[] 
 ifdef::managed[]
-:productname-long: Red Hat OpenShift Data Science
+:productname-long: Red{nbsp}Hat OpenShift Data Science
 :productname-short: OpenShift Data Science
 :url-productname-long: red_hat_openshift_data_science
 :url-productname-short: openshift_data_science
@@ -16,7 +16,7 @@ endif::[]
 
 // conditional entities for RHODS-SM
 ifdef::self-managed[]
-:productname-long: Red Hat OpenShift Data Science Self-managed
+:productname-long: Red{nbsp}Hat OpenShift Data Science Self-managed
 :productname-short: OpenShift Data Science Self-managed
 :url-productname-long: red_hat_openshift_data_science_self-managed
 :url-productname-short: openshift_data_science_self-managed

--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -56,6 +56,7 @@ ifeval::[{vernum} > 1]
 endif::[]
 
 // generic entities
+:org-name: Red{nbsp}Hat
 :rhodsdocshome: https://access.redhat.com/documentation/en-us/{url-productname-long}/{vernum}/
 :default-format-url: html
 :ocp-latest-version: 4.13

--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -4,7 +4,7 @@
 // conditional entities for RHODS
 //ifndef::self-managed[] 
 ifdef::managed[]
-:productname-long: Red{nbsp}Hat OpenShift Data Science
+:productname-long: {org-name} OpenShift Data Science
 :productname-short: OpenShift Data Science
 :url-productname-long: red_hat_openshift_data_science
 :url-productname-short: openshift_data_science
@@ -16,7 +16,7 @@ endif::[]
 
 // conditional entities for RHODS-SM
 ifdef::self-managed[]
-:productname-long: Red{nbsp}Hat OpenShift Data Science Self-managed
+:productname-long: {org-name} OpenShift Data Science Self-managed
 :productname-short: OpenShift Data Science Self-managed
 :url-productname-long: red_hat_openshift_data_science_self-managed
 :url-productname-short: openshift_data_science_self-managed

--- a/assemblies/monitoring-models-for-bias.adoc
+++ b/assemblies/monitoring-models-for-bias.adoc
@@ -19,8 +19,8 @@ endif::preview[]
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/assemblies/monitoring-models-for-bias.adoc
+++ b/assemblies/monitoring-models-for-bias.adoc
@@ -19,8 +19,8 @@ endif::preview[]
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/assemblies/support-requirements-and-limitations.adoc
+++ b/assemblies/support-requirements-and-limitations.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 ifndef::upstream[]
-Review this section to understand the requirements for {org-name} support and any limitations to {org-name} support of {org-name} OpenShift Data Science.
+Review this section to understand the requirements for {org-name} support and any limitations to {org-name} support of {productname-long}.
 endif::[]
 
 ifndef::upstream[]

--- a/assemblies/support-requirements-and-limitations.adoc
+++ b/assemblies/support-requirements-and-limitations.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 ifndef::upstream[]
-Review this section to understand the requirements for Red Hat support and any limitations to Red Hat support of Red Hat OpenShift Data Science.
+Review this section to understand the requirements for Red{nbsp}Hat support and any limitations to Red{nbsp}Hat support of Red{nbsp}Hat OpenShift Data Science.
 endif::[]
 
 ifndef::upstream[]

--- a/assemblies/support-requirements-and-limitations.adoc
+++ b/assemblies/support-requirements-and-limitations.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 ifndef::upstream[]
-Review this section to understand the requirements for Red{nbsp}Hat support and any limitations to Red{nbsp}Hat support of Red{nbsp}Hat OpenShift Data Science.
+Review this section to understand the requirements for {org-name} support and any limitations to {org-name} support of {org-name} OpenShift Data Science.
 endif::[]
 
 ifndef::upstream[]

--- a/assemblies/working-with-data-science-pipelines.adoc
+++ b/assemblies/working-with-data-science-pipelines.adoc
@@ -35,7 +35,7 @@ ifdef::upstream[]
 Before you can use data science pipelines, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red Hat Openshift Data Science: Supported Configurations].
+Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red{nbsp}Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red{nbsp}Hat Openshift Data Science: Supported Configurations].
 endif::[]
 
 You can store your pipeline artifacts in an Amazon Web Services (AWS) Simple Storage Service (S3) bucket so that you do not consume local storage. To do this, you must first configure write access to your S3 bucket on your AWS account.

--- a/assemblies/working-with-data-science-pipelines.adoc
+++ b/assemblies/working-with-data-science-pipelines.adoc
@@ -35,7 +35,7 @@ ifdef::upstream[]
 Before you can use data science pipelines, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{org-name} Openshift Data Science: Supported Configurations].
+Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{productname-long}: Supported Configurations].
 endif::[]
 
 You can store your pipeline artifacts in an Amazon Web Services (AWS) Simple Storage Service (S3) bucket so that you do not consume local storage. To do this, you must first configure write access to your S3 bucket on your AWS account.

--- a/assemblies/working-with-data-science-pipelines.adoc
+++ b/assemblies/working-with-data-science-pipelines.adoc
@@ -35,7 +35,7 @@ ifdef::upstream[]
 Before you can use data science pipelines, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red{nbsp}Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red{nbsp}Hat Openshift Data Science: Supported Configurations].
+Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{org-name} Openshift Data Science: Supported Configurations].
 endif::[]
 
 You can store your pipeline artifacts in an Amazon Web Services (AWS) Simple Storage Service (S3) bucket so that you do not consume local storage. To do this, you must first configure write access to your S3 bucket on your AWS account.

--- a/modules/common-questions.adoc
+++ b/modules/common-questions.adoc
@@ -4,7 +4,7 @@
 = Common questions
 
 [role="_abstract"]
-In addition to documentation, Red Hat provides a rich set of learning resources for {productname-short} and supported applications.
+In addition to documentation, Red{nbsp}Hat provides a rich set of learning resources for {productname-short} and supported applications.
 
 On the *Resources* page of the {productname-short} dashboard, you can use the category links to filter the resources for various stages of your data science workflow.
 For example, click the *Model serving* category to display resources that describe various methods of deploying models.

--- a/modules/common-questions.adoc
+++ b/modules/common-questions.adoc
@@ -4,7 +4,7 @@
 = Common questions
 
 [role="_abstract"]
-In addition to documentation, Red{nbsp}Hat provides a rich set of learning resources for {productname-short} and supported applications.
+In addition to documentation, {org-name} provides a rich set of learning resources for {productname-short} and supported applications.
 
 On the *Resources* page of the {productname-short} dashboard, you can use the category links to filter the resources for various stages of your data science workflow.
 For example, click the *Model serving* category to display resources that describe various methods of deploying models.

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -8,9 +8,9 @@ ifdef::upstream[]
 You can configure custom notebook images that cater to your project's specific requirements.
 endif::[]
 ifndef::upstream[]
-In addition to notebook images provided and supported by Red{nbsp}Hat and independent software vendors (ISVs), you can configure custom notebook images that cater to your project's specific requirements.
+In addition to notebook images provided and supported by {org-name} and independent software vendors (ISVs), you can configure custom notebook images that cater to your project's specific requirements.
 
-Red{nbsp}Hat supports you in adding custom notebook images to your deployment of {productname-short} and ensuring that they are available for selection when creating a notebook server. However, Red{nbsp}Hat does not support the contents of your custom notebook image. That is, if your custom notebook image is available for selection during notebook server creation, but does not create a usable notebook server, Red{nbsp}Hat does not provide support to fix your custom notebook image.
+{org-name} supports you in adding custom notebook images to your deployment of {productname-short} and ensuring that they are available for selection when creating a notebook server. However, {org-name} does not support the contents of your custom notebook image. That is, if your custom notebook image is available for selection during notebook server creation, but does not create a usable notebook server, {org-name} does not provide support to fix your custom notebook image.
 endif::[]
 
 .Prerequisites

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -8,9 +8,9 @@ ifdef::upstream[]
 You can configure custom notebook images that cater to your project's specific requirements.
 endif::[]
 ifndef::upstream[]
-In addition to notebook images provided and supported by Red Hat and independent software vendors (ISVs), you can configure custom notebook images that cater to your project's specific requirements.
+In addition to notebook images provided and supported by Red{nbsp}Hat and independent software vendors (ISVs), you can configure custom notebook images that cater to your project's specific requirements.
 
-Red Hat supports you in adding custom notebook images to your deployment of {productname-short} and ensuring that they are available for selection when creating a notebook server. However, Red Hat does not support the contents of your custom notebook image. That is, if your custom notebook image is available for selection during notebook server creation, but does not create a usable notebook server, Red Hat does not provide support to fix your custom notebook image.
+Red{nbsp}Hat supports you in adding custom notebook images to your deployment of {productname-short} and ensuring that they are available for selection when creating a notebook server. However, Red{nbsp}Hat does not support the contents of your custom notebook image. That is, if your custom notebook image is available for selection during notebook server creation, but does not create a usable notebook server, Red{nbsp}Hat does not provide support to fix your custom notebook image.
 endif::[]
 
 .Prerequisites

--- a/modules/configuring-bias-monitoring-cli.adoc
+++ b/modules/configuring-bias-monitoring-cli.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/configuring-bias-monitoring-cli.adoc
+++ b/modules/configuring-bias-monitoring-cli.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/configuring-bias-monitoring-ui.adoc
+++ b/modules/configuring-bias-monitoring-ui.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/configuring-bias-monitoring-ui.adoc
+++ b/modules/configuring-bias-monitoring-ui.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -8,7 +8,7 @@ To configure how resources are claimed within your {productname-short} cluster, 
 
 //Changing your cluster's default PVC size causes a redeployment of the Jupyter server launcher, making it temporarily unavailable. PVCs that were already assigned before the default size was changed are unaffected and retain their original size. Notebook servers created by users before the PVC size change are also unaffected.
 
-//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
+//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red{nbsp}Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -8,7 +8,7 @@ To configure how resources are claimed within your {productname-short} cluster, 
 
 //Changing your cluster's default PVC size causes a redeployment of the Jupyter server launcher, making it temporarily unavailable. PVCs that were already assigned before the default size was changed are unaffected and retain their original size. Notebook servers created by users before the PVC size change are also unaffected.
 
-//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red{nbsp}Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
+//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -19,7 +19,7 @@ Do not follow this procedure when disabling the following applications:
 ifndef::upstream[]
 --
 ifndef::self-managed[]
-* Red Hat OpenShift API Management. You can only uninstall Red Hat OpenShift API Management from OpenShift Cluster Manager.
+* Red{nbsp}Hat OpenShift API Management. You can only uninstall Red{nbsp}Hat OpenShift API Management from OpenShift Cluster Manager.
 endif::[]
 --
 endif::[]

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -19,7 +19,7 @@ Do not follow this procedure when disabling the following applications:
 ifndef::upstream[]
 --
 ifndef::self-managed[]
-* Red{nbsp}Hat OpenShift API Management. You can only uninstall Red{nbsp}Hat OpenShift API Management from OpenShift Cluster Manager.
+* {org-name} OpenShift API Management. You can only uninstall {org-name} OpenShift API Management from OpenShift Cluster Manager.
 endif::[]
 --
 endif::[]

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -14,10 +14,10 @@ Typically, you can install services, or enable services connected to {productnam
 ifndef::upstream[]
 [NOTE]
 ====
-Deployments containing Operators installed from OperatorHub may not be fully supported by Red{nbsp}Hat.
+Deployments containing Operators installed from OperatorHub may not be fully supported by {org-name}.
 ====
 endif::[]
-* Installing the Operator for the service from Red{nbsp}Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
+* Installing the Operator for the service from {org-name} Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/4.13/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 
 For some services (such as Jupyter), the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -14,10 +14,10 @@ Typically, you can install services, or enable services connected to {productnam
 ifndef::upstream[]
 [NOTE]
 ====
-Deployments containing Operators installed from OperatorHub may not be fully supported by Red Hat.
+Deployments containing Operators installed from OperatorHub may not be fully supported by Red{nbsp}Hat.
 ====
 endif::[]
-* Installing the Operator for the service from Red Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
+* Installing the Operator for the service from Red{nbsp}Hat Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/4.13/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 
 For some services (such as Jupyter), the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.

--- a/modules/enabling-trustyai-service-cli.adoc
+++ b/modules/enabling-trustyai-service-cli.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/enabling-trustyai-service-cli.adoc
+++ b/modules/enabling-trustyai-service-cli.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/installing-python-packages-on-your-notebook-server.adoc
+++ b/modules/installing-python-packages-on-your-notebook-server.adoc
@@ -15,7 +15,7 @@
 You can install Python packages that are not part of the default notebook server image by adding the package and the version to a `requirements.txt` file and then running the `pip install` command in a notebook cell.
 
 ifndef::upstream[]
-NOTE: You can also install packages directly, but Red Hat recommends using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
+NOTE: You can also install packages directly, but Red{nbsp}Hat recommends using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
 endif::[]
 ifdef::upstream[]
 NOTE: You can also install packages directly, but using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks is recommended. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
@@ -48,7 +48,7 @@ altair==4.1.0
 ifndef::upstream[]
 [NOTE]
 ====
-Red Hat recommends specifying exact package versions to enhance the stability of your notebook server over time. New package versions can introduce undesirable or unexpected changes in your environment's behavior.
+Red{nbsp}Hat recommends specifying exact package versions to enhance the stability of your notebook server over time. New package versions can introduce undesirable or unexpected changes in your environment's behavior.
 ====
 endif::[]
 ifdef::upstream[]

--- a/modules/installing-python-packages-on-your-notebook-server.adoc
+++ b/modules/installing-python-packages-on-your-notebook-server.adoc
@@ -15,7 +15,7 @@
 You can install Python packages that are not part of the default notebook server image by adding the package and the version to a `requirements.txt` file and then running the `pip install` command in a notebook cell.
 
 ifndef::upstream[]
-NOTE: You can also install packages directly, but Red{nbsp}Hat recommends using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
+NOTE: You can also install packages directly, but {org-name} recommends using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
 endif::[]
 ifdef::upstream[]
 NOTE: You can also install packages directly, but using a `requirements.txt` file so that the packages stated in the file can be easily re-used across different notebooks is recommended. In addition, using a `requirements.txt` file is also useful when using a S2I build to deploy a model.
@@ -48,7 +48,7 @@ altair==4.1.0
 ifndef::upstream[]
 [NOTE]
 ====
-Red{nbsp}Hat recommends specifying exact package versions to enhance the stability of your notebook server over time. New package versions can introduce undesirable or unexpected changes in your environment's behavior.
+{org-name} recommends specifying exact package versions to enhance the stability of your notebook server over time. New package versions can introduce undesirable or unexpected changes in your environment's behavior.
 ====
 endif::[]
 ifdef::upstream[]

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -19,7 +19,7 @@ endif::[]
 ifndef::upstream[]
 [NOTE]
 --
-Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. To use the latest package versions, Red{nbsp}Hat recommends that you use the most recently added notebook image.
+Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. To use the latest package versions, {org-name} recommends that you use the most recently added notebook image.
 --
 endif::[]
 +

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -19,7 +19,7 @@ endif::[]
 ifndef::upstream[]
 [NOTE]
 --
-Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. To use the latest package versions, Red Hat recommends that you use the most recently added notebook image.
+Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur approximately every six months. Therefore, two supported notebook images are typically available at any given time. To use the latest package versions, Red{nbsp}Hat recommends that you use the most recently added notebook image.
 --
 endif::[]
 +

--- a/modules/overview-of-pipelines-in-jupyterlab.adoc
+++ b/modules/overview-of-pipelines-in-jupyterlab.adoc
@@ -10,7 +10,7 @@ ifdef::upstream[]
 Before you can work with pipelines in JupyterLab, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{org-name} Openshift Data Science: Supported Configurations].
+Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{productname-long}: Supported Configurations].
 endif::[]
 
 You can access the Elyra extension within JupyterLab when you create the most recent version of one of the following notebook images:

--- a/modules/overview-of-pipelines-in-jupyterlab.adoc
+++ b/modules/overview-of-pipelines-in-jupyterlab.adoc
@@ -10,7 +10,7 @@ ifdef::upstream[]
 Before you can work with pipelines in JupyterLab, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red{nbsp}Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red{nbsp}Hat Openshift Data Science: Supported Configurations].
+Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{org-name} Openshift Data Science: Supported Configurations].
 endif::[]
 
 You can access the Elyra extension within JupyterLab when you create the most recent version of one of the following notebook images:

--- a/modules/overview-of-pipelines-in-jupyterlab.adoc
+++ b/modules/overview-of-pipelines-in-jupyterlab.adoc
@@ -10,7 +10,7 @@ ifdef::upstream[]
 Before you can work with pipelines in JupyterLab, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
 endif::[]
 ifndef::upstream[]
-Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red Hat Openshift Data Science: Supported Configurations].
+Before you can work with pipelines in JupyterLab, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[Red{nbsp}Hat OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[Red{nbsp}Hat Openshift Data Science: Supported Configurations].
 endif::[]
 
 You can access the Elyra extension within JupyterLab when you create the most recent version of one of the following notebook images:

--- a/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
@@ -8,7 +8,7 @@ To change the size of resources utilized within your {productname-short} cluster
 
 //Changing your cluster's default PVC size causes a redeployment of the Jupyter server launcher, making it temporarily unavailable. PVCs that were already assigned before the default size was changed are unaffected and retain their original size. Notebook servers created by users before the PVC size change are also unaffected.
 
-//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
+//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red{nbsp}Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
@@ -8,7 +8,7 @@ To change the size of resources utilized within your {productname-short} cluster
 
 //Changing your cluster's default PVC size causes a redeployment of the Jupyter server launcher, making it temporarily unavailable. PVCs that were already assigned before the default size was changed are unaffected and retain their original size. Notebook servers created by users before the PVC size change are also unaffected.
 
-//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. Red{nbsp}Hat recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
+//Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/supported-packages.adoc
+++ b/modules/supported-packages.adoc
@@ -11,7 +11,7 @@ endif::[]
 
 You can install packages that are compatible with Python 3.9 on any notebook server that has the binaries required by that package.
 ifndef::upstream[]
-If the required binaries are not included on the notebook server image you want to use, contact Red{nbsp}Hat Support to request that the binary be considered for inclusion.
+If the required binaries are not included on the notebook server image you want to use, contact {org-name} Support to request that the binary be considered for inclusion.
 endif::[]
 
 You can install packages on a temporary basis by using the `pip install` command. You can also provide a list of packages to the `pip install` command using a `requirements.txt` file.

--- a/modules/supported-packages.adoc
+++ b/modules/supported-packages.adoc
@@ -11,7 +11,7 @@ endif::[]
 
 You can install packages that are compatible with Python 3.9 on any notebook server that has the binaries required by that package.
 ifndef::upstream[]
-If the required binaries are not included on the notebook server image you want to use, contact Red Hat Support to request that the binary be considered for inclusion.
+If the required binaries are not included on the notebook server image you want to use, contact Red{nbsp}Hat Support to request that the binary be considered for inclusion.
 endif::[]
 
 You can install packages on a temporary basis by using the `pip install` command. You can also provide a list of packages to the `pip install` command using a `requirements.txt` file.

--- a/modules/supported-services.adoc
+++ b/modules/supported-services.adoc
@@ -30,14 +30,14 @@ ifndef::upstream[]
 ====
 While every effort is made to make {productname-long} resilient to OpenShift node failure, upgrades, and similarly disruptive operations, individual users' notebook environments can be interrupted during these events. If an OpenShift node restarts or becomes unavailable, any user notebook environment on that node is restarted on a different node. When this occurs, any ongoing process executing in the user's notebook environment is interrupted, and the user needs to re-execute it when their environment becomes available again.
 
-Due to this limitation, Red Hat recommends that processes for which interruption is unacceptable are not executed in the Jupyter notebook server environment on {productname-short}.
+Due to this limitation, Red{nbsp}Hat recommends that processes for which interruption is unacceptable are not executed in the Jupyter notebook server environment on {productname-short}.
 ====
 endif::[]
 
 | Pachyderm
 | Use Pachyderm's data versioning, pipeline and lineage capabilities to automate the machine learning life cycle and optimize machine learning operations.
 
-| Red Hat OpenShift API Management
+| Red{nbsp}Hat OpenShift API Management
 | OpenShift API Management is a service that accelerates time-to-value and reduces the cost of delivering API-first, microservices-based applications.
 
 | OpenVINO

--- a/modules/supported-services.adoc
+++ b/modules/supported-services.adoc
@@ -30,14 +30,14 @@ ifndef::upstream[]
 ====
 While every effort is made to make {productname-long} resilient to OpenShift node failure, upgrades, and similarly disruptive operations, individual users' notebook environments can be interrupted during these events. If an OpenShift node restarts or becomes unavailable, any user notebook environment on that node is restarted on a different node. When this occurs, any ongoing process executing in the user's notebook environment is interrupted, and the user needs to re-execute it when their environment becomes available again.
 
-Due to this limitation, Red{nbsp}Hat recommends that processes for which interruption is unacceptable are not executed in the Jupyter notebook server environment on {productname-short}.
+Due to this limitation, {org-name} recommends that processes for which interruption is unacceptable are not executed in the Jupyter notebook server environment on {productname-short}.
 ====
 endif::[]
 
 | Pachyderm
 | Use Pachyderm's data versioning, pipeline and lineage capabilities to automate the machine learning life cycle and optimize machine learning operations.
 
-| Red{nbsp}Hat OpenShift API Management
+| {org-name} OpenShift API Management
 | OpenShift API Management is a service that accelerates time-to-value and reduces the cost of delivering API-first, microservices-based applications.
 
 | OpenVINO

--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -48,7 +48,7 @@ ifdef::upstream[]
 * The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to access the {productname-short} documentation.
 endif::[]
 ifndef::upstream[]
-* The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to create a ticket with Red{nbsp}Hat Support and access the {productname-short} documentation.
+* The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to create a ticket with {org-name} Support and access the {productname-short} documentation.
 endif::[]
 * The *User* menu displays the name of the currently logged-in user and provides access to the *Log out* button.
 
@@ -77,7 +77,7 @@ Resources:: The *Resources* page displays learning resources such as documentati
 Settings -> Notebook images:: The *Notebook image settings* page allows you to configure custom notebook images that cater to your project's specific requirements. After you have added custom notebook images to your deployment of {productname-short}, they are available for selection when creating a notebook server.
 
 Settings -> Cluster settings::  The *Cluster settings* page allows you perform the following administrative tasks on your cluster:
-* Enable or disable Red{nbsp}Hat's ability to collect data about {productname-short} usage on your cluster.
+* Enable or disable {org-name}'s ability to collect data about {productname-short} usage on your cluster.
 * Configure how resources are claimed within your cluster by changing the default size of the cluster's persistent volume claim (PVC).
 * Reduce resource usage in your {productname-short} deployment by stopping notebook servers that have been idle.
 * Schedule notebook pods on tainted nodes by adding tolerations.

--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -48,7 +48,7 @@ ifdef::upstream[]
 * The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to access the {productname-short} documentation.
 endif::[]
 ifndef::upstream[]
-* The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to create a ticket with Red Hat Support and access the {productname-short} documentation.
+* The *Help* menu (image:images/rhods-help-icon.png["Help menu icon"]) provides a link to create a ticket with Red{nbsp}Hat Support and access the {productname-short} documentation.
 endif::[]
 * The *User* menu displays the name of the currently logged-in user and provides access to the *Log out* button.
 
@@ -77,7 +77,7 @@ Resources:: The *Resources* page displays learning resources such as documentati
 Settings -> Notebook images:: The *Notebook image settings* page allows you to configure custom notebook images that cater to your project's specific requirements. After you have added custom notebook images to your deployment of {productname-short}, they are available for selection when creating a notebook server.
 
 Settings -> Cluster settings::  The *Cluster settings* page allows you perform the following administrative tasks on your cluster:
-* Enable or disable Red Hat's ability to collect data about {productname-short} usage on your cluster.
+* Enable or disable Red{nbsp}Hat's ability to collect data about {productname-short} usage on your cluster.
 * Configure how resources are claimed within your cluster by changing the default size of the cluster's persistent volume claim (PVC).
 * Reduce resource usage in your {productname-short} deployment by stopping notebook servers that have been idle.
 * Schedule notebook pods on tainted nodes by adding tolerations.

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -7,7 +7,7 @@
 If your users are experiencing errors in {productname-long} relating to Jupyter, their notebooks, or their notebook server, read this section to understand what could be causing the problem, and how to resolve the problem.
 
 ifndef::upstream[]
-If you cannot see the problem here or in the release notes, contact Red Hat Support.
+If you cannot see the problem here or in the release notes, contact Red{nbsp}Hat Support.
 endif::[]
 
 == A user receives a *404: Page not found* error when logging in to Jupyter
@@ -37,7 +37,7 @@ The *Group details* page for that group appears.
 .Resolution
 ifndef::upstream[]
 * If the user is not added to any of the groups allowed access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/#adding-users-for-openshift-data-science_useradd[Adding users for {productname-short}] to add them.
-* If the user is already added to a group that is allowed to access Jupyter, contact Red Hat Support.
+* If the user is already added to a group that is allowed to access Jupyter, contact Red{nbsp}Hat Support.
 endif::[]
 
 ifdef::upstream[]
@@ -85,9 +85,9 @@ If worker nodes with sufficient CPU and RAM are available for scheduling in the 
 * If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the OpenShift cluster, or choose a smaller image size.
 ifndef::upstream[]
 * If the Jupyter pod is in a *FAILED* state:
-.. Retrieve the logs for the `jupyter-nb-*` pod and send them to Red Hat Support for further evaluation.
+.. Retrieve the logs for the `jupyter-nb-*` pod and send them to Red{nbsp}Hat Support for further evaluation.
 .. Delete the `jupyter-nb-*` pod.
-* If none of the previous resolutions apply, contact Red Hat Support.
+* If none of the previous resolutions apply, contact Red{nbsp}Hat Support.
 endif::[]
 
 == The user receives a *database or disk is full* error or a *no space left on device* error when they run notebook cells

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -7,7 +7,7 @@
 If your users are experiencing errors in {productname-long} relating to Jupyter, their notebooks, or their notebook server, read this section to understand what could be causing the problem, and how to resolve the problem.
 
 ifndef::upstream[]
-If you cannot see the problem here or in the release notes, contact Red{nbsp}Hat Support.
+If you cannot see the problem here or in the release notes, contact {org-name} Support.
 endif::[]
 
 == A user receives a *404: Page not found* error when logging in to Jupyter
@@ -37,7 +37,7 @@ The *Group details* page for that group appears.
 .Resolution
 ifndef::upstream[]
 * If the user is not added to any of the groups allowed access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/#adding-users-for-openshift-data-science_useradd[Adding users for {productname-short}] to add them.
-* If the user is already added to a group that is allowed to access Jupyter, contact Red{nbsp}Hat Support.
+* If the user is already added to a group that is allowed to access Jupyter, contact {org-name} Support.
 endif::[]
 
 ifdef::upstream[]
@@ -85,9 +85,9 @@ If worker nodes with sufficient CPU and RAM are available for scheduling in the 
 * If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the OpenShift cluster, or choose a smaller image size.
 ifndef::upstream[]
 * If the Jupyter pod is in a *FAILED* state:
-.. Retrieve the logs for the `jupyter-nb-*` pod and send them to Red{nbsp}Hat Support for further evaluation.
+.. Retrieve the logs for the `jupyter-nb-*` pod and send them to {org-name} Support for further evaluation.
 .. Delete the `jupyter-nb-*` pod.
-* If none of the previous resolutions apply, contact Red{nbsp}Hat Support.
+* If none of the previous resolutions apply, contact {org-name} Support.
 endif::[]
 
 == The user receives a *database or disk is full* error or a *no space left on device* error when they run notebook cells

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -7,7 +7,7 @@
 If you are seeing errors in {productname-long} related to Jupyter, your notebooks, or your notebook server, read this section to understand what could be causing the problem.
 
 ifndef::upstream[]
-If you cannot see your problem here or in the release notes, contact Red{nbsp}Hat Support.
+If you cannot see your problem here or in the release notes, contact {org-name} Support.
 endif::[]
 
 == I see a *403: Forbidden* error when I log in to Jupyter

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -7,7 +7,7 @@
 If you are seeing errors in {productname-long} related to Jupyter, your notebooks, or your notebook server, read this section to understand what could be causing the problem.
 
 ifndef::upstream[]
-If you cannot see your problem here or in the release notes, contact Red Hat Support.
+If you cannot see your problem here or in the release notes, contact Red{nbsp}Hat Support.
 endif::[]
 
 == I see a *403: Forbidden* error when I log in to Jupyter

--- a/modules/tutorials-for-data-scientists.adoc
+++ b/modules/tutorials-for-data-scientists.adoc
@@ -92,8 +92,8 @@ ifndef::upstream[]
 | Querying data with Starburst Galaxy
 | Learn to query data using Starburst Galaxy from a Jupyter notebook.
 
-| Securing a deployed model using Red{nbsp}Hat OpenShift API Management
-| Protect a model service API using Red{nbsp}Hat OpenShift API Management.
+| Securing a deployed model using {org-name} OpenShift API Management
+| Protect a model service API using {org-name} OpenShift API Management.
 
 | Using the Intel&#174; oneAPI AI Analytics Toolkit (AI Kit) Notebook
 | Run a data science notebook sample with the Intel&#174; oneAPI AI Analytics Toolkit.

--- a/modules/tutorials-for-data-scientists.adoc
+++ b/modules/tutorials-for-data-scientists.adoc
@@ -92,8 +92,8 @@ ifndef::upstream[]
 | Querying data with Starburst Galaxy
 | Learn to query data using Starburst Galaxy from a Jupyter notebook.
 
-| Securing a deployed model using Red Hat OpenShift API Management
-| Protect a model service API using Red Hat OpenShift API Management.
+| Securing a deployed model using Red{nbsp}Hat OpenShift API Management
+| Protect a model service API using Red{nbsp}Hat OpenShift API Management.
 
 | Using the Intel&#174; oneAPI AI Analytics Toolkit (AI Kit) Notebook
 | Run a data science notebook sample with the Intel&#174; oneAPI AI Analytics Toolkit.

--- a/modules/viewing-bias-metrics.adoc
+++ b/modules/viewing-bias-metrics.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/viewing-bias-metrics.adoc
+++ b/modules/viewing-bias-metrics.adoc
@@ -6,8 +6,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
+++ b/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
@@ -8,8 +8,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-This feature is for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+This feature is for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
+++ b/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
@@ -8,8 +8,8 @@
 ifndef::upstream[]
 [IMPORTANT]
 ====
-This feature is for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+This feature is for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/monitoring-data-science-models.adoc
+++ b/monitoring-data-science-models.adoc
@@ -18,8 +18,8 @@ include::_artifacts/document-attributes-global.adoc[]
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs), might not be functionally complete, and {org-name} does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 

--- a/monitoring-data-science-models.adoc
+++ b/monitoring-data-science-models.adoc
@@ -18,8 +18,8 @@ include::_artifacts/document-attributes-global.adoc[]
 ifndef::upstream[]
 [IMPORTANT]
 ====
-The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
-For more information on Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
+The TrustyAI features are for Technology Preview only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs), might not be functionally complete, and Red{nbsp}Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 			
+For more information on Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/ [Technology Preview Features Scope]. 		
 ====
 endif::[]
 


### PR DESCRIPTION
Added the org-name attribute to use in place of 'Red Hat'. The new attribute includes a non-breaking space, per style guidance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
