### PR TITLE
RHODS-13082: Adding inline passthrough macros for user and admin group attributes

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -30,8 +30,8 @@ endif::[]
 ifdef::upstream[]
 :productname-long: Open Data Hub
 :productname-short: Open Data Hub
-:odh-user-group: odh-users
-:odh-admin-group: odh-admins
+:odh-user-group: pass:q,a[`odh-users`]
+:odh-admin-group: pass:q,a[`odh-admins`]
 //:url-productname-long: red_hat_openshift_data_science_self-managed
 //:url-productname-short: openshift_data_science_self-managed
 // change this to match the stage-<ver> branch, e.g. 1-latest, 1.n, to get the correct title for release notes

--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -43,8 +43,8 @@ ifdef::upstream[]
 endif::[]
 
 ifndef::upstream[]
-:oai-user-group: oai-users
-:oai-admin-group: oai-admins
+:oai-user-group: pass:q,a[`oai-users`]
+:oai-admin-group: pass:q,a[`oai-admins`]
 endif::[]
 
 // conditional entities for release note titles using numbers or not

--- a/modules/accessing-the-pipeline-editor.adoc
+++ b/modules/accessing-the-pipeline-editor.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 
 * You have created a data science project.

--- a/modules/accessing-the-pipeline-editor.adoc
+++ b/modules/accessing-the-pipeline-editor.adoc
@@ -10,7 +10,7 @@ You can use Elyra to create visual end-to-end pipeline workflows in JupyterLab. 
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/adding-a-data-connection-to-your-data-science-project.adoc
+++ b/modules/adding-a-data-connection-to-your-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that you can add a data connection to.
 * You have access to S3-compatible object storage.

--- a/modules/adding-a-data-connection-to-your-data-science-project.adoc
+++ b/modules/adding-a-data-connection-to-your-data-science-project.adoc
@@ -9,7 +9,7 @@ You can enhance your data science project by adding a connection to a data sourc
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/adding-a-model-server-to-your-data-science-project.adoc
+++ b/modules/adding-a-model-server-to-your-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that you can add a model server to.
 ifndef::upstream[]

--- a/modules/adding-a-model-server-to-your-data-science-project.adoc
+++ b/modules/adding-a-model-server-to-your-data-science-project.adoc
@@ -9,7 +9,7 @@ Before you can successfully deploy a data science model on {productname-short}, 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that you can add cluster storage to.
 

--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -9,7 +9,7 @@ For data science projects that require data to be retained, you can add cluster 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/adding-users-to-specialized-data-science-user-groups.adoc
+++ b/modules/adding-users-to-specialized-data-science-user-groups.adoc
@@ -37,8 +37,8 @@ endif::[]
 .Procedure
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.
 . Click the name of the group you want to add users to.
-** For administrative users, click the administrator group, for example, `{oai-admin-group}`.
-** For normal users, click the user group, for example, `{oai-user-group}`.
+** For administrative users, click the administrator group, for example, {oai-admin-group}.
+** For normal users, click the user group, for example, {oai-user-group}.
 +
 The *Group details* page for that group appears.
 . Click *Actions* -> *Add Users*.

--- a/modules/cloning-a-scheduled-pipeline-run.adoc
+++ b/modules/cloning-a-scheduled-pipeline-run.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 * You have imported a pipeline to an active pipeline server.

