### PR TITLE
Updating section to highlight that users lose access to dashboard

### DIFF
--- a/modules/adding-users-to-specialized-data-science-user-groups.adoc
+++ b/modules/adding-users-to-specialized-data-science-user-groups.adoc
@@ -11,7 +11,7 @@ The *user group* provides the user with access to developer functions in the {pr
 
 The *administrator group* provides the user with access to developer and administrator functions in the {productname-long} dashboard and associated services, such as Jupyter.
 
-If you restrict access by using specialized user groups, users that are not in the {productname-short} user group or administrator group can still view the dashboard, but are unable to use associated services, such as Jupyter. They are also unable to access the *Cluster settings* page.
+If you restrict access by using specialized user groups, users that are not in the {productname-short} user group or administrator group cannot view the dashboard and use associated services, such as Jupyter. They are also unable to access the *Cluster settings* page.
 
 ifndef::self-managed[]
 [IMPORTANT]

--- a/modules/revoking-user-access-to-jupyter.adoc
+++ b/modules/revoking-user-access-to-jupyter.adoc
@@ -4,7 +4,7 @@
 = Revoking user access to Jupyter
 
 [role='_abstract']
-You can revoke a user's access to Jupyter by removing them from the specialized user groups that restrict access to {productname-short}. Removing users from specialized user groups will prevent them from accessing the {productname-short} dashboard and using associated services such as Jupyter to run notebook servers and consume resources in your cluster.
+You can revoke a user's access to Jupyter by removing the user from the specialized user groups that define access to {productname-short}. When you remove a user from the specialized user groups, the user is prevented from accessing the {productname-short} dashboard and from using associated services that consume resources in your cluster.
 
 IMPORTANT: Follow these steps only if you have implemented specialized user groups to restrict access to {productname-short}. To completely remove a user from {productname-short}, you must remove them from the allowed group in your OpenShift identity provider.
 
@@ -16,7 +16,7 @@ endif::[]
 ifdef::self-managed[]
 * You are assigned the `cluster-admin` role in {openshift-platform}.
 endif::[]
-* You are using specialized user groups for {productname-short}, and the user is part of the user group, administrator group, or both.
+* You are using specialized user groups for {productname-short}, and the user is part of the specialized user group, administrator group, or both.
 
 .Procedure
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.

--- a/modules/revoking-user-access-to-jupyter.adoc
+++ b/modules/revoking-user-access-to-jupyter.adoc
@@ -4,9 +4,9 @@
 = Revoking user access to Jupyter
 
 [role='_abstract']
-You can revoke a user’s access to Jupyter to prevent them from running notebook servers and consuming resources in your cluster through Jupyter, while still allowing them access to {productname-short} and other services that use OpenShift's identity provider for authentication.
+You can revoke a user's access to Jupyter by removing them from the specialized user groups that restrict access to {productname-short}. Removing users from specialized user groups will prevent them from accessing the {productname-short} dashboard and using associated services such as Jupyter to run notebook servers and consume resources in your cluster.
 
-IMPORTANT: Follow these steps only if you have implemented specialized user groups to restricted access to {productname-short}. To completely remove a user from {productname-short}, you must remove them from the allowed group in your OpenShift identity provider.
+IMPORTANT: Follow these steps only if you have implemented specialized user groups to restrict access to {productname-short}. To completely remove a user from {productname-short}, you must remove them from the allowed group in your OpenShift identity provider.
 
 .Prerequisites
 * You have stopped any notebook servers owned by the user you want to delete.
@@ -16,7 +16,7 @@ endif::[]
 ifdef::self-managed[]
 * You are assigned the `cluster-admin` role in {openshift-platform}.
 endif::[]
-* If you are using specialized user groups for {productname-short}, the user is part of the user group, administrator group, or both.
+* You are using specialized user groups for {productname-short}, and the user is part of the user group, administrator group, or both.
 
 .Procedure
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.


### PR DESCRIPTION
As per https://issues.redhat.com/browse/RHOAIENG-649, the current content under the section "Revoking access to Jupyter"  indicates that the user can still access Openshift AI once the steps to revoke access to Jupyter are followed. The steps involve removing the affected user from specialized user groups (rhods-users,rhods-admins). Once removed from a specialized user group, the user actually loses access to the dashboard and associated services. I've updated the content to reflect the same.

## How Has This Been Tested?
- Local build

<img width="879" alt="Screenshot 2023-12-21 at 2 02 55 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/72db7ba1-9edf-4223-9daa-df7ee4bd2287">
