### PR TITLE
DS-1808 Contribute updates to model-serving documentation upstream

### DIFF
--- a/assemblies/serving-large-language-models.adoc
+++ b/assemblies/serving-large-language-models.adoc
@@ -1,0 +1,31 @@
+:_module-type: ASSEMBLY
+
+ifdef::context[:parent-context: {context}]
+
+:context: serving-large-language-models
+
+[id="serving-large-language-models_{context}"]
+= Serving large language models
+
+[role='_abstract']
+For deploying large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on the KServe component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.
+
+include::modules/about-the-single-model-serving-platform.adoc[leveloffset=+1]
+include::modules/installing-kserve.adoc[leveloffset=+1]
+include::modules/deploying-models-using-the-single-model-serving-platform.adoc[leveloffset=+1]
+include::modules/enabling-the-single-model-serving-platform.adoc[leveloffset=+2]
+include::modules/deploying-models-on-the-single-model-serving-platform.adoc[leveloffset=+2]
+include::modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc[leveloffset=+2]
+
+// Conditionalized for self-managed because monitoring of user-defined projects is enabled on OSD and ROSA by default
+ifdef::self-managed[]
+include::modules/configuring-monitoring-for-the-single-model-serving-platform.adoc[leveloffset=+1]
+endif::[]
+
+include::modules/viewing-metrics-for-the-single-model-serving-platform.adoc[leveloffset=+1]
+
+// [role='_additional-resources']
+// == Additional resources
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/assemblies/serving-large-language-models.adoc
+++ b/assemblies/serving-large-language-models.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 = Serving large language models
 
 [role='_abstract']
-For deploying large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on the KServe component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.
+For deploying large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on the KServe component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs that require increased resources.
 
 include::modules/about-the-single-model-serving-platform.adoc[leveloffset=+1]
 include::modules/installing-kserve.adoc[leveloffset=+1]

--- a/assemblies/serving-small-and-medium-sized-models.adoc
+++ b/assemblies/serving-small-and-medium-sized-models.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 = Serving small and medium-sized models
 
 [role='_abstract']
-For deploying small and medium-sized models (that is, models that are not considered to be large language models), {productname-short} includes a _multi-model serving platform_ that is based on the ModelMesh component. On the multi-model serving platform, multiple models can be deployed from the same model server and share the server resources.
+On the multi-model serving platform, multiple models can be deployed from the same model server and share the server resources.
 
 == Configuring model servers
 include::modules/enabling-the-multi-model-serving-platform.adoc[leveloffset=+2]

--- a/assemblies/serving-small-and-medium-sized-models.adoc
+++ b/assemblies/serving-small-and-medium-sized-models.adoc
@@ -4,34 +4,24 @@ ifdef::context[:parent-context: {context}]
 
 :context: model-serving
 
-[id="model-serving_{context}"]
-= Model serving on {productname-short}
+[id="serving-small-and-medium-sized-models_{context}"]
+= Serving small and medium-sized models
 
 [role='_abstract']
-As a data scientist, you can deploy your trained machine-learning models to serve intelligent applications in production. After you have deployed your model, applications can send requests to the model using its deployed API endpoint.
+For deploying small and medium-sized models (that is, models that are not considered to be large language models), {productname-short} includes a _multi-model serving platform_ that is based on the ModelMesh component. On the multi-model serving platform, multiple models can be deployed from the same model server and share the server resources.
 
 == Configuring model servers
-
 include::modules/enabling-the-multi-model-serving-platform.adoc[leveloffset=+2]
-
-include::modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc[leveloffset=+2]
-
 include::modules/adding-a-custom-model-serving-runtime.adoc[leveloffset=+2]
-
+include::modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc[leveloffset=+2]
 include::modules/updating-a-model-server.adoc[leveloffset=+2]
-
 include::modules/deleting-a-model-server.adoc[leveloffset=+2]
 
 == Working with deployed models
-
 include::modules/deploying-a-model-using-the-multi-model-serving-platform.adoc[leveloffset=+2]
-
 include::modules/viewing-a-deployed-model.adoc[leveloffset=+2]
-
 include::modules/updating-the-deployment-properties-of-a-deployed-model.adoc[leveloffset=+2]
-
 include::modules/deleting-a-deployed-model.adoc[leveloffset=+2]
-//include::modules/viewing-the-performance-metrics-of-a-deployed-model.adoc[leveloffset=+2]
 
 // [role='_additional-resources']
 // == Additional resources

--- a/modules/about-model-serving.adoc
+++ b/modules/about-model-serving.adoc
@@ -4,15 +4,15 @@
 = About model serving
 
 [role="_abstract"]
-Serving trained models on {productname-long} means deploying the models on your OpenShift cluster to test and then integrate them into intelligent applications. Deploying a model makes it available as a service that you can access using an API. This enables you to return predictions based on data inputs that you provide through API calls. This process is known as model inferencing. When you serve a model on OpenShift AI, the inference endpoints that you can access for the deployed model are shown in the dashboard. 
+Serving trained models on {productname-long} means deploying the models on your OpenShift cluster to test and then integrate them into intelligent applications. Deploying a model makes it available as a service that you can access by using an API. This enables you to return predictions based on data inputs that you provide through API calls. This process is known as model _inferencing_. When you serve a model on {product-short}, the inference endpoints that you can access for the deployed model are shown in the dashboard. 
 