--- a/modules/cloning-a-scheduled-pipeline-run.adoc
+++ b/modules/cloning-a-scheduled-pipeline-run.adoc
@@ -10,7 +10,7 @@ To make it easier to schedule runs to execute as part of your pipeline configura
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that you can add a pipeline server to.
 

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -10,7 +10,7 @@ Before you can successfully create a pipeline in {productname-short}, you must c
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/configuring-a-recommended-accelerator-for-serving-runtimes.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-serving-runtimes.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the admin group (for example, `{oai-admin-group}` ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the admin group (for example, `{odh-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[]
 
 .Procedure

--- a/modules/creating-a-data-science-project.adoc
+++ b/modules/creating-a-data-science-project.adoc
@@ -9,7 +9,7 @@ To start your data science work, create a data science project. Creating a proje
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/creating-a-data-science-project.adoc
+++ b/modules/creating-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 
 .Procedure

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -9,7 +9,7 @@ To examine and work with models in an isolated area, you can create a workbench.
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that you can add a workbench to.
 

--- a/modules/creating-a-runtime-configuration.adoc
+++ b/modules/creating-a-runtime-configuration.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have access to S3-compatible cloud storage.
 * You have created a data science project that contains a workbench.

--- a/modules/creating-a-runtime-configuration.adoc
+++ b/modules/creating-a-runtime-configuration.adoc
@@ -10,7 +10,7 @@ If you create a workbench as part of a data science project, a default runtime c
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-data-connection.adoc
+++ b/modules/deleting-a-data-connection.adoc
@@ -9,7 +9,7 @@ You can delete data connections from your data science projects to help you remo
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-data-connection.adoc
+++ b/modules/deleting-a-data-connection.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project with a data connection.
 

--- a/modules/deleting-a-data-science-pipeline.adoc
+++ b/modules/deleting-a-data-science-pipeline.adoc
@@ -15,7 +15,7 @@ You can delete data science pipelines so that they do not appear on the {product
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-data-science-pipeline.adoc
+++ b/modules/deleting-a-data-science-pipeline.adoc
@@ -18,7 +18,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * There are active pipelines available on the *Pipelines* page.
 

--- a/modules/deleting-a-data-science-project.adoc
+++ b/modules/deleting-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}`) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group}) in OpenShift.
 endif::[]
 * You have created a data science project.
 

--- a/modules/deleting-a-deployed-model.adoc
+++ b/modules/deleting-a-deployed-model.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}`) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group}) in OpenShift.
 endif::[]
 * You have deployed a model.
 

--- a/modules/deleting-a-model-server.adoc
+++ b/modules/deleting-a-model-server.adoc
@@ -12,7 +12,7 @@ NOTE: When you remove a model server, you also remove the models that are hosted
 * You have created a data science project and an associated model server.
 * You have notified the users of the applications that access the models that the models will no longer be available.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-model-server.adoc
+++ b/modules/deleting-a-model-server.adoc
@@ -15,7 +15,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 
 .Procedure

--- a/modules/deleting-a-pipeline-server.adoc
+++ b/modules/deleting-a-pipeline-server.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a pipeline server.
 

--- a/modules/deleting-a-pipeline-server.adoc
+++ b/modules/deleting-a-pipeline-server.adoc
@@ -9,7 +9,7 @@ After you have finished running your data science pipelines, you can delete the 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-runtime-configuration.adoc
+++ b/modules/deleting-a-runtime-configuration.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.

--- a/modules/deleting-a-runtime-configuration.adoc
+++ b/modules/deleting-a-runtime-configuration.adoc
@@ -10,7 +10,7 @@ After you have finished using your runtime configuration, you can delete it from
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-scheduled-pipeline-run.adoc
+++ b/modules/deleting-a-scheduled-pipeline-run.adoc
@@ -10,7 +10,7 @@ To discard pipeline runs that you previously scheduled, but no longer require, y
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-scheduled-pipeline-run.adoc
+++ b/modules/deleting-a-scheduled-pipeline-run.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 * You have imported a pipeline to an active pipeline server.

--- a/modules/deleting-a-triggered-pipeline-run.adoc
+++ b/modules/deleting-a-triggered-pipeline-run.adoc
@@ -10,7 +10,7 @@ To discard pipeline runs that you previously executed, but no longer require a r
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-triggered-pipeline-run.adoc
+++ b/modules/deleting-a-triggered-pipeline-run.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 * You have imported a pipeline to an active pipeline server.

--- a/modules/deleting-a-workbench-from-a-data-science-project.adoc
+++ b/modules/deleting-a-workbench-from-a-data-science-project.adoc
@@ -9,7 +9,7 @@ You can delete workbenches from your data science projects to help you remove Ju
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-a-workbench-from-a-data-science-project.adoc
+++ b/modules/deleting-a-workbench-from-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project with a workbench.
 

--- a/modules/deleting-cluster-storage-from-a-data-science-project.adoc
+++ b/modules/deleting-cluster-storage-from-a-data-science-project.adoc
@@ -9,7 +9,7 @@ You can delete cluster storage from your data science projects to help you free 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/deleting-cluster-storage-from-a-data-science-project.adoc
+++ b/modules/deleting-cluster-storage-from-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project with cluster storage.
 

--- a/modules/deploying-a-model.adoc
+++ b/modules/deploying-a-model.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}`) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains an associated model server.
 * You know the folder path for the data connection that you want the model to access.

--- a/modules/downloading-a-data-science-pipeline.adoc
+++ b/modules/downloading-a-data-science-pipeline.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 * You have created and imported a pipeline to an active pipeline server that is available to download.

