### PR TITLE
Updating AWS S3 storage references to S3-compatible storage

### DIFF
--- a/modules/adding-a-data-connection-to-your-data-science-project.adoc
+++ b/modules/adding-a-data-connection-to-your-data-science-project.adoc
@@ -28,11 +28,11 @@ A project details page opens.
 +
 The *Add data connection* dialog opens.
 . Enter a *name* for the data connection.
-. Enter your access key ID for your chosen S3-compatible object storage provider in the *Access key* field.
-. Enter your secret access key for the S3-compatible object storage account you specified in the *Secret key* field.
-. Enter the endpoint of your S3-compatible object storage bucket in the *Endpoint* field.
-. Enter the default region of your S3-compatible object storage account in the *Region* field.
-. Enter the name of your S3-compatible object storage bucket in the *Bucket* field.
+. In the *Access key* field, enter the access key ID for your S3-compatible object storage provider.
+. In the *Secret key* field, enter the secret access key for the S3-compatible object storage account you specified.
+. In the *Endpoint* field, enter the endpoint of your S3-compatible object storage bucket.
+. In the *Region* field, enter the default region of your S3-compatible object storage account.
+. In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
 . Click *Add data connection*.
 
 .Verification

--- a/modules/adding-a-data-connection-to-your-data-science-project.adoc
+++ b/modules/adding-a-data-connection-to-your-data-science-project.adoc
@@ -4,7 +4,7 @@
 = Adding a data connection to your data science project
 
 [role='_abstract']
-You can enhance your data science project by adding a connection to a data source. When you want to work with a very large data sets, you can store your data in an Amazon Web Services (AWS) Simple Storage Service (S3) bucket so that you do not fill up your local storage. You also have the option of associating the data connection with an existing workbench that does not already have a connection.
+You can enhance your data science project by adding a connection to a data source. When you want to work with a very large data sets, you can store your data in an S3-compatible object storage bucket, so that you do not fill up your local storage. You also have the option of associating the data connection with an existing workbench that does not already have a connection.
 
 .Prerequisites
 * You have logged in to {productname-long}.
@@ -28,11 +28,11 @@ A project details page opens.
 +
 The *Add data connection* dialog opens.
 . Enter a *name* for the data connection.
-. Enter your access key ID for Amazon Web Services in the *AWS_ACCESS_KEY_ID* field.
-. Enter your secret access key for the account you specified in the *AWS_SECRET_ACCESS_KEY_ID* field.
-. Enter the endpoint of your AWS S3 storage in the *AWS_S3_ENDPOINT* field.
-. Enter the default region of your AWS account in the *AWS_DEFAULT_REGION* field.
-. Enter the name of the AWS S3 bucket in the *AWS_S3_BUCKET* field.
+. Enter your access key ID for your chosen S3-compatible object storage provider in the *Access key* field.
+. Enter your secret access key for the S3-compatible object storage account you specified in the *Secret key* field.
+. Enter the endpoint of your S3-compatible object storage bucket in the *Endpoint* field.
+. Enter the default region of your S3-compatible object storage account in the *Region* field.
+. Enter the name of your S3-compatible object storage bucket in the *Bucket* field.
 . Click *Add data connection*.
 
 .Verification

--- a/modules/adding-a-data-connection-to-your-data-science-project.adoc
+++ b/modules/adding-a-data-connection-to-your-data-science-project.adoc
@@ -15,6 +15,7 @@ ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `odh-users` or `odh-admins`) in OpenShift.
 endif::[]
 * You have created a data science project that you can add a data connection to.
+* You have access to S3-compatible object storage.
 * If you intend to add the data connection to an existing workbench, you have saved any data in the workbench to avoid losing work.
 
 .Procedure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As per https://issues.redhat.com/browse/RHODS-9559, the data connections section currently mentions that data can be stored in an AWS S3 bucket. I've updated the doc to reflect that data can be stored in **any S3-compatible object storage.**

## How Has This Been Tested?
Validated with a local build of the Open Data Hub website.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