-{productname-short} provides two primary model serving platforms:
+{productname-short} provides the following model serving platforms:
 
 Single model serving platform::
-For deploying large language models (LLMs), {productname-short} includes a single model serving platform that uses the link:https://github.com/kserve/kserve[KServe^] component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.    
+For deploying large language models (LLMs), {productname-short} includes a _single model serving platform_ that is based on the link:https://github.com/kserve/kserve[KServe^] component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.    
 
 Multi-model serving platform::
-For deploying small and medium-sized models (that is, models that are not considered to be large language models), {productname-short} includes a multi-model serving platform that is based on the link:https://github.com/kserve/modelmesh[ModelMesh^] component. On the multi-model serving platform, you can deploy multiple models on the same model server. Each of the deployed models shares the server resources. This approach can be advantageous on OpenShift clusters that have finite compute resources or pods.
+For deploying small and medium-sized models (that is, models that are not considered to be large language models), {productname-short} includes a _multi-model serving platform_ that is based on the link:https://github.com/kserve/modelmesh[ModelMesh^] component. On the multi-model serving platform, you can deploy multiple models on the same model server. Each of the deployed models shares the server resources. This approach can be advantageous on OpenShift clusters that have finite compute resources or pods.
 
 // [role="_additional-resources"]
 // .Additional resources

--- a/modules/about-model-serving.adoc
+++ b/modules/about-model-serving.adoc
@@ -1,0 +1,18 @@
+:_module-type: CONCEPT
+
+[id="about-model-serving_{context}"]
+= About model serving
+
+[role="_abstract"]
+Serving trained models on {productname-long} means deploying the models on your OpenShift cluster to test and then integrate them into intelligent applications. Deploying a model makes it available as a service that you can access using an API. This enables you to return predictions based on data inputs that you provide through API calls. This process is known as model inferencing. When you serve a model on OpenShift AI, the inference endpoints that you can access for the deployed model are shown in the dashboard. 
+
+{productname-short} provides two primary model serving platforms:
+
+Single model serving platform::
+For deploying large language models (LLMs), {productname-short} includes a single model serving platform that uses the link:https://github.com/kserve/kserve[KServe^] component. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.    
+
+Multi-model serving platform::
+For deploying small and medium-sized models (that is, models that are not considered to be large language models), {productname-short} includes a multi-model serving platform that is based on the link:https://github.com/kserve/modelmesh[ModelMesh^] component. On the multi-model serving platform, you can deploy multiple models on the same model server. Each of the deployed models shares the server resources. This approach can be advantageous on OpenShift clusters that have finite compute resources or pods.
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/about-the-single-model-serving-platform.adoc
+++ b/modules/about-the-single-model-serving-platform.adoc
@@ -1,0 +1,30 @@
+:_module-type: CONCEPT
+
+[id="about-the-single-model-serving-platform_{context}"]
+= About the single model serving platform
+
+[role="_abstract"]
+For serving large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on KServe. The single model serving platform consists of the following components:
+
+* link:https://github.com/opendatahub-io/kserve[KServe^]: Kubernetes custom resource definition (CRD) that orchestrates model serving for all types of models. It includes model-serving runtimes that implement the loading of given types of model servers. KServe handles the lifecycle of the deployment object, storage access, and networking setup.
+
+* link:https://docs.openshift.com/serverless/1.29/about/about-serverless.html[{org-name} OpenShift Serverless^]: Cloud-native development model that allows for serverless deployments of models. OpenShift Serverless is based on the open source link:https://knative.dev/docs/[Knative^] project.
+
+ifdef::self-managed[]
+* link:https://docs.openshift.com/container-platform/{ocp-latest-version}/service_mesh/v2x/ossm-architecture.html[{org-name} OpenShift Service Mesh^]: Service mesh networking layer that manages traffic flows and enforces access policies. OpenShift Service Mesh is based on the open source link:https://istio.io/[Istio^] project.
+endif::[]
+
+ifndef::self-managed[]
+* link:https://docs.openshift.com/rosa/service_mesh/v2x/ossm-architecture.html[{org-name} OpenShift Service Mesh^]: Service mesh networking layer that manages traffic flows and enforces access policies. OpenShift Service Mesh is based on the open source link:https://istio.io/[Istio^] project.
+endif::[]
+
+To install the single model serving platform, you have the following options:
+
+Automated installation:: If you have not already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you can configure the {productname-long} Operator to install KServe and its dependencies.
+
+Manual installation:: If you have already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you _cannot_ configure the {productname-long} Operator to install KServe and its dependencies. In this situation, you must install KServe manually.
+
+When you have installed KServe, you can use the {productname-short} dashboard to deploy models using a link:https://github.com/opendatahub-io/caikit[Caikit^] and link:https://github.com/opendatahub-io/text-generation-inference[Text Generation Inference Server (TGIS)^]-based runtime that is included in {productname-short}. You can also configure monitoring for the platform and use Prometheus to scrape the available metrics.
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/about-the-single-model-serving-platform.adoc
+++ b/modules/about-the-single-model-serving-platform.adoc
@@ -4,14 +4,14 @@
 = About the single model serving platform
 
 [role="_abstract"]