--- a/modules/downloading-a-data-science-pipeline.adoc
+++ b/modules/downloading-a-data-science-pipeline.adoc
@@ -10,7 +10,7 @@ To make further changes to a data science pipeline that you previously uploaded 
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/duplicating-a-model-server.adoc
+++ b/modules/duplicating-a-model-server.adoc
@@ -9,7 +9,7 @@ To avoid re-creating a model server runtime with similar values, you can duplica
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/duplicating-a-model-server.adoc
+++ b/modules/duplicating-a-model-server.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that has a model server assigned.
 

--- a/modules/duplicating-a-runtime-configuration.adoc
+++ b/modules/duplicating-a-runtime-configuration.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.

--- a/modules/duplicating-a-runtime-configuration.adoc
+++ b/modules/duplicating-a-runtime-configuration.adoc
@@ -10,7 +10,7 @@ To prevent you from re-creating runtime configurations with similar values in th
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/enabling-trustyai-service-cli.adoc
+++ b/modules/enabling-trustyai-service-cli.adoc
@@ -55,7 +55,7 @@ ifndef::upstream[]
 endif::[]
 
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 
 * You have created a data science project, as described in link:{odhdocshome}/working-on-data-science-projects/#working-on-data-science-projects_nb-server[Creating a data science project], that contains (or will contain) the models that you want to monitor.  
 endif::[]

--- a/modules/enabling-trustyai-service-cli.adoc
+++ b/modules/enabling-trustyai-service-cli.adoc
@@ -49,7 +49,7 @@ To verify this setting, navigate to *Operators* -> *Installed Operators* -> *Red
 * You have logged in to {productname-short}.
 
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 
 * You have created a data science project, as described in link:{rhodsdocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project], that contains (or will contain) the models that you want to monitor.  
 endif::[]

--- a/modules/exporting-a-pipeline-in-jupyterlab.adoc
+++ b/modules/exporting-a-pipeline-in-jupyterlab.adoc
@@ -12,7 +12,7 @@ Before you can export a pipeline, you must create a data science project and a p
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/exporting-a-pipeline-in-jupyterlab.adoc
+++ b/modules/exporting-a-pipeline-in-jupyterlab.adoc
@@ -15,7 +15,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains a workbench.
 * You have created and configured a pipeline server within the data science project that contains your workbench.

--- a/modules/importing-a-data-science-pipeline.adoc
+++ b/modules/importing-a-data-science-pipeline.adoc
@@ -10,7 +10,7 @@ To help you begin working with data science pipelines in {productname-short}, yo
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/importing-a-data-science-pipeline.adoc
+++ b/modules/importing-a-data-science-pipeline.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 

--- a/modules/removing-access-to-a-data-science-project.adoc
+++ b/modules/removing-access-to-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project.
 * You have previously shared access to your project with other users or groups.

--- a/modules/removing-access-to-a-data-science-project.adoc
+++ b/modules/removing-access-to-a-data-science-project.adoc
@@ -9,7 +9,7 @@ If you no longer want to work collaboratively on your data science project, you 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/revoking-user-access-to-jupyter.adoc
+++ b/modules/revoking-user-access-to-jupyter.adoc
@@ -21,8 +21,8 @@ endif::[]
 .Procedure
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.
 . Click the name of the group that you want to remove the user from.
-** For administrative users, click the name of your administrator group, for example, `{oai-admin-group}`.
-** For normal users, click the name of your user group, for example, `{oai-user-group}`.
+** For administrative users, click the name of your administrator group, for example, {oai-admin-group}.
+** For normal users, click the name of your user group, for example, {oai-user-group}.
 
 +
 The *Group details* page for the group appears.

--- a/modules/running-a-pipeline-in-jupyterlab.adoc
+++ b/modules/running-a-pipeline-in-jupyterlab.adoc
@@ -11,7 +11,7 @@ Your pipeline instance in JupyterLab must contain a runtime configuration. If yo
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/running-a-pipeline-in-jupyterlab.adoc
+++ b/modules/running-a-pipeline-in-jupyterlab.adoc
@@ -14,7 +14,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have access to S3-compatible storage.
 * You have created a pipeline in JupyterLab.

