### PR TITLE
RHODS-9984: Correcting Accessing the pipeline editor section. Adding HabanaAI to …

### DIFF
--- a/modules/accessing-the-pipeline-editor.adoc
+++ b/modules/accessing-the-pipeline-editor.adoc
@@ -16,9 +16,10 @@ ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `odh-users` or `odh-admins`) in OpenShift.
 endif::[]
 
-* You have created a data science project that contains a workbench.
+* You have created a data science project.
+* You have created a workbench with the *Standard Data Science* notebook image.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 * You have access to S3-compatible storage.
 
 .Procedure

--- a/modules/creating-a-runtime-configuration.adoc
+++ b/modules/creating-a-runtime-configuration.adoc
@@ -18,7 +18,7 @@ endif::[]
 * You have access to S3-compatible cloud storage.
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the left sidebar of JupyterLab, click *Runtimes* (image:images/jupyter-runtimes-sidebar.png[The Runtimes icon]).

--- a/modules/deleting-a-runtime-configuration.adoc
+++ b/modules/deleting-a-runtime-configuration.adoc
@@ -18,7 +18,7 @@ endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
 * A previously created runtime configuration is visible in the JupyterLab interface.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the left sidebar of JupyterLab, click *Runtimes* (image:images/jupyter-runtimes-sidebar.png[The Runtimes icon]).

--- a/modules/duplicating-a-runtime-configuration.adoc
+++ b/modules/duplicating-a-runtime-configuration.adoc
@@ -18,7 +18,7 @@ endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
 * A previously created runtime configuration is visible in the JupyterLab interface.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the left sidebar of JupyterLab, click *Runtimes* (image:images/jupyter-runtimes-sidebar.png[The Runtimes icon]).

--- a/modules/exporting-a-pipeline-in-jupyterlab.adoc
+++ b/modules/exporting-a-pipeline-in-jupyterlab.adoc
@@ -23,7 +23,7 @@ endif::[]
 * You have a created a pipeline in JupyterLab.
 * You have opened your pipeline in the Pipeline Editor in JupyterLab.
 * Your pipeline instance contains a runtime configuration.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the Pipeline Editor user interface, click *Export Pipeline* (image:images/jupyterlab-export-pipeline-button.png[Export pipeline]).

--- a/modules/running-a-pipeline-in-jupyterlab.adoc
+++ b/modules/running-a-pipeline-in-jupyterlab.adoc
@@ -21,7 +21,7 @@ endif::[]
 * You have opened your pipeline in the Pipeline Editor in JupyterLab.
 * Your pipeline instance contains a runtime configuration.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the Pipeline Editor user interface, click *Run Pipeline* (image:images/jupyterlab-run-pipeline-button.png[The Runtimes icon]).

--- a/modules/updating-a-runtime-configuration.adoc
+++ b/modules/updating-a-runtime-configuration.adoc
@@ -19,7 +19,7 @@ endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.
 * A previously created runtime configuration is available in the JupyterLab interface.
-* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, or  PyTorch).
+* You have created and launched a Jupyter server from a notebook image that contains the Elyra extension (Standard data science, TensorFlow, TrustyAI, PyTorch, or HabanaAI).
 
 .Procedure
 . In the left sidebar of JupyterLab, click *Runtimes* (image:images/jupyter-runtimes-sidebar.png[The Runtimes icon]).


### PR DESCRIPTION
…list.

- Added a step to the _Accessing the pipeline editor_ section to select a specific image in order to have Elyra up and running. Confirmed with Diego, the additional step is only needed for _Accessing the pipeline editor_.
- Added HabanaAI to the list of notebook images which support Elyra.



## How Has This Been Tested?
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