-For serving large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on KServe. The single model serving platform consists of the following components:
+The single model serving platform consists of the following components:
 
-* link:https://github.com/opendatahub-io/kserve[KServe^]: Kubernetes custom resource definition (CRD) that orchestrates model serving for all types of models. It includes model-serving runtimes that implement the loading of given types of model servers. KServe handles the lifecycle of the deployment object, storage access, and networking setup.
+* link:https://github.com/opendatahub-io/kserve[KServe^]: A Kubernetes custom resource definition (CRD) that orchestrates model serving for all types of models. It includes model-serving runtimes that implement the loading of given types of model servers. KServe handles the lifecycle of the deployment object, storage access, and networking setup.
 
-* link:https://docs.openshift.com/serverless/1.29/about/about-serverless.html[{org-name} OpenShift Serverless^]: Cloud-native development model that allows for serverless deployments of models. OpenShift Serverless is based on the open source link:https://knative.dev/docs/[Knative^] project.
+* link:https://docs.openshift.com/serverless/1.29/about/about-serverless.html[{org-name} OpenShift Serverless^]: A cloud-native development model that allows for serverless deployments of models. OpenShift Serverless is based on the open source link:https://knative.dev/docs/[Knative^] project.
 
 ifdef::self-managed[]
-* link:https://docs.openshift.com/container-platform/{ocp-latest-version}/service_mesh/v2x/ossm-architecture.html[{org-name} OpenShift Service Mesh^]: Service mesh networking layer that manages traffic flows and enforces access policies. OpenShift Service Mesh is based on the open source link:https://istio.io/[Istio^] project.
+* link:https://docs.openshift.com/container-platform/{ocp-latest-version}/service_mesh/v2x/ossm-architecture.html[{org-name} OpenShift Service Mesh^]: A service mesh networking layer that manages traffic flows and enforces access policies. OpenShift Service Mesh is based on the open source link:https://istio.io/[Istio^] project.
 endif::[]
 
 ifndef::self-managed[]

--- a/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
+++ b/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
@@ -1,0 +1,40 @@
+:_module-type: PROCEDURE
+
+[id="accessing-api-endpoints-for-models-deployed-on-single-model-serving-platform_{context}"]
+= Accessing the API endpoints for models deployed on the single model serving platform
+
+[role='_abstract']
+When you deploy a model by using the single model serving platform, the model is available as a service that you can access using API requests. This enables you to return predictions based on data inputs. To use API requests to interact with your deployed model, you must know how to access the API endpoints that are available.
+
+.Prerequisites
+* You have logged in to {productname-long}.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
+* You have deployed a model by using the single model serving platform.
+
+.Procedure
+. From the {productname-short} dashboard, click *Model Serving*.
+. From the *Project* list, select the project that you deployed a model in.
+. In the *Deployed models* table, for the model that you want to access, copy the URL shown in the *Inference endpoint* column.
+. Depending on what action you want to perform with the model (and if the model supports that action), add one of the following paths to the end of the inference endpoint URL:
++
+--
+* `:443/api/v1/task/server-streaming-text-generation`
+// * `:443/api/v1/task/text-classification`
+* `:443/api/v1/task/text-generation`
+// * `:443/api/v1/task/token-classification`
+--
++
+As indicated by the paths shown, the single model serving platform uses the HTTPS port of your OpenShift router (usually port 443) to serve external API requests.
+
+. Use the endpoints to make API requests to your deployed model, as shown in the following example `curl` command:
++
+[source]
+----
+curl --json '{
+    "model_id": "<model_name>",
+    "inputs": "<query_text>"
+}' https://<inference_endpoint_url>:443/api/v1/task/server-streaming-text-generation
+----
+
+//[role='_additional-resources']
+//.Additional resources

--- a/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
+++ b/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {oai-admin-group}) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have deployed a model by using the single model serving platform.
 

--- a/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
+++ b/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
@@ -8,7 +8,12 @@ When you deploy a model by using the single model serving platform, the model is
 
 .Prerequisites
 * You have logged in to {productname-long}.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
+ifndef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
+endif::[]
+ifdef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {oai-admin-group}) in OpenShift.
+endif::[]
 * You have deployed a model by using the single model serving platform.
 
 .Procedure

--- a/modules/adding-a-custom-model-serving-runtime.adoc
+++ b/modules/adding-a-custom-model-serving-runtime.adoc
@@ -58,7 +58,7 @@ The embedded YAML editor opens with no content.
 .. In the YAML editor, locate the `kind` field for your runtime. Update the value of this field to `ServingRuntime`.
 .. In the link:https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/kustomization.yaml[kustomization.yaml] file in the https://github.com/kserve/modelmesh-serving/tree/main/config/runtimes[kserve/modelmesh-serving^] repository, take note of the `newName` and `newTag` values for the runtime that you want to add. You will specify these values in a later step.
 .. In the YAML editor for your custom runtime, locate the `containers.image` field. 