--- a/modules/scheduling-a-pipeline-run.adoc
+++ b/modules/scheduling-a-pipeline-run.adoc
@@ -10,7 +10,7 @@ You can instantiate a single execution of a pipeline by scheduling a pipeline ru
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/scheduling-a-pipeline-run.adoc
+++ b/modules/scheduling-a-pipeline-run.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a configured pipeline server.
 * You have imported a pipeline to an active pipeline server.

--- a/modules/sharing-access-to-a-data-science-project.adoc
+++ b/modules/sharing-access-to-a-data-science-project.adoc
@@ -9,7 +9,7 @@ To enable your organization to work collaboratively, you can share access to you
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/sharing-access-to-a-data-science-project.adoc
+++ b/modules/sharing-access-to-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project.
 

--- a/modules/starting-a-workbench.adoc
+++ b/modules/starting-a-workbench.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains a workbench.
 

--- a/modules/starting-a-workbench.adoc
+++ b/modules/starting-a-workbench.adoc
@@ -9,7 +9,7 @@ You can manually start a data science project's workbench from the *Details* pag
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/stopping-a-triggered-pipeline-run.adoc
+++ b/modules/stopping-a-triggered-pipeline-run.adoc
@@ -10,7 +10,7 @@ If you no longer require a triggered pipeline run to continue executing, you can
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/stopping-a-triggered-pipeline-run.adoc
+++ b/modules/stopping-a-triggered-pipeline-run.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * There is a previously created data science project available that contains a pipeline server.
 * You have imported a pipeline to an active and available pipeline server.

--- a/modules/updating-a-connected-data-source.adoc
+++ b/modules/updating-a-connected-data-source.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project, created a workbench, and you have defined a data connection.
 

--- a/modules/updating-a-connected-data-source.adoc
+++ b/modules/updating-a-connected-data-source.adoc
@@ -9,7 +9,7 @@ To use an existing data source with a different workbench, you can change the da
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-a-data-science-project.adoc
+++ b/modules/updating-a-data-science-project.adoc
@@ -9,7 +9,7 @@ You can update your data science project's details by changing your project's na
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-a-data-science-project.adoc
+++ b/modules/updating-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project.
 

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -9,7 +9,7 @@ You can update your data science project's model server by changing details, suc
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that has a model server assigned.
 

--- a/modules/updating-a-project-workbench.adoc
+++ b/modules/updating-a-project-workbench.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that has a workbench.
 

--- a/modules/updating-a-project-workbench.adoc
+++ b/modules/updating-a-project-workbench.adoc
@@ -9,7 +9,7 @@ If your data science work requires you to change your workbench's notebook image
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you use specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-a-runtime-configuration.adoc
+++ b/modules/updating-a-runtime-configuration.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have access to S3-compatible storage.
 * You have created a data science project that contains a workbench.

--- a/modules/updating-a-runtime-configuration.adoc
+++ b/modules/updating-a-runtime-configuration.adoc
@@ -10,7 +10,7 @@ To ensure that your runtime configuration is accurate and updated, you can chang
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-access-to-a-data-science-project.adoc
+++ b/modules/updating-access-to-a-data-science-project.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project.
 * You have previously shared access to your project with other users or groups.

--- a/modules/updating-access-to-a-data-science-project.adoc
+++ b/modules/updating-access-to-a-data-science-project.adoc
@@ -9,7 +9,7 @@ To change the level of collaboration on your data science project, you can updat
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-cluster-storage.adoc
+++ b/modules/updating-cluster-storage.adoc
@@ -9,7 +9,7 @@ If your data science work requires you to change the identifying information of 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/updating-cluster-storage.adoc
+++ b/modules/updating-cluster-storage.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have created a data science project that contains cluster storage.
 

--- a/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
+++ b/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}`) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group}) in OpenShift.
 endif::[]
 * You have deployed a model on {productname-short}.
 

--- a/modules/viewing-a-deployed-model.adoc
+++ b/modules/viewing-a-deployed-model.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}`) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group}) in OpenShift.
 endif::[]
 * There are active and deployed data science models available on the *Model Serving* page.
 

--- a/modules/viewing-data-science-users.adoc
+++ b/modules/viewing-data-science-users.adoc
@@ -19,8 +19,8 @@ endif::[]
 
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.
 . Click the name of the group containing the users that you want to view.
-** For administrative users, click the name of your administrator group. for example, `{oai-admin-group}`.
-** For normal users, click the name of your user group, for example, `{oai-user-group}`.
+** For administrative users, click the name of your administrator group. for example, {oai-admin-group}.
+** For normal users, click the name of your user group, for example, {oai-user-group}.
 +
 The *Group details* page for the group appears.
 

