### PR TITLE
ds-12932 fix broken links

### DIFF
--- a/modules/adding-a-model-server-to-your-data-science-project.adoc
+++ b/modules/adding-a-model-server-to-your-data-science-project.adoc
@@ -17,7 +17,7 @@ endif::[]
 * You have created a data science project that you can add a model server to.
 ifndef::upstream[]
 * If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{rhodsdocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#adding-a-custom-model-serving-runtime_nb-server[Adding a custom model-serving runtime].
-* If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support in {productname-short}. See {rhodsdocshome}{default-format-url}/managing_resources#enabling-gpu-support-in-data-science[Enabling GPU support in {productname-short}]
+* If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support in {productname-short}. See link:{rhodsdocshome}{default-format-url}/managing_resources/managing-cluster-resources_resource-mgmt#enabling-gpu-support_cluster-mgmt[Enabling GPU support in {productname-short}]
 endif::[]
 ifdef::upstream[]
 * If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{odhdocshome}/working-on-data-science-projects/#adding-a-custom-model-serving-runtime_nb-server[Adding a custom model-serving runtime].
@@ -43,7 +43,7 @@ The *Add model server* dialog opens.
 * Large
 * Custom
 . Optional: If you selected *Custom* in the preceding step, configure the following settings in the *Model server size* section to customize your model server:
-.. In the *CPUs requested* field, specify a number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+.. In the *CPUs requested* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
 .. In the *CPU limit* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
 .. In the *Memory requested* field, specify the requested memory for the model server in gibibytes (Gi).
 .. In the *Memory limit* field, specify the maximum memory limit for the model server in gibibytes (Gi).
@@ -56,8 +56,8 @@ If you are using a _custom_ model-serving runtime with your model server, you mu
 ====
 . Optional: From the *Accelerator* list, select an accelerator. 
 .. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
-. Optional: In the *Model route* section, select the *Make deployed models available through an external route* check box to make your deployed models available to external clients.
-. Optional: In the *Token authorization* section, select the *Require token authentication* check box to require token authentication for your model server. To finish configuring token authentication, perform the following actions:
+. Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
+. Optional: In the *Token authorization* section, select the *Require token authentication* checkbox to require token authentication for your model server. To finish configuring token authentication, perform the following actions:
 .. In the *Service account name* field, enter a service account name for which the token will be generated. The generated token is created and displayed in the *Token secret* field when the model server is configured.
 .. To add an additional service account, click *Add a service account* and enter another service account name.
 . Click *Add*.

--- a/modules/configuring-distributed-workloads.adoc
+++ b/modules/configuring-distributed-workloads.adoc
@@ -12,7 +12,7 @@ To configure the distributed workloads feature for your data scientists to use i
 * You have access to a Ray cluster image. For information about how to create a Ray cluster, see the link:https://docs.ray.io/en/latest/index.html[Ray documentation].
 * You have removed any previously installed instances of the CodeFlare Operator, as described in the Knowledgebase solution link:https://access.redhat.com/solutions/7043796[How to migrate from CodeFlare Operator to Red Hat OpenShift Data Science Cluster].
 ifndef::upstream[]
-* If you want to use graphics processing units (GPUs), you have enabled GPU support in {productname-short}. See link:{rhodsdocshome}{default-format-url}/managing_resources/enabling-gpu-support-in-data-science_user-mgmt[Enabling GPU support in {productname-short}].
+* If you want to use graphics processing units (GPUs), you have enabled GPU support in {productname-short}. See link:{rhodsdocshome}{default-format-url}/managing_resources/managing-cluster-resources_resource-mgmt#enabling-gpu-support_cluster-mgmt[Enabling GPU support in {productname-short}].
 endif::[]
 
 .Procedure

--- a/modules/launching-jupyter-and-starting-a-notebook-server.adoc
+++ b/modules/launching-jupyter-and-starting-a-notebook-server.adoc
@@ -19,7 +19,7 @@ Launch Jupyter and start a notebook server to start working with your notebooks.
 +
 If you see an *Access permission needed* message, you are not in the default user group or the default administrator group for {productname-short}.
 ifndef::upstream[]
-Contact your administrator so that they can add you to the correct group using link:{rhodsdocshome}{default-format-url}/managing_users#adding-users-for-openshift-data-science_useradd[Adding users for {productname-short}].
+Contact your administrator so that they can add you to the correct group using link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users].
 endif::[]
 ifdef::upstream[]
 Contact your administrator so that they can add you to the correct group.
@@ -49,7 +49,7 @@ ifdef::upstream[]
 Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster.
 endif::[]
 ifndef::upstream[]
-Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster. To learn how to enable GPU support, see link:{rhodsdocshome}{default-format-url}/managing_resources/enabling-gpu-support-in-data-science_user-mgmt[Enabling GPU support in {productname-short}].
+Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster. To learn how to enable GPU support, see link:{rhodsdocshome}{default-format-url}/managing_resources/managing-cluster-resources_resource-mgmt#enabling-gpu-support_cluster-mgmt[Enabling GPU support in {productname-short}].
 endif::[]
 --
 .. Optional: Select and specify values for any new *Environment variables*.

--- a/modules/launching-jupyter-and-starting-a-notebook-server.adoc
+++ b/modules/launching-jupyter-and-starting-a-notebook-server.adoc
@@ -19,10 +19,10 @@ Launch Jupyter and start a notebook server to start working with your notebooks.
 +
 If you see an *Access permission needed* message, you are not in the default user group or the default administrator group for {productname-short}.
 ifndef::upstream[]
-Contact your administrator so that they can add you to the correct group using link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users].
+Ask your administrator to add you to the correct group by using link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users].
 endif::[]
 ifdef::upstream[]
-Contact your administrator so that they can add you to the correct group.
+Ask your administrator to add you to the correct group.
 endif::[]
 +
 If you have not previously authorized the `jupyter-nb-<username>` service account to access your account, the *Authorize Access* page appears prompting you to provide authorization. Inspect the permissions selected by default, and click the *Allow selected permissions* button.

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -295,7 +295,7 @@ ifdef::upstream[]
 Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster.
 endif::[]
 ifndef::upstream[]
-Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster. To learn how to enable GPU support, see link:{rhodsdocshome}{default-format-url}/managing_resources/enabling-gpu-support-in-data-science_user-mgmt[Enabling GPU support in {productname-short}].
+Using accelerators is only supported with specific notebook images. For GPUs, only the PyTorch, TensorFlow, and CUDA notebook images are supported. For Habana Gaudi devices, only the HabanaAI notebook image is supported. In addition, you can only specify the number of accelerators required for your notebook server if accelerators are enabled on your cluster. To learn how to enable GPU support, see link:{rhodsdocshome}{default-format-url}/managing_resources/managing-cluster-resources_resource-mgmt#enabling-gpu-support_cluster-mgmt[Enabling GPU support in {productname-short}].
 endif::[]
 --
 

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -32,12 +32,12 @@ endif::[]
 +
 The *Group details* page for that group appears.
 
-. Click the *Details* tab for the group and confirm that the *Users* section for the relevant group, contains the users who have permission to access Jupyter.
+. Click the *Details* tab for the group and confirm that the *Users* section for the relevant group contains the users who have permission to access Jupyter.
 
 .Resolution
 ifndef::upstream[]
-* If the user is not added to any of the groups allowed access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users] to add them.
-* If the user is already added to a group that is allowed to access Jupyter, contact {org-name} Support.
+* If the user is not added to any of the groups with permission access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users] to add them.
+* If the user is already added to a group with permission to access Jupyter, contact {org-name} Support.
 endif::[]
 
 ifdef::upstream[]

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -36,7 +36,7 @@ The *Group details* page for that group appears.
 
 .Resolution
 ifndef::upstream[]
-* If the user is not added to any of the groups allowed access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/#adding-users-for-openshift-data-science_useradd[Adding users for {productname-short}] to add them.
+* If the user is not added to any of the groups allowed access to Jupyter, follow link:{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users] to add them.
 * If the user is already added to a group that is allowed to access Jupyter, contact {org-name} Support.
 endif::[]
 

--- a/modules/updating-notebook-server-settings-by-restarting-your-server.adoc
+++ b/modules/updating-notebook-server-settings-by-restarting-your-server.adoc
@@ -26,14 +26,11 @@ The *Start a notebook server* page opens.
 .Verification
 * The notebook server starts and contains your updated settings.
 
-ifndef::upstream[]
 [role="_additional-resources"]
 .Additional resources
+ifdef::upstream[]
+* link:{odhdocshome}/getting-started-with-open-data-hub/#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server]
 endif::[]
-
-ifdef::self-managed[]
-* link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server]
-endif::[]
-ifndef::self-managed[]
+ifndef::upstream[]
 * link:{rhodsdocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server]
 endif::[]


### PR DESCRIPTION
Updated "Adding users" links to
{rhodsdocshome}{default-format-url}/managing_users/adding-users_user-mgmt

Updated "Enabling GPU support" links to
{rhodsdocshome}{default-format-url}/managing_resources/managing-cluster-resources_resource-mgmt#enabling-gpu-support_cluster-mgmt

Upstream only link, fixed "Launching Jupyter and starting a notebook server" link under Additional Resources in updating-notebook-server-settings-by-restarting-your-server.adoc