-.. Update the value of the `containers.image` field to specify the runtime that you want to add. Based on the the `newName` and `newTag` values that you noted in the link:https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/kustomization.yaml[kustomization.yaml] file, specify the value in the format `newName:newTag`, as shown in the following examples:
+.. Update the value of the `containers.image` field in the format `newName:newTag`, based on the values that you previously noted in the link:https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/kustomization.yaml[kustomization.yaml] file. Some examples are shown.
 +
 --
 Nvidia Triton Inference Server::

--- a/modules/adding-a-custom-model-serving-runtime.adoc
+++ b/modules/adding-a-custom-model-serving-runtime.adoc
@@ -12,10 +12,10 @@ As an administrator, you can use the {productname-short} interface to add and en
 .Prerequisites
 * You have logged in to {productname-short} as an administrator.
 ifdef::upstream[]
-* You are familiar with how to link:{odhdocshome}/working-on-data-science-projects/#adding-a-model-server-for-the-multi-model-serving-platform_nb-server[add a model server to your project]. When you have added a custom model-serving runtime, you must configure a new model server to use the runtime.
+* You are familiar with how to link:{odhdocshome}/serving-models/#adding-a-model-server-for-the-multi-model-serving-platform_model-serving[add a model server to your project]. When you have added a custom model-serving runtime, you must configure a new model server to use the runtime.
 endif::[]
 ifndef::upstream[]
-* You are familiar with how to link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#adding-a-model-server-for-the-multi-model-serving-platform_nb-server[add a model server to your project]. When you have added a custom model-serving runtime, you must configure a new model server to use the runtime.
+* You are familiar with how to link:{rhoaidocshome}{default-format-url}/serving-models/serving-small-and-medium-sized-models_model-serving#adding-a-model-server-for-the-multi-model-serving-platform_model-serving[add a model server to your project]. When you have added a custom model-serving runtime, you must configure a new model server to use the runtime.
 endif::[]
 * You have reviewed the example runtimes in the https://github.com/kserve/modelmesh-serving/tree/main/config/runtimes[kserve/modelmesh-serving^] repository. You can use these examples as _starting points_. However, each runtime requires some further modification before you can deploy it in {productname-short}. The required modifications are described in the following procedure.
 +
@@ -56,23 +56,25 @@ The embedded YAML editor opens with no content.
 
 . Optional: If you are adding one of the example runtimes in the https://github.com/kserve/modelmesh-serving/tree/main/config/runtimes[kserve/modelmesh-serving^] repository, perform the following modifications:
 .. In the YAML editor, locate the `kind` field for your runtime. Update the value of this field to `ServingRuntime`.
-.. In the YAML editor, locate the `containers.image` field for your runtime. Based on the runtime that you are adding, update the field to one of the following:
+.. In the link:https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/kustomization.yaml[kustomization.yaml] file in the https://github.com/kserve/modelmesh-serving/tree/main/config/runtimes[kserve/modelmesh-serving^] repository, take note of the `newName` and `newTag` values for the runtime that you want to add. You will specify these values in a later step.
+.. In the YAML editor for your custom runtime, locate the `containers.image` field. 
+.. Update the value of the `containers.image` field to specify the runtime that you want to add. Based on the the `newName` and `newTag` values that you noted in the link:https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/kustomization.yaml[kustomization.yaml] file, specify the value in the format `newName:newTag`, as shown in the following examples:
 +
 --
 Nvidia Triton Inference Server::
 +
-`image: nvcr.io/nvidia/tritonserver:21.06.1-py3`
+`image: nvcr.io/nvidia/tritonserver:23.04-py3`
 
 Seldon Python MLServer::
 +
-`image: seldonio/mlserver:0.5.2`
+`image: seldonio/mlserver:1.3.2`
 
 TorchServe::
 +
-`image: pytorch/torchserve:0.6.0-cpu`
+`image: pytorch/torchserve:0.7.1-cpu`
 --
 