--- a/modules/viewing-existing-pipelines.adoc
+++ b/modules/viewing-existing-pipelines.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a pipeline server.
 * You have imported a pipeline to an active and available pipeline server.

--- a/modules/viewing-existing-pipelines.adoc
+++ b/modules/viewing-existing-pipelines.adoc
@@ -10,7 +10,7 @@ You can view the details of pipelines that you have imported to {productname-lon
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/viewing-scheduled-pipeline-runs.adoc
+++ b/modules/viewing-scheduled-pipeline-runs.adoc
@@ -11,7 +11,7 @@ You can view a list of pipeline runs that are scheduled for execution in {produc
 * You have logged in to {productname-long}.
 ifndef::upstream[]
 * You have installed the OpenShift Pipelines operator.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * You have installed the Data Science Pipelines operator.

--- a/modules/viewing-scheduled-pipeline-runs.adoc
+++ b/modules/viewing-scheduled-pipeline-runs.adoc
@@ -15,7 +15,7 @@ ifndef::upstream[]
 endif::[]
 ifdef::upstream[]
 * You have installed the Data Science Pipelines operator.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a pipeline server.
 * You have imported a pipeline to an active and available pipeline server.

--- a/modules/viewing-the-details-of-a-pipeline-run.adoc
+++ b/modules/viewing-the-details-of-a-pipeline-run.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and contains a pipeline server.
 * You have imported a pipeline to an active and available pipeline server.

--- a/modules/viewing-the-details-of-a-pipeline-run.adoc
+++ b/modules/viewing-the-details-of-a-pipeline-run.adoc
@@ -9,7 +9,7 @@ To gain a clearer understanding of your pipeline runs, you can view the details 
 * You have installed the OpenShift Pipelines operator.
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/viewing-the-details-of-a-pipeline-server.adoc
+++ b/modules/viewing-the-details-of-a-pipeline-server.adoc
@@ -14,7 +14,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 
 .Procedure

--- a/modules/viewing-the-details-of-a-pipeline-server.adoc
+++ b/modules/viewing-the-details-of-a-pipeline-server.adoc
@@ -11,7 +11,7 @@ You can view the details of pipeline servers configured in {productname-short}, 
 * You have logged in to {productname-long}.
 * You have previously created a data science project that contains an active and available pipeline server.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
+++ b/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
@@ -30,7 +30,7 @@ To ensure that your deployed model is functioning correctly, you can monitor the
 
 * You have logged in to {productname-short}.
 ifndef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.

--- a/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
+++ b/modules/viewing-the-performance-metrics-of-a-deployed-model.adoc
@@ -33,7 +33,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * There are deployed data science models available on the *Model Serving* page.
 

--- a/modules/viewing-triggered-pipeline-runs.adoc
+++ b/modules/viewing-triggered-pipeline-runs.adoc
@@ -15,7 +15,7 @@ ifndef::upstream[]
 endif::[]
 ifdef::upstream[]
 * You have installed the Data Science Pipelines operator.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{odh-user-group}` or `{odh-admin-group}`) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have previously created a data science project that is available and has a pipeline server.
 * You have imported a pipeline to an active and available pipeline server.

--- a/modules/viewing-triggered-pipeline-runs.adoc
+++ b/modules/viewing-triggered-pipeline-runs.adoc
@@ -11,7 +11,7 @@ You can view a list of pipeline runs that were previously executed in {productna
 * You have logged in to {productname-long}.
 ifndef::upstream[]
 * You have installed the OpenShift Pipelines operator.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, `{oai-user-group}` or `{oai-admin-group}` ) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
 endif::[]
 ifdef::upstream[]
 * You have installed the Data Science Pipelines operator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added inline passthrough macros for **odh-admin-group** and **odh-user-group** attributes
- Added inline passthrough macros for **oai-admin-group** and **oai-user-group** attributes
- Removed backticks from attributes substitutions


## How Has This Been Tested?
Tested with local build, **odh-admin-group** and **odh-user-group** substitutions are working as expected. Screenshots attached.

![Screenshot 2023-12-06 at 11 27 53 AM](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/27c9e2ff-6130-4ecf-b7fb-badb5f3f3433)
![Screenshot 2023-12-06 at 11 28 19 AM](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/e200a396-cce4-4f54-b5d3-8e47cd9e2cd4)


