### PR TITLE
Additional pre-requisites w.r.t S3-compatible storage

### DIFF
--- a/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
+++ b/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
@@ -19,7 +19,7 @@ endif::[]
 * You have enabled the multi-model serving platform.
 * You have created a data science project and added a model server.
 * You have access to S3-compatible object storage.
-* You know the folder path for the datasets in your S3-compatible object storage bucket, that you want your model to access.
+* For the datasets that you want your model to access, you know the folder paths in your S3-compatible object storage bucket.
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Data Science Projects*.

--- a/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
+++ b/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
@@ -18,7 +18,8 @@ ifdef::upstream[]
 endif::[]
 * You have enabled the multi-model serving platform.
 * You have created a data science project and added a model server.
-* You know the folder path for the data connection that you want the model to access.
+* You have access to S3-compatible object storage.
+* You know the folder path for the datasets in your S3-compatible object storage bucket, that you want your model to access.
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Data Science Projects*.
@@ -31,7 +32,7 @@ A project details page opens.
 .. From the *Model framework* list, select a framework for your model. 
 +
 NOTE: The *Model framework* list shows only the frameworks that are supported by the model-serving runtime that you specified when you configured your model server.
-.. To specify the location of your model, perform one of the following sets of actions:
+.. To specify the location of your datasets in your S3-compatible object storage bucket, perform one of the following actions:
 +
 --
 * *To use an existing data connection*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://issues.redhat.com/browse/RHOAIENG-666

Attempting to add clarity concerning object storage in this module: Users need access to and use S3-compatible object storage for storing their datasets. The described procedure doesn't "create" a bucket but creates a data source connection to the bucket so that the model to be deployed can access datasets as needed. 
## How Has This Been Tested?
Local Build

## Preview
<img width="979" alt="Screenshot 2024-01-04 at 1 57 46 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/333da30d-d1cc-4bcc-bd29-b3edcc929ae8">
<img width="903" alt="Screenshot 2024-01-04 at 1 58 06 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/b152365b-d043-488b-a535-fa9a9940e4d0">


