### PR TITLE
RHODS-12832 generic S3 references

### DIFF
--- a/assemblies/working-with-data-science-pipelines.adoc
+++ b/assemblies/working-with-data-science-pipelines.adoc
@@ -38,7 +38,7 @@ ifndef::upstream[]
 Before you can use data science pipelines, you must install the OpenShift Pipelines operator. For more information about installing a compatible version of the OpenShift Pipelines operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/cicd/pipelines#op-release-notes[{org-name} OpenShift Pipelines release notes] and link:https://access.redhat.com/articles/6986416[{productname-long}: Supported Configurations].
 endif::[]
 
-You can store your pipeline artifacts in an Amazon Web Services (AWS) Simple Storage Service (S3) bucket so that you do not consume local storage. To do this, you must first configure write access to your S3 bucket on your AWS account.
+You can store your pipeline artifacts in an S3-compatible object storage bucket so that you do not consume local storage. To do this, you must first configure write access to your S3 bucket on your storage account.
 
 == Managing data science pipelines
 

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -37,11 +37,11 @@ After the pipeline server is created, the `/metadata` and `/artifacts` folders a
 * Select *Create new data connection* to add a new data connection that your pipeline server can access.
 . If you selected *Create new data connection*, perform the following steps:
 .. In the *Name* field, enter a name for the data connection.
-.. In the *Access key* field, enter your access key ID for Amazon Web Services.
+.. In the *Access key* field, enter the access key ID for your S3-compatible object storage provider.
 .. In the *Secret key* field, enter your secret access key for the account you specified.
-.. Optional: In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
-.. Optional: In the *Region* field, enter the default region of your AWS account.
-.. In the *Bucket* field, enter the name of the AWS S3 bucket.
+.. Optional: In the *Endpoint* field, enter the endpoint of your S3-compatible object storage.
+.. Optional: In the *Region* field, enter the default region of your S3-compatible object storage account.
+.. In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
 +
 [IMPORTANT]
 ====

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -45,7 +45,7 @@ After the pipeline server is created, the `/metadata` and `/artifacts` folders a
 +
 [IMPORTANT]
 ====
-If you are creating a new data connection, in addition to the other designated mandatory fields, the *AWS_S3_BUCKET* field is mandatory. If you specify incorrect data connection settings, you cannot update these settings on the same pipeline server. Therefore, you must delete the pipeline server and configure another one.
+If you are creating a new data connection, in addition to the other designated mandatory fields, the *Bucket* field is mandatory. If you specify incorrect data connection settings, you cannot update these settings on the same pipeline server. Therefore, you must delete the pipeline server and configure another one.
 ====
 . In the *Database* section, click *Show advanced database options* to specify the database to store your pipeline data and select one of the following sets of actions:
 * Select *Use default database stored on your cluster* to deploy a MariaDB database in your project.

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -61,11 +61,11 @@ endif::[]
 * Create a new data connection as follows:
 ... Select *Create new data connection*.
 ... In the *Name* field, enter a unique name for the data connection.
-... In the *Access key* field, enter your access key ID for Amazon Web Services (AWS).
-... In the *Secret key* field, enter your secret access key for the AWS account that you specified.
-... In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
-... In the *Region* field, enter the default region of your AWS account.
-... In the *Bucket* field, enter the name of the AWS S3 bucket.
+... In the *Access key* field, enter the access key ID for your S3-compatible object storage provider.
+... In the *Secret key* field, enter your secret access key for the account you specified.
+... In the *Endpoint* field, enter the endpoint of your S3-compatible object storage.
+... In the *Region* field, enter the default region of your S3-compatible object storage account.
+... In the *Bucket* field, enter the name of the S3-compatible object storage bucket.
 
 * Use an existing data connection as follows:
 ... Select *Use existing data connection*.

--- a/modules/deploying-a-model.adoc
+++ b/modules/deploying-a-model.adoc
@@ -43,12 +43,12 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.
 ... In the *Name* field, enter a unique name for the data connection.
-... In the *Access key* field, enter your access key ID for Amazon Web Services (AWS).
-... In the *Secret key* field, enter your secret access key for the AWS account you specified.
-... In the *Endpoint* field, enter the endpoint of your AWS S3 storage.
-... In the *Region* field, enter the default region of your AWS account.
-... In the *Bucket* field, enter the name of the AWS S3 bucket.
-... In the *Folder path* field, enter the folder path in your AWS S3 bucket that contains your data file. 
+... In the *Access key* field, enter your access key ID for for your S3-compatible object storage provider.
+... In the *Secret key* field, enter your secret access key for the account you specified.
+... In the *Endpoint* field, enter the endpoint of your S3-compatible object storage.
+... In the *Region* field, enter the default region of your S3-compatible object storage account.
+... In the *Bucket* field, enter the name of the S3-compatible object storage bucket.
+... In the *Folder path* field, enter the folder path in your S3-compatible object storage bucket that contains your data file. 
 --
 
 .. Click *Deploy*.

--- a/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
+++ b/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
@@ -37,12 +37,12 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 
 * *If you previously specified a new data connection*
 ... In the *Name* field, update the name of the data connection.
-... In the *Access key* field, update your access key ID for Amazon Web Services (AWS).
-... In the *Secret key* field, update your secret access key for the AWS account you specified.
-... In the *Endpoint* field, update the endpoint of your AWS S3 storage.
-... In the *Region* field, update the default region of your AWS account.
-... In the *Bucket* field, update the name of the AWS S3 bucket.
-... In the *Folder path* field, update the folder path in your AWS S3 bucket that contains your data file. 
+... In the *Access key* field, update your access key ID for your S3-compatible object storage provider.
+... In the *Secret key* field, update your secret access key for the account you specified.
+... In the *Endpoint* field, update the endpoint of your S3-compatible object storage.
+... In the *Region* field, update the default region of your S3-compatible object storage account.
+... In the *Bucket* field, update the name of the S3-compatible object storage bucket.
+... In the *Folder path* field, update the folder path in your S3-compatible object storage bucket that contains your data file. 
 --
 
 .. Click *Configure*.


### PR DESCRIPTION
Remove "AWS" from field names and make S3 references generic instead of AWS-specific