### PR TITLE
update to options for notebook server environments module to include …

### DIFF
--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -19,9 +19,9 @@ endif::[]
 ifndef::upstream[]
 [NOTE]
 --
-Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur about every six months. Therefore, two supported notebook image versions are typically available at any given time. Legacy notebook image versions, that is, not the two most recent versions, might still be available for selection. Legacy image versions include a label that indicates the image is out-of-date. 
+Notebook images are supported for a minimum of one year. Major updates to preconfigured notebook images occur about every six months. Therefore, two supported notebook image versions are typically available at any given time. Legacy notebook image versions, that is, not the two most recent versions, might still be available for selection. Legacy image versions include a label that indicates the image is out-of-date. 
 
-Version 1.2 of notebook images available in {productname-short} 2.4 will not longer be supported at {productname-short} 2.5. To use the latest package versions, {org-name} recommends that you use the most recently added notebook image, that is, notebook images with the version 2023.2. 
+Version 1.2 of notebook images available in {productname-short} 2.4 will no longer be supported in {productname-short} 2.5. To use the latest package versions, {org-name} recommends that you use the most recently added notebook image.
 --
 endif::[]
 +

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -19,7 +19,9 @@ endif::[]
 ifndef::upstream[]
 [NOTE]
 --
-Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur about every six months. Therefore, two supported notebook image versions are typically available at any given time. Legacy notebook image versions, that is, not the two most recent versions, might still be available for selection. Legacy image versions include a label that indicates the image is out-of-date. To use the latest package versions, {org-name} recommends that you use the most recently added notebook image.
+Notebook images are supported for a minimum of one year. Major updates to pre-configured notebook images occur about every six months. Therefore, two supported notebook image versions are typically available at any given time. Legacy notebook image versions, that is, not the two most recent versions, might still be available for selection. Legacy image versions include a label that indicates the image is out-of-date. 
+
+Version 1.2 of notebook images available in {productname-short} 2.4 will not longer be supported at {productname-short} 2.5. To use the latest package versions, {org-name} recommends that you use the most recently added notebook image, that is, notebook images with the version 2023.2. 
 --
 endif::[]
 +


### PR DESCRIPTION
…1.2 deprecation notice

<!--- Provide a general summary of your changes in the Title above -->

## Description
I have updated the "Options for notebook server environments" module to provide a deprecation notice that the 1.2 versions of the notebook images available at OAI 2.4, will be deprecated at 2.5

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