-. In the `metadata.name` field, ensure that the value of the runtime you are adding is unique (that is, the value isn't the same as for a runtime you have already added).
+. In the `metadata.name` field, ensure that the value of the runtime you are adding is unique (that is, the value doesn't match a runtime that you have already added).
 
 . Optional: To configure a custom display name for the runtime that you are adding, add a `metadata.annotations.openshift.io/display-name` field and specify a value, as shown in the following example:
 +

--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -17,11 +17,11 @@ endif::[]
 * You have created a data science project that you can add a model server to.
 * You have enabled the multi-model serving platform.
 ifndef::upstream[]
-* If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#adding-a-custom-model-serving-runtime_nb-server[Adding a custom model-serving runtime].
+* If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{rhoaidocshome}{default-format-url}/serving-models/serving-small-and-medium-sized-models_model-serving#adding-a-custom-model-serving-runtime_model-serving[Adding a custom model-serving runtime].
 * If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support in {productname-short}. See link:{rhoaidocshome}{default-format-url}/managing_resources/managing-cluster-resources_cluster-mgmt#enabling-gpu-support_cluster-mgmt[Enabling GPU support in {productname-short}].
 endif::[]
 ifdef::upstream[]
-* If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{odhdocshome}/working-on-data-science-projects/#adding-a-custom-model-serving-runtime_nb-server[Adding a custom model-serving runtime].
+* If you want to use a custom model-serving runtime for your model server, you have added and enabled the runtime. See link:{odhdocshome}/serving-models/#adding-a-custom-model-serving-runtime_model-serving[Adding a custom model-serving runtime].
 * If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support. This includes installing the Node Feature Discovery and GPU Operators. For more information, see https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/index.html[NVIDIA GPU Operator on {org-name} OpenShift Container Platform] in the NVIDIA documentation.
 endif::[]
 

--- a/modules/configuring-monitoring-for-the-single-model-serving-platform.adoc
+++ b/modules/configuring-monitoring-for-the-single-model-serving-platform.adoc
@@ -1,0 +1,145 @@
+:_module-type: PROCEDURE
+
+[id="configuring-monitoring-for-the-single-model-serving-platform_{context}"]
+= Configuring monitoring for the single model serving platform
+
+[role="_abstract"]
+The single model serving platform includes metrics for Caikit and TGIS. You can also configure monitoring for OpenShift Service Mesh. The service mesh metrics helps you to understand dependencies and traffic flow between components in the mesh. When you have configured monitoring, you can grant Prometheus access to scrape the available metrics.
+
+.Prerequisites
+* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have created OpenShift Service Mesh and Knative Serving instances and installed KServe.
+* You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.openshift.com/container-platform/{ocp-latest-version}/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli[Installing the OpenShift CLI].
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[creating a config map] for monitoring a user-defined workflow. You will perform similar steps in this procedure.
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[enabling monitoring] for user-defined projects in OpenShift. You will perform similar steps in this procedure.
+* You have link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned] the `monitoring-rules-view` role to users that will monitor metrics.
+
+.Procedure
+. In a terminal window, if you are not already logged in to your OpenShift cluster as a cluster administrator, log in to the OpenShift CLI as shown in the following example:
++
+[source,subs="+quotes"]
+----
+$ oc login __<openshift_cluster_url>__ -u __<admin_username>__ -p __<password>__
+----
+
+. Define a `ConfigMap` object in a YAML file called `uwm-cm-conf.yaml` with the following contents:
++
+[source]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      logLevel: debug 
+      retention: 15d
+----
++
+The `user-workload-monitoring-config` object configures the components that monitor user-defined projects.  Observe that the retention time is set to the recommended value of 15 days.
+
+. Apply the configuration to create the `user-workload-monitoring-config` object.
++
+[source]
+----
+$ oc apply -f uwm-cm-conf.yaml
+----
+
+. Define another `ConfigMap` object in a YAML file called `uwm-cm-enable.yaml` with the following contents:
+
++
+[source]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
++
+The `cluster-monitoring-config` object enables monitoring for user-defined projects.
+
+. Apply the configuration to create the `cluster-monitoring-config` object.
++
+[source]
+----
+$ oc apply -f uwm-cm-enable.yaml
+----
+
+. Create `ServiceMonitor` and `PodMonitor` objects to monitor metrics in the service mesh control plane as follows:
+
+
+.. Create an `istiod-monitor.yaml` YAML file with the following contents:
++
+[source]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod-monitor
+  namespace: istio-system
+spec:
+  targetLabels:
+  - app
+  selector:
+    matchLabels:
+      istio: pilot
+  endpoints:
+  - port: http-monitoring
+    interval: 30s
+----
+
+.. Deploy the `ServiceMonitor` CR in the specified `istio-system` namespace.
++
+[source]
+----
+$ oc apply -f istiod-monitor.yaml
+----
++
+You see the following output:
++
+[source]
+----
+servicemonitor.monitoring.coreos.com/istiod-monitor created
+----
+
+.. Create an `istio-proxies-monitor.yaml` YAML file with the following contents:
++
+[source]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies-monitor
+  namespace: istio-system
+spec:
+  selector:
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    interval: 30s
+----
+
+.. Deploy the `PodMonitor` CR in the specified `istio-system` namespace.
++
+[source]
+----
+$ oc apply -f istio-proxies-monitor.yaml
+----
++
+You see the following output:
++
+[source]
+----
+podmonitor.monitoring.coreos.com/istio-proxies-monitor created
+----
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
+++ b/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
@@ -38,7 +38,7 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 * *To use an existing data connection*
 ... Select *Existing data connection*.
 ... From the *Name* list, select a data connection that you previously defined.
-... In the *Folder path* field, enter the folder path that contains the model in your specified data source.
+... In the *Path* field, enter the folder path that contains the model in your specified data source.
 
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.
@@ -48,7 +48,7 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 ... In the *Endpoint* field, enter the endpoint of your S3-compatible object storage bucket.
 ... In the *Region* field, enter the default region of your S3-compatible object storage account.
 ... In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
-... In the *Folder path* field, enter the folder path in your S3-compatible object storage that contains your data file. 
+... In the *Path* field, enter the folder path in your S3-compatible object storage that contains your data file. 
 --
 
 .. Click *Deploy*.

--- a/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
+++ b/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
@@ -4,9 +4,9 @@
 = Deploying a model by using the multi-model serving platform
 
 [role='_abstract']
-You can deploy trained models on {productname-short} to enable you to test and implement them into intelligent applications. Deploying a model makes it available as a service that you can access using an API. This enables you to return predictions based on data inputs.
+You can deploy trained models on {productname-short} to enable you to test and implement them into intelligent applications. Deploying a model makes it available as a service that you can access by using an API. This enables you to return predictions based on data inputs.
 
-When you have enabled the _multi-model serving platform_ (which uses the ModelMesh component of {productname-short}) you can deploy models on the platform.
+When you have enabled the multi-model serving platform, you can deploy models on the platform.
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -1,0 +1,68 @@
+:_module-type: PROCEDURE
+
+[id="deploying-models-on-the-single-model-serving-platform_{context}"]
+= Deploying models on the single model serving platform
+
+[role='_abstract']
+When you have enabled the _single model serving platform_ (which uses the KServe component of {productname-short}), you can enable the Caikit-TGIS runtime that this platform uses and start to deploy models on the platform. 
+
+.Prerequisites
+* You have logged in to {productname-long}.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
+* You have installed KServe.
+* You have enabled the single model serving platform.
+* You have created a data science project.
+* To use the Caikit-TGIS runtime, you have converted your model to Caikit format. For an example, see link:https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/built-tip.md#bootstrap-process[Converting Hugging Face Hub models to Caikit format] in the link:https://github.com/opendatahub-io/caikit-tgis-serving/tree/main[caikit-tgis-serving] repository.
+* You know the folder path for the data connection that you want the model to access.
+ifdef::self-managed[]
+* If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support in {productname-short}. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/enabling-gpu-support_install[Enabling GPU support in {productname-short}].
+endif::[]
+ifndef::self-managed[]
+* If you want to use graphics processing units (GPUs) with your model server, you have enabled GPU support in {productname-short}. See link:{rhoaidocshome}{default-format-url}/installing_{url-productname-short}/enabling-gpu-support_install[Enabling GPU support in {productname-short}].
+endif::[]
+
+.Procedure
+. Enable the Caikit-TGIS runtime as follows:
+.. In the left menu of the {productname-short} dashboard, click *Settings* -> *Serving runtimes*.
+.. On the *Serving runtimes* page, set the *Caikit TGIS ServingRuntime for KServe* runtime to *Enabled*. 
+. In the left menu, click *Data Science Projects*.
+. Click the name of the project that you want to deploy a model in.
+. In the *Models and model servers* section, perform one of the following actions:
++
+--
+* If you see a *​​Single model serving platform* tile, click *Deploy model* on the tile. 
+* If you do not see any tiles, click the *Deploy model* button.
+--
++
+The *Deploy model* dialog opens.
+. Configure properties for deploying your model as follows:
+.. In the *Model name* field, enter a unique name for the model that you are deploying.
+.. In the *Serving runtime* field, select *Caikit TGIS ServingRuntime for KServe*.
+.. From the *Model framework* list, select *caikit*.
+.. In the *Number of model replicas to deploy* field, specify a value.
+.. From the *Model server size* list, select a value.
+.. To specify the location of your model, perform one of the following sets of actions:
++
+--
+* *To use an existing data connection*
+... Select *Existing data connection*.
+... From the *Name* list, select a data connection that you previously defined.
+... In the *Folder path* field, enter the folder path that contains the model in your specified data source.
+
+* *To use a new data connection*
+... To define a new data connection that your model can access, select *New data connection*.
+... In the *Name* field, enter a unique name for the data connection.
+... In the *Access key* field, enter the access key ID for your S3-compatible object storage provider.
+... In the *Secret key* field, enter the secret access key for the S3-compatible object storage account that you specified.
+... In the *Endpoint* field, enter the endpoint of your S3-compatible object storage bucket.
+... In the *Region* field, enter the default region of your S3-compatible object storage account.
+... In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
+... In the *Folder* path field, enter the folder path in your S3-compatible object storage that contains your data file.
+--
+.. Click *Deploy*.
+
+.Verification
+* Confirm that the deployed model is shown in the *Models and model servers* section of your project, and on the *Model Serving* page of the dashboard with a check mark in the *Status* column.
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -4,7 +4,7 @@
 = Deploying models on the single model serving platform
 
 [role='_abstract']
-When you have enabled the _single model serving platform_ (which uses the KServe component of {productname-short}), you can enable the Caikit-TGIS runtime that this platform uses and start to deploy models on the platform. 
+When you have enabled the single model serving platform, you can enable the Caikit-TGIS runtime that this platform uses and start to deploy models on the platform. 
 
 .Prerequisites
 * You have logged in to {productname-long}.
@@ -12,7 +12,7 @@ ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {oai-admin-group}) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
 * You have installed KServe.
 * You have enabled the single model serving platform.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -8,7 +8,12 @@ When you have enabled the _single model serving platform_ (which uses the KServe
 
 .Prerequisites
 * You have logged in to {productname-long}.
-* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
+ifndef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
+endif::[]
+ifdef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {oai-admin-group}) in OpenShift.
+endif::[]
 * You have installed KServe.
 * You have enabled the single model serving platform.
 * You have created a data science project.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -52,7 +52,7 @@ The *Deploy model* dialog opens.
 * *To use an existing data connection*
 ... Select *Existing data connection*.
 ... From the *Name* list, select a data connection that you previously defined.
