### PR TITLE
Updating labels for pipeline data connection

### DIFF
--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -37,11 +37,11 @@ After the pipeline server is created, the `/metadata` and `/artifacts` folders a
 * Select *Create new data connection* to add a new data connection that your pipeline server can access.
 . If you selected *Create new data connection*, perform the following steps:
 .. In the *Name* field, enter a name for the data connection.
-.. In the *AWS_ACCESS_KEY_ID* field, enter your access key ID for Amazon Web Services.
-.. In the *AWS_SECRET_ACCESS_KEY_ID* field, enter your secret access key for the account you specified.
-.. Optional: In the *AWS_S3_ENDPOINT* field, enter the endpoint of your AWS S3 storage.
-.. Optional: In the *AWS_DEFAULT_REGION* field, enter the default region of your AWS account.
-.. In the *AWS_S3_BUCKET* field, enter the name of the AWS S3 bucket.
+.. In the *Access key* field, enter your access key ID for Amazon Web Services.
+.. In the *Secret key* field, enter your secret access key for the account you specified.
+.. Optional: In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
+.. Optional: In the *Region* field, enter the default region of your AWS account.
+.. In the *Bucket* field, enter the name of the AWS S3 bucket.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As per https://issues.redhat.com/browse/RHODS-12944, the AWS_ prefix no longer exists in the `configure a pipeline` dialog. To address this, I've updated the labels of the data connections.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Validated with a local build of the Open Data Hub website.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
