### PR TITLE
Adding attribute for ocp minimum version

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -60,3 +60,4 @@ endif::[]
 :rhodsdocshome: https://access.redhat.com/documentation/en-us/{url-productname-long}/{vernum}/
 :default-format-url: html
 :ocp-latest-version: 4.14
+:ocp-minimum-version: 4.12

--- a/modules/habana-gaudi-integration.adoc
+++ b/modules/habana-gaudi-integration.adoc
@@ -10,7 +10,7 @@ Before you can successfully enable Habana Gaudi devices in {productname-short}, 
 
 [IMPORTANT]
 ====
-Currently, Habana Gaudi integration is only supported in OpenShift 4.11 and 4.12. 
+Currently, Habana Gaudi integration is only supported in OpenShift {ocp-minimum-version}. 
 
 You can use Habana Gaudi accelerators on {productname-short} with version 1.10.0 of the Habana Gaudi Operator. For information about the supported configurations for version 1.10 of the Habana Gaudi Operator, see link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.10.0.html#support-matrix-1-10-0[Support Matrix v1.10.0].
 

--- a/modules/installing-the-odh-operator-v1.adoc
+++ b/modules/installing-the-odh-operator-v1.adoc
@@ -4,7 +4,7 @@
 = Installing the Open Data Hub Operator version 1
 
 .Prerequisites
-* You are using OpenShift Container Platform 4.11 or later.
+* You are using OpenShift Container Platform {ocp-minimum-version} or later.
 * Your OpenShift cluster has a minimum of 16 CPUs and 32GB of memory across all OpenShift worker nodes.
 * You can log in as a user with `cluster-admin` privileges.
 

--- a/modules/installing-the-odh-operator-v2.adoc
+++ b/modules/installing-the-odh-operator-v2.adoc
@@ -4,7 +4,7 @@
 = Installing the Open Data Hub Operator version 2
 
 .Prerequisites
-* You are using OpenShift Container Platform 4.11 or later.
+* You are using OpenShift Container Platform {ocp-minimum-version} or later.
 * Your OpenShift cluster has a minimum of 16 CPUs and 32GB of memory across all OpenShift worker nodes.
 * You can log in as a user with `cluster-admin` privileges.
 

--- a/modules/upgrading-the-odh-operator-v1.adoc
+++ b/modules/upgrading-the-odh-operator-v1.adoc
@@ -5,7 +5,7 @@
 
 .Prerequisites
 * You have installed version 1 of the Open Data Hub Operator.
-* You are using OpenShift Container Platform 4.11 or later.
+* You are using OpenShift Container Platform {ocp-minimum-version} or later.
 * Your OpenShift cluster has a minimum of 16 CPUs and 32GB of memory across all OpenShift worker nodes.
 * You can log in as a user with `cluster-admin` privileges.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an attribute for `minimum ocp version`, replaced occurrences of 4.11 and 4.12 with the new attribute.

## How Has This Been Tested?
Local build. Screenshots added below.