-... In the *Folder path* field, enter the folder path that contains the model in your specified data source.
+... In the *Path* field, enter the folder path that contains the model in your specified data source.
 
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.
@@ -62,7 +62,7 @@ The *Deploy model* dialog opens.
 ... In the *Endpoint* field, enter the endpoint of your S3-compatible object storage bucket.
 ... In the *Region* field, enter the default region of your S3-compatible object storage account.
 ... In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
-... In the *Folder* path field, enter the folder path in your S3-compatible object storage that contains your data file.
+... In the *Path* field, enter the folder path in your S3-compatible object storage that contains your data file.
 --
 .. Click *Deploy*.
 

--- a/modules/deploying-models-using-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-using-the-single-model-serving-platform.adoc
@@ -1,0 +1,11 @@
+:_module-type: CONCEPT
+
+[id="deploying-models-using-the-single-model-serving-platform_{context}"]
+= Deploying models by using the single model serving platform
+
+[role='_abstract']
+You can deploy trained models on {productname-short} to test and implement them into intelligent applications. Deploying a model makes it available as a service that you can access using an API. This enables you to return predictions based on data inputs.
+
+For serving large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on KServe. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.
+
+IMPORTANT: The single model serving platform does not support self-signed certificates. Therefore, to deploy a model from S3 storage, you need to follow a workaround to disable SSL authentication. For more information, see the following Red Hat Solution article: link:https://access.redhat.com/solutions/7047512[How to skip the validation of SSL for KServe].

