### PR TITLE
RHOAIENG-1444 fixes

### DIFF
--- a/modules/accessing-notebook-servers-owned-by-other-users.adoc
+++ b/modules/accessing-notebook-servers-owned-by-other-users.adoc
@@ -14,7 +14,12 @@ ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 ifndef::upstream[]
+ifdef::self-managed[]
 * You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+endif::[]
+ifndef::self-managed[]
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_{url-productname-short}/adding-administrative-users-for-openshift-dedicated_install[Adding administrative users].
+endif::[]
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 * The notebook server that you want to access is running.
@@ -28,5 +33,6 @@ endif::[]
 
 .Verification
 * The user's notebook server opens in JupyterLab.
+
 
 

--- a/modules/enabling-gpu-support-in-data-science.adoc
+++ b/modules/enabling-gpu-support-in-data-science.adoc
@@ -52,7 +52,7 @@ endif::[]
 The *Delete ConfigMap* dialog appears.
 .. Inspect the dialog and confirm that you are deleting the correct ConfigMap.
 .. Click *Delete*.
-. Restart the dashboard replica set.
+. Restart the dashboard replicaset.
 .. In the {openshift-platform} web console, change into the *Administrator* perspective.
 .. Click *Workloads* -> *Deployments*.
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate deployment.

--- a/modules/starting-notebook-servers-owned-by-other-users.adoc
+++ b/modules/starting-notebook-servers-owned-by-other-users.adoc
@@ -15,7 +15,12 @@ ifdef::upstream[]
 endif::[]
 
 ifndef::upstream[]
+ifdef::self-managed[]
 * You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+endif::[]
+ifndef::self-managed[]
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_{url-productname-short}/adding-administrative-users-for-openshift-dedicated_install[Adding administrative users].
+endif::[]
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 


### PR DESCRIPTION
- Broken link in "Enabling GPU support in Openshift AI" was fixed with https://issues.redhat.com/browse/RHOAIENG-961
- Changed "replica set" to "replicaset"
- Fixed link in "Starting notebook servers owned by other users" and "Accessing notebook servers owned by other users" for Cloud Services docs