### PR TITLE
RHODS-10182-Updating labels for data connections

### DIFF
--- a/modules/deploying-a-model.adoc
+++ b/modules/deploying-a-model.adoc
@@ -43,11 +43,11 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.
 ... In the *Name* field, enter a unique name for the data connection.
-... In the *AWS_ACCESS_KEY_ID* field, enter your access key ID for Amazon Web Services (AWS).
-... In the *AWS_SECRET_ACCESS_KEY* field, enter your secret access key for the AWS account you specified.
-... In the *AWS_S3_ENDPOINT* field, enter the endpoint of your AWS S3 storage.
-... In the *AWS_DEFAULT_REGION* field, enter the default region of your AWS account.
-... In the *AWS_S3_BUCKET* field, enter the name of the AWS S3 bucket.
+... In the *Access_key* field, enter your access key ID for Amazon Web Services (AWS).
+... In the *Secret_key* field, enter your secret access key for the AWS account you specified.
+... In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
+... In the *Region* field, enter the default region of your AWS account.
+... In the *Bucket* field, enter the name of the AWS S3 bucket.
 ... In the *Folder path* field, enter the folder path in your AWS S3 bucket that contains your data file. 
 --
 

--- a/modules/deploying-a-model.adoc
+++ b/modules/deploying-a-model.adoc
@@ -43,8 +43,8 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.
 ... In the *Name* field, enter a unique name for the data connection.
-... In the *Access_key* field, enter your access key ID for Amazon Web Services (AWS).
-... In the *Secret_key* field, enter your secret access key for the AWS account you specified.
+... In the *Access key* field, enter your access key ID for Amazon Web Services (AWS).
+... In the *Secret key* field, enter your secret access key for the AWS account you specified.
 ... In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
 ... In the *Region* field, enter the default region of your AWS account.
 ... In the *Bucket* field, enter the name of the AWS S3 bucket.

--- a/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
+++ b/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
@@ -37,11 +37,11 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 
 * *If you previously specified a new data connection*
 ... In the *Name* field, update the name of the data connection.
-... In the *AWS_ACCESS_KEY_ID* field, update your access key ID for Amazon Web Services (AWS).
-... In the *AWS_SECRET_ACCESS_KEY* field, update your secret access key for the AWS account you specified.
-... In the *AWS_S3_ENDPOINT* field, update the endpoint of your AWS S3 storage.
-... In the *AWS_DEFAULT_REGION* field, update the default region of your AWS account.
-... In the *AWS_S3_BUCKET* field, update the name of the AWS S3 bucket.
+... In the *Access key* field, update your access key ID for Amazon Web Services (AWS).
+... In the *Secret key* field, update your secret access key for the AWS account you specified.
+... In the *Endpoint* field, update the endpoint of your AWS S3 storage.
+... In the *Region* field, update the default region of your AWS account.
+... In the *Bucket* field, update the name of the AWS S3 bucket.
 ... In the *Folder path* field, update the folder path in your AWS S3 bucket that contains your data file. 
 --
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As per https://issues.redhat.com/browse/RHODS-10182, the **AWS_ prefix** no longer exists in the _define a new data connection dialog_. To address this, I've updated the labels of the data connections to remove the **AWS_prefix**, under the following sections:

- Deploying a model in Open Data Hub
- Updating the deployment properties of a deployed model


## How Has This Been Tested?
Validated with a local build of the Open Data Hub website.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