--- a/modules/deploying-models-using-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-using-the-single-model-serving-platform.adoc
@@ -4,8 +4,6 @@
 = Deploying models by using the single model serving platform
 
 [role='_abstract']
-You can deploy trained models on {productname-short} to test and implement them into intelligent applications. Deploying a model makes it available as a service that you can access using an API. This enables you to return predictions based on data inputs.
-
-For serving large language models (LLMs), {productname-long} includes a _single model serving platform_ that is based on KServe. Because each model is deployed from its own model server, the single model serving platform helps you to deploy, monitor, scale, and maintain LLMs.
+On the single model serving platform, each model is deployed from its own model server. This helps you to deploy, monitor, scale, and maintain LLMs that require increased resources.
 
 IMPORTANT: The single model serving platform does not support self-signed certificates. Therefore, to deploy a model from S3 storage, you need to follow a workaround to disable SSL authentication. For more information, see the following Red Hat Solution article: link:https://access.redhat.com/solutions/7047512[How to skip the validation of SSL for KServe].

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -4,15 +4,15 @@
 = Enabling the multi-model serving platform
 
 [role='_abstract']
-To use the _multi-model serving platform_ (which uses the ModelMesh component of {productname-short}), you must first enable the platform.
+To use the multi-model serving platform, you must first enable the platform.
 
 .Prerequisites
 * You have logged in to {productname-long}.
 ifndef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift.
 endif::[]
 ifdef::upstream[]
-* If you use specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
+* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[]
 
 .Procedure

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -1,0 +1,27 @@
+:_module-type: PROCEDURE
+
+[id="enabling-the-single-model-serving-platform_{context}"]
+= Enabling the single model serving platform
+
+[role="_abstract"]
+When you have installed KServe, you can use the {productname-long} dashboard to enable the _single model serving platform_ that uses it. You can also use the dashboard to enable the Caikit-TGIS model-serving runtime that this platform uses. 
+
+.Prerequisites
+* You have logged in to {productname-long}.
+* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift. 
+* You have installed KServe.
+
+.Procedure
+. Enable the single model serving platform as follows:
+.. In the left menu, click *Settings* -> *Cluster settings*.
+.. Locate the *Model serving platforms* section.
+.. To enable the single model serving platform for projects, select the *Single model serving platform* checkbox.
+.. Click *Save changes*.
+. Enable the Caikit-TGIS runtime as follows:
+.. In the left menu of the {productname-short} dashboard, click *Settings* -> *Serving runtimes*.
+.. On the *Serving runtimes* page, set the *Caikit TGIS ServingRuntime for KServe* runtime to *Enabled*.
++
+The single model serving platform is now available for model deployments. 
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -4,11 +4,16 @@
 = Enabling the single model serving platform
 
 [role="_abstract"]
-When you have installed KServe, you can use the {productname-long} dashboard to enable the _single model serving platform_ that uses it. You can also use the dashboard to enable the Caikit-TGIS model-serving runtime that this platform uses. 
+When you have installed KServe, you can use the {productname-long} dashboard to enable the single model serving platform. You can also use the dashboard to enable the Caikit-TGIS model-serving runtime that this platform uses. 
 
 .Prerequisites
 * You have logged in to {productname-long}.
-* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift. 
+ifndef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift.
+endif::[]
+ifdef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
+endif::[] 
 * You have installed KServe.
 
 .Procedure

--- a/modules/installing-kserve.adoc
+++ b/modules/installing-kserve.adoc
@@ -4,7 +4,7 @@
 = Installing KServe
 
 [role="_abstract"]
-To learn how to install KServe, see link:https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[Installation] in the https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[caikit-tgis-serving] repository.
+To learn how to perform both automated and manual installation of KServe, see link:https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[Installation] in the https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[caikit-tgis-serving] repository.
 
 // [role="_additional-resources"]
 // .Additional resources

--- a/modules/installing-kserve.adoc
+++ b/modules/installing-kserve.adoc
@@ -1,0 +1,10 @@
+:_module-type: PROCEDURE
+
+[id="installing-kserve_{context}"]
+= Installing KServe
+
+[role="_abstract"]
+To learn how to install KServe, see link:https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[Installation] in the https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/docs#installation[caikit-tgis-serving] repository.
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
+++ b/modules/updating-the-deployment-properties-of-a-deployed-model.adoc
@@ -33,7 +33,7 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 +
 --
 * *If you previously specified an existing data connection*
-... In the *Folder path* field, update the folder path that contains the model in your specified data source.
+... In the *Path* field, update the folder path that contains the model in your specified data source.
 
 * *If you previously specified a new data connection*
 ... In the *Name* field, update a unique name for the data connection.
@@ -42,7 +42,7 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 ... In the *Endpoint* field, update the endpoint of your S3-compatible object storage bucket.
 ... In the *Region* field, update the default region of your S3-compatible object storage account.
 ... In the *Bucket* field, update the name of your S3-compatible object storage bucket.
-... In the *Folder path* field, update the folder path in your S3-compatible object storage that contains your data file. 
+... In the *Path* field, update the folder path in your S3-compatible object storage that contains your data file. 
 --
 
 .. Click *Deploy*.

--- a/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
@@ -1,0 +1,38 @@
+:_module-type: PROCEDURE
+
+[id="viewing-metrics-for-the-single-model-serving-platform_{context}"]
+= Viewing metrics for the single model serving platform
+
+[role="_abstract"]
+When a cluster administrator has configured monitoring for the single model serving platform, non-admin users can use the OpenShift web console to view metrics. 
+
+.Prerequisites
+ifdef::self-managed[]
+* A cluster administrator has configured monitoring for the single model serving platform.
+endif::[]
+ifdef::self-managed[]
+* You have been link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned] the `monitoring-rules-view` role.
+endif::[]
+ifdef::self-managed[]
+* You are familiar with how to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitor project metrics] in the {openshift-platform} web console.
+endif::[]
+ifndef::self-managed[]
+* You have access to the OpenShift cluster as a developer or as a user with view permissions for the project that you are viewing metrics for.
+endif::[]
+ifndef::self-managed[]
+* You are familiar with querying metrics in user-defined projects. See link:https://docs.openshift.com/dedicated/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] (Red Hat OpenShift Dedicated) or link:https://docs.openshift.com/rosa/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] (Red Hat OpenShift Service on AWS).
+endif::[]
+
+.Procedure
+. Log in to the {openshift-platform} web console.
+. Switch to the *Developer* perspective.
+. In the left menu, click *Observe*.
+ifdef::self-managed[]
+. As described in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitoring project metrics], use the web console to run queries for `caikit_*`, `tgi_*` or `istio_*` metrics.
+endif::[]
+ifndef::self-managed[]
+. As described in link:https://docs.openshift.com/dedicated/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] (Red Hat OpenShift Dedicated) or link:https://docs.openshift.com/rosa/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] (Red Hat OpenShift Service on AWS), use the web console to run queries for `caikit_*`, `tgi_*`, or `istio_*` metrics.
+endif::[]
+
+// [role="_additional-resources"]
+// .Additional resources

--- a/serving-models.adoc
+++ b/serving-models.adoc
@@ -1,0 +1,26 @@
+---
+layout: docs
+title: Serving models
+permalink: /docs/serving-models
+custom_css: asciidoc.css
+---
+
+:upstream:
+include::_artifacts/document-attributes-global.adoc[]
+
+:doctype: book
+:toc: left
+:compat-mode:
+:context: model-serving
+
+= Serving models
+
+:context: about-model-serving
+include::modules/about-model-serving.adoc[leveloffset=+1]
+
+:context: serving-small-and-medium-models
+include::assemblies/serving-small-and-medium-sized-models.adoc[leveloffset=+1]
+
+:context: serving-large-language-models
+include::assemblies/serving-large-language-models.adoc[leveloffset=+1]
+

--- a/working-on-data-science-projects.adoc
+++ b/working-on-data-science-projects.adoc
@@ -29,9 +29,6 @@ include::assemblies/working-on-data-science-projects.adoc[leveloffset=+1]
 :context: ds-pipelines
 include::assemblies/working-with-data-science-pipelines.adoc[leveloffset=+1]
 
-:context: model-serving
-include::assemblies/model-serving.adoc[leveloffset=+1]
-
 :context: accelerators
 include::assemblies/working-with-accelerators.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR covers the following:

- Contributing documentation for [serving large language models](https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.5/html/working_on_data_science_projects/serving-large-language-models_serving-large-language-models) upstream
- Replicating changes to chapter on [serving small and medium-sized models](https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.5/html/working_on_data_science_projects/serving-small-and-medium-sized-models_model-serving) upstream
- Adding both chapters to a new, standalone model serving guide

Changes verified via a local build of the Open Data Hub website.