### PR TITLE
RHOAIENG-1540: Updating OSD references upstream

### DIFF
--- a/modules/accessing-tutorials.adoc
+++ b/modules/accessing-tutorials.adoc
@@ -21,6 +21,7 @@ ifndef::self-managed[]
 endif::[]
 --
 endif::[]
+
 .Procedure
 . On the {productname-long} home page, click *Resources*.
 +

--- a/modules/accessing-tutorials.adoc
+++ b/modules/accessing-tutorials.adoc
@@ -8,8 +8,19 @@ You can access learning resources for {productname-long} and supported applicati
 
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
+ifdef::upstream[[]
 * You have logged in to the {openshift-platform} web console.
-
+endif::[]
+ifndef::upstream[]
+--
+ifdef::self-managed[]
+* You have logged in to the {openshift-platform} web console.
+endif::[]
+ifndef::self-managed[]
+* You have logged in to the OpenShift web console.
+endif::[]
+--
+endif::[]
 .Procedure
 . On the {productname-long} home page, click *Resources*.
 +

--- a/modules/accessing-tutorials.adoc
+++ b/modules/accessing-tutorials.adoc
@@ -8,18 +8,11 @@ You can access learning resources for {productname-long} and supported applicati
 
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
-ifdef::upstream[]
+ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream[]
---
-ifdef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-endif::[]
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 * You have logged in to the OpenShift web console.
-endif::[]
---
 endif::[]
 
 .Procedure

--- a/modules/accessing-tutorials.adoc
+++ b/modules/accessing-tutorials.adoc
@@ -8,7 +8,7 @@ You can access learning resources for {productname-long} and supported applicati
 
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
-ifdef::upstream[[]
+ifdef::upstream[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
 ifndef::upstream[]

--- a/modules/accessing-tutorials.adoc
+++ b/modules/accessing-tutorials.adoc
@@ -11,7 +11,7 @@ You can access learning resources for {productname-long} and supported applicati
 ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * You have logged in to the OpenShift web console.
 endif::[]
 

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -16,7 +16,7 @@ endif::[]
 Do not follow this procedure when disabling the following applications:
 
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * {org-name} OpenShift API Management. You can only uninstall {org-name} OpenShift API Management from OpenShift Cluster Manager.
 endif::[]
 ====
@@ -28,7 +28,7 @@ ifdef::upstream,self-managed[]
 * You have installed or configured the service on your {openshift-platform} cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * You have logged in to the OpenShift web console.
 * You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
 * You have installed or configured the service on your OpenShift cluster.
@@ -39,7 +39,7 @@ endif::[]
 ifdef::upstream,self-managed[]
 . In the {openshift-platform} web console, switch to the *Administrator* perspective.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 . In the OpenShift web console, switch to the *Administrator* perspective.
 endif::[]
 ifndef::upstream[]

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -37,7 +37,7 @@ ifndef::upstream[]
 --
 ifndef::self-managed[]
 * You have logged in to the OpenShift web console.
-* You are part of the `cluster-admins` user group in your OpenShift cluster.
+* You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
 * You have installed or configured the service on your OpenShift cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
@@ -54,18 +54,18 @@ endif::[]
 ifndef::upstream[]
 --
 ifdef::self-managed[]
-. In the {openshift-platform} web console, change into the *Administrator* perspective.
+. In the {openshift-platform} web console, switch to the *Administrator* perspective.
 endif::[]
 ifndef::self-managed[]
-. In the OpenShift web console, change into the *Administrator* perspective.
+. In the OpenShift web console, switch to the *Administrator* perspective.
 endif::[]
 --
 endif::[]
 ifndef::upstream[]
-. Change into the `redhat-ods-applications` project.
+. Switch to the `redhat-ods-applications` project.
 endif::[]
 ifdef::upstream[]
-. Change into the `odh` project.
+. Switch to the `odh` project.
 endif::[]
 . Click *Operators* -> *Installed Operators*.
 . Click on the Operator that you want to uninstall. You can enter a keyword into the *Filter by name* field to help you find the Operator faster.

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -16,50 +16,31 @@ endif::[]
 Do not follow this procedure when disabling the following applications:
 
 * Anaconda Professional Edition. You cannot manually disable Anaconda Professional Edition. It is automatically disabled only when its license expires.
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 * {org-name} OpenShift API Management. You can only uninstall {org-name} OpenShift API Management from OpenShift Cluster Manager.
-endif::[]
---
 endif::[]
 ====
 
 .Prerequisites
-ifdef::upstream[]
-* You have logged in to the {productname-short} web console.
+ifdef::upstream,self-managed[]
+* You have logged in to the {openshift-platform} web console.
 * You are part of the `cluster-admins` user group in {openshift-platform}.
-* You have installed or configured the service on your {productname-short} cluster.
+* You have installed or configured the service on your {openshift-platform} cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
-
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 * You have logged in to the OpenShift web console.
 * You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
 * You have installed or configured the service on your OpenShift cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
-ifdef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-* You are assigned the `cluster-admin` role  in {openshift-platform}.
-* You have installed or configured the service on your {openshift-platform} cluster.
-* The application or component that you want to disable is enabled and appears on the *Enabled* page.
-endif::[]
---
-endif::[]
 
 .Procedure
-ifndef::upstream[]
---
-ifdef::self-managed[]
+ifdef::upstream,self-managed[]
 . In the {openshift-platform} web console, switch to the *Administrator* perspective.
 endif::[]
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 . In the OpenShift web console, switch to the *Administrator* perspective.
-endif::[]
---
 endif::[]
 ifndef::upstream[]
 . Switch to the `redhat-ods-applications` project.

--- a/modules/disabling-applications-connected-to-open-data-hub.adoc
+++ b/modules/disabling-applications-connected-to-open-data-hub.adoc
@@ -36,9 +36,9 @@ endif::[]
 ifndef::upstream[]
 --
 ifndef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-* You are part of the `cluster-admins` user group in {openshift-platform}.
-* You have installed or configured the service on your {openshift-platform} cluster.
+* You have logged in to the OpenShift web console.
+* You are part of the `cluster-admins` user group in your OpenShift cluster.
+* You have installed or configured the service on your OpenShift cluster.
 * The application or component that you want to disable is enabled and appears on the *Enabled* page.
 endif::[]
 ifdef::self-managed[]
@@ -51,8 +51,16 @@ endif::[]
 endif::[]
 
 .Procedure
-
+ifndef::upstream[]
+--
+ifdef::self-managed[]
 . In the {openshift-platform} web console, change into the *Administrator* perspective.
+endif::[]
+ifndef::self-managed[]
+. In the OpenShift web console, change into the *Administrator* perspective.
+endif::[]
+--
+endif::[]
 ifndef::upstream[]
 . Change into the `redhat-ods-applications` project.
 endif::[]

--- a/modules/enabling-gpu-support-in-data-science.adoc
+++ b/modules/enabling-gpu-support-in-data-science.adoc
@@ -34,7 +34,7 @@ ifdef::upstream,self-managed[]
 * You have logged in to your {openshift-platform} cluster.
 * You have the `cluster-admin` role in your {openshift-platform} cluster.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * You have logged in to your OpenShift cluster.
 * You have the `cluster-admin` role in your OpenShift cluster.
 endif::[]
@@ -53,7 +53,7 @@ endif::[]
 ifdef::upstream,self-managed[]
 .. In the {openshift-platform} web console, change into the *Administrator* perspective.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 .. In the OpenShift web console, change into the *Administrator* perspective.
 endif::[]
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate ConfigMap.
@@ -67,7 +67,7 @@ The *Delete ConfigMap* dialog appears.
 ifdef::upstream,self-managed[]
 .. In the {openshift-platform} web console, change into the *Administrator* perspective.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 .. In the OpenShift web console, change into the *Administrator* perspective.
 endif::[]
 .. Click *Workloads* -> *Deployments*.
@@ -80,7 +80,7 @@ endif::[]
 ifdef::upstream,self-managed[]
 * The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the {openshift-platform} web console.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the OpenShift web console.
 endif::[]
 * The reset *migration-gpu-status* instance is present in the *Instances* tab on the `AcceleratorProfile` custom resource definition (CRD) details page.

--- a/modules/enabling-gpu-support-in-data-science.adoc
+++ b/modules/enabling-gpu-support-in-data-science.adoc
@@ -30,8 +30,14 @@ endif::[]
 endif::[]
 
 .Prerequisites
-* You have logged in to {openshift-platform}.
-* You have the `cluster-admin` role in {openshift-platform}.
+ifdef::upstream,self-managed[]
+* You have logged in to your {openshift-platform} cluster.
+* You have the `cluster-admin` role in your {openshift-platform} cluster.
+endif::[]
+ifndef::upstream,self-managed[]
+* You have logged in to your OpenShift cluster.
+* You have the `cluster-admin` role in your OpenShift cluster.
+endif::[]
 
 .Procedure
 //the following step applies to cloud service, self-managed connected, and upstream
@@ -44,7 +50,12 @@ ifdef::disconnected[]
 endif::[]
 //the following steps apply to upstream and downstream: self-managed (connected and disconnected) and cloud service
 . Delete the *migration-gpu-status* ConfigMap.
+ifdef::upstream,self-managed[]
 .. In the {openshift-platform} web console, change into the *Administrator* perspective.
+endif::[]
+ifndef::upstream,self-managed[]
+.. In the OpenShift web console, change into the *Administrator* perspective.
+endif::[]
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate ConfigMap.
 .. Search for the *migration-gpu-status* ConfigMap.
 .. Click the action menu (&#8942;) and select *Delete ConfigMap* from the list.
@@ -53,7 +64,12 @@ The *Delete ConfigMap* dialog appears.
 .. Inspect the dialog and confirm that you are deleting the correct ConfigMap.
 .. Click *Delete*.
 . Restart the dashboard replicaset.
+ifdef::upstream,self-managed[]
 .. In the {openshift-platform} web console, change into the *Administrator* perspective.
+endif::[]
+ifndef::upstream,self-managed[]
+.. In the OpenShift web console, change into the *Administrator* perspective.
+endif::[]
 .. Click *Workloads* -> *Deployments*.
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate deployment.
 .. Search for the *rhods-dashboard* deployment.
@@ -61,7 +77,12 @@ The *Delete ConfigMap* dialog appears.
 .. Wait until the *Status* column indicates that all pods in the rollout have fully restarted.
 
 .Verification
+ifdef::upstream,self-managed[]
 * The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the {openshift-platform} web console.
+endif::[]
+ifndef::upstream,self-managed[]
+* The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the OpenShift web console.
+endif::[]
 * The reset *migration-gpu-status* instance is present in the *Instances* tab on the `AcceleratorProfile` custom resource definition (CRD) details page.
 
 //the following step applies to downstream only: self-managed (connected and disconnected) and cloud service

--- a/modules/enabling-gpu-support-in-data-science.adoc
+++ b/modules/enabling-gpu-support-in-data-science.adoc
@@ -51,10 +51,10 @@ endif::[]
 //the following steps apply to upstream and downstream: self-managed (connected and disconnected) and cloud service
 . Delete the *migration-gpu-status* ConfigMap.
 ifdef::upstream,self-managed[]
-.. In the {openshift-platform} web console, change into the *Administrator* perspective.
+.. In the {openshift-platform} web console, switch to the *Administrator* perspective.
 endif::[]
 ifdef::cloud-service[]
-.. In the OpenShift web console, change into the *Administrator* perspective.
+.. In the OpenShift web console, switch to the *Administrator* perspective.
 endif::[]
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate ConfigMap.
 .. Search for the *migration-gpu-status* ConfigMap.
@@ -65,10 +65,10 @@ The *Delete ConfigMap* dialog appears.
 .. Click *Delete*.
 . Restart the dashboard replicaset.
 ifdef::upstream,self-managed[]
-.. In the {openshift-platform} web console, change into the *Administrator* perspective.
+.. In the {openshift-platform} web console, switch to the *Administrator* perspective.
 endif::[]
 ifdef::cloud-service[]
-.. In the OpenShift web console, change into the *Administrator* perspective.
+.. In the OpenShift web console, switch to the *Administrator* perspective.
 endif::[]
 .. Click *Workloads* -> *Deployments*.
 .. Set the *Project* to *All Projects* or *redhat-ods-applications* to ensure you can see the appropriate deployment.
@@ -78,10 +78,10 @@ endif::[]
 
 .Verification
 ifdef::upstream,self-managed[]
-* The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the {openshift-platform} web console.
+* The NVIDIA GPU Operator appears on the *Operators* -> *Installed Operators* page in the {openshift-platform} web console.
 endif::[]
 ifdef::cloud-service[]
-* The NVIDIA GPU Operator displays on the *Operators* -> *Installed Operators* page in the OpenShift web console.
+* The NVIDIA GPU Operator appears on the *Operators* -> *Installed Operators* page in the OpenShift web console.
 endif::[]
 * The reset *migration-gpu-status* instance is present in the *Instances* tab on the `AcceleratorProfile` custom resource definition (CRD) details page.
 

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -21,7 +21,7 @@ endif::[]
 ifdef::upstream,self-managed[]
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * Installing the service as an {install-package} to your OpenShift Dedicated (link:https://docs.openshift.com/dedicated/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to an OpenShift Dedicated cluster]) or ROSA cluster (link:https://docs.openshift.com/rosa/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a ROSA cluster]).
 endif::[]
 
@@ -36,7 +36,7 @@ To help you get started quickly, you can access the service's learning resources
 ifdef::upstream,self-managed[]
 * Your administrator has installed or configured the service on your {openshift-platform} cluster.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * Your administrator has installed or configured the service on your OpenShift cluster.
 endif::[]
 

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -31,6 +31,7 @@ ifndef::self-managed[]
 endif::[]
 --
 endif::[]
+
 For some services (such as Jupyter), the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
 
 Some independent software vendor (ISV) applications must be installed in specific namespaces. In these cases, the tile for the application in the {productname-short} dashboard specifies the required namespace.

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -18,18 +18,11 @@ Deployments containing Operators installed from OperatorHub may not be fully sup
 ====
 endif::[]
 * Installing the Operator for the service from {org-name} Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
-ifdef::upstream[]
+ifdef::upstream,self-managed[]
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
 endif::[]
-ifndef::upstream[]
---
-ifdef::self-managed[]
-* Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
-endif::[]
-ifndef::self-managed[]
-* Installing the service as an {install-package} to your OpenShift cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
-endif::[]
---
+ifndef::upstream,self-managed[]
+* Installing the service as an {install-package} to your OpenShift Dedicated (link:https://docs.openshift.com/dedicated/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to an OpenShift Dedicated cluster]) or ROSA cluster (link:https://docs.openshift.com/rosa/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a ROSA cluster]).
 endif::[]
 
 For some services (such as Jupyter), the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
@@ -40,7 +33,12 @@ To help you get started quickly, you can access the service's learning resources
 
 .Prerequisites
 * You have logged in to {productname-short}.
+ifdef::upstream,self-managed[]
+* Your administrator has installed or configured the service on your {openshift-platform} cluster.
+endif::[]
+ifndef::upstream,self-managed[]
 * Your administrator has installed or configured the service on your OpenShift cluster.
+endif::[]
 
 .Procedure
 . On the {productname-short} home page, click *Explore*.

--- a/modules/enabling-services-connected-to-open-data-hub.adoc
+++ b/modules/enabling-services-connected-to-open-data-hub.adoc
@@ -18,8 +18,19 @@ Deployments containing Operators installed from OperatorHub may not be fully sup
 ====
 endif::[]
 * Installing the Operator for the service from {org-name} Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
+ifdef::upstream[]
 * Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
-
+endif::[]
+ifndef::upstream[]
+--
+ifdef::self-managed[]
+* Installing the service as an {install-package} to your {openshift-platform} cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
+endif::[]
+ifndef::self-managed[]
+* Installing the service as an {install-package} to your OpenShift cluster (link:https://docs.openshift.com/container-platform/{ocp-latest-version}/operators/admin/olm-adding-operators-to-cluster.html[Adding Operators to a cluster]).
+endif::[]
+--
+endif::[]
 For some services (such as Jupyter), the service endpoint is available on the tile for the service on the *Enabled* page of {productname-short}. Certain services cannot be accessed directly from their tiles, for example, OpenVINO and Anaconda provide notebook images for use in Jupyter and do not provide an endpoint link from their tile. Additionally, it may be useful to store these endpoint URLs as environment variables for easy reference in a notebook environment.
 
 Some independent software vendor (ISV) applications must be installed in specific namespaces. In these cases, the tile for the application in the {productname-short} dashboard specifies the required namespace.

--- a/modules/logging-in-to-open-data-hub.adoc
+++ b/modules/logging-in-to-open-data-hub.adoc
@@ -17,7 +17,7 @@ endif::[]
 ifdef::upstream,self-managed[]
 ** If you have access to {openshift-platform}, you can browse to the {openshift-platform} web console and click the *Application Launcher* (image:images/osd-app-launcher.png[The application launcher]) -> *{productname-long}*.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 ** If you have access to OpenShift, you can browse to the OpenShift web console and click the *Application Launcher* (image:images/osd-app-launcher.png[The application launcher]) -> *{productname-long}*.
 endif::[]
 

--- a/modules/logging-in-to-open-data-hub.adoc
+++ b/modules/logging-in-to-open-data-hub.adoc
@@ -14,7 +14,12 @@ endif::[]
 ifndef::upstream[]
 ** If you are a data scientist user, your administrator must provide you with the {productname-short} instance URL, for example, `https://rhods-dashboard-redhat-oai-applications.apps.example.abc1.p1.openshiftapps.com/`
 endif::[]
+ifdef::upstream,self-managed[]
 ** If you have access to {openshift-platform}, you can browse to the {openshift-platform} web console and click the *Application Launcher* (image:images/osd-app-launcher.png[The application launcher]) -> *{productname-long}*.
+endif::[]
+ifndef::upstream,self-managed[]
+** If you have access to OpenShift, you can browse to the OpenShift web console and click the *Application Launcher* (image:images/osd-app-launcher.png[The application launcher]) -> *{productname-long}*.
+endif::[]
 
 . Click the name of your identity provider, for example, `GitHub`.
 . Enter your credentials and click *Log in* (or equivalent for your identity provider).

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -10,6 +10,16 @@ After your administrator has disabled your unused applications, you can manually
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
 * You have logged in to the {openshift-platform} web console.
+ifndef::upstream
+--
+ifndef::self-managed[]
+You have logged in to the OpenShift web console.
+endif::[]
+ifdef::self-managed[]
+You have logged in to the {openshift-platform} web console.
+endif::[]
+--
+endif::[]
 * Your administrator has previously disabled the application that you want to remove.
 
 .Procedure

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -12,7 +12,7 @@ After your administrator has disabled your unused applications, you can manually
 ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * You have logged in to the OpenShift web console.
 endif::[]
 * Your administrator has previously disabled the application that you want to remove.

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -10,15 +10,13 @@ After your administrator has disabled your unused applications, you can manually
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
 * You have logged in to the {openshift-platform} web console.
-ifndef::upstream
---
+ifndef::upstream[]
 ifndef::self-managed[]
-You have logged in to the OpenShift web console.
+*You have logged in to the OpenShift web console.
 endif::[]
 ifdef::self-managed[]
 You have logged in to the {openshift-platform} web console.
 endif::[]
---
 endif::[]
 * Your administrator has previously disabled the application that you want to remove.
 

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -9,18 +9,11 @@ After your administrator has disabled your unused applications, you can manually
 
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
-ifdef::upstream[]
+ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 * You have logged in to the OpenShift web console.
-endif::[]
-ifdef::self-managed[]
-* You have logged in to the {openshift-platform} web console.
-endif::[]
---
 endif::[]
 * Your administrator has previously disabled the application that you want to remove.
 

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -9,7 +9,9 @@ After your administrator has disabled your unused applications, you can manually
 
 .Prerequisites
 * Ensure that you have logged in to {productname-long}.
+ifdef::upstream[]
 * You have logged in to the {openshift-platform} web console.
+endif::[]
 ifndef::upstream[]
 ifndef::self-managed[]
 *You have logged in to the OpenShift web console.

--- a/modules/removing-disabled-applications-from-open-data-hub.adoc
+++ b/modules/removing-disabled-applications-from-open-data-hub.adoc
@@ -13,12 +13,14 @@ ifdef::upstream[]
 * You have logged in to the {openshift-platform} web console.
 endif::[]
 ifndef::upstream[]
+--
 ifndef::self-managed[]
-*You have logged in to the OpenShift web console.
+* You have logged in to the OpenShift web console.
 endif::[]
 ifdef::self-managed[]
-You have logged in to the {openshift-platform} web console.
+* You have logged in to the {openshift-platform} web console.
 endif::[]
+--
 endif::[]
 * Your administrator has previously disabled the application that you want to remove.
 

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -19,21 +19,14 @@ If you have configured specialized user groups for {productname-short}, the user
 Check whether the user is part of the default user group.
 
 . Find the names of groups allowed access to Jupyter.
-ifndef::upstream[]
---
-ifdef::self-managed[]
-.. Log in to {openshift-platform} web console.
+ifdef::upstream,self-managed[]
+.. Log in to the {openshift-platform} web console.
 endif::[]
-ifndef::self-managed[]
-.. Log in to OpenShift web console.
-endif::[]
---
-endif::[]
-ifdef::upstream[]
-.. Log in to {productname-short} web console.
+ifndef::upstream,self-managed[]
+.. Log in to the OpenShift web console.
 endif::[]
 .. Click *User Management* -> *Groups*.
-.. Click the name of your user group, for example, `{oai-user-group}`.
+.. Click the name of your user group, for example, {oai-user-group}.
 +
 The *Group details* page for that group appears.
 
@@ -44,40 +37,26 @@ ifndef::upstream[]
 * If the user is not added to any of the groups with permission access to Jupyter, follow link:{rhoaidocshome}{default-format-url}/managing_users/adding-users_user-mgmt[Adding users] to add them.
 * If the user is already added to a group with permission to access Jupyter, contact {org-name} Support.
 endif::[]
-
 ifdef::upstream[]
-If the user is not added to any of the groups allowed access to Jupyter, add them.
+* If the user is not added to any of the groups allowed access to Jupyter, add them.
 endif::[]
 
 == A user's notebook server does not start
 
 .Problem
-ifdef::upstream[]
+ifdef::upstream,self-managed[]
 The {openshift-platform} cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 The OpenShift cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
-ifdef:self-managed[]
-The {openshift-platform} cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
-endif::[]
---
-endif::[]
+
 .Diagnosis
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 . Log in to the OpenShift web console.
 endif::[]
-ifdef::self-managed[]
+ifdef::upstream,self-managed[]
 . Log in to the {openshift-platform} web console.
-endif::[]
---
-endif::[]
-ifdef::upstream[]
-. Log in to {productname-short} web console.
 endif::[]
 . Delete and restart the notebook server pod for this user.
 .. Click *Workloads* -> *Pods* and set the *Project* to `rhods-notebooks`.
@@ -87,7 +66,12 @@ endif::[]
 If the notebook server pod exists, an intermittent failure may have occurred in the notebook server pod.
 +
 If the notebook server pod for the user does not exist, continue with diagnosis.
+ifdef::upstream,self-managed[]
+. Check the resources currently available in the {openshift-platform} cluster against the resources required by the selected notebook server image.
+endif::[]
+ifndef::upstream,self-managed[]
 . Check the resources currently available in the OpenShift cluster against the resources required by the selected notebook server image.
+endif::[]
 +
 If worker nodes with sufficient CPU and RAM are available for scheduling in the cluster, continue with diagnosis.
 . Check the state of the Jupyter pod.
@@ -97,7 +81,12 @@ If worker nodes with sufficient CPU and RAM are available for scheduling in the 
 * If there was an intermittent failure of the notebook server pod:
 .. Delete the notebook server pod that belongs to the user.
 .. Ask the user to start their notebook server again.
+ifdef::upstream,self-managed[]
+* If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the {openshift-platform} cluster, or choose a smaller image size.
+endif::[]
+ifndef::upstream,self-managed[]
 * If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the OpenShift cluster, or choose a smaller image size.
+endif::[]
 ifndef::upstream[]
 * If the Jupyter pod is in a *FAILED* state:
 .. Retrieve the logs for the `jupyter-nb-*` pod and send them to {org-name} Support for further evaluation.
@@ -112,18 +101,11 @@ The user might have run out of storage space on their notebook server.
 
 .Diagnosis
 . Log in to Jupyter and start the notebook server that belongs to the user having problems. If the notebook server does not start, follow these steps to check whether the user has run out of storage space:
-ifndef::upstream[]
---
-ifdef::self-managed[]
-.. Log in to {openshift-platform} web console.
+ifdef::upstream,self-managed[]
+.. Log in to the {openshift-platform} web console.
 endif::[]
-ifndef::self-managed[]
-.. Log in to your OpenShift web console.
-endif::[]
---
-endif::[]
-ifdef::upstream[]
-. Log in to {productname-short} web console.
+ifndef::upstream,self-managed[]
+.. Log in to the OpenShift web console.
 endif::[]
 .. Click *Workloads* -> *Pods* and set the *Project* to `rhods-notebooks`.
 .. Click the notebook server pod that belongs to this user, for example, `jupyter-nb-<idp>-<username>-*`.
@@ -140,7 +122,6 @@ endif::[]
 ifdef::upstream[]
 * Increase the user's available storage by expanding their persistent volume.
 endif::[]
-
 * Work with the user to identify files that can be deleted from the `/opt/app-root/src` directory on their notebook server to free up their existing storage space.
 
 [NOTE]

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -22,7 +22,7 @@ Check whether the user is part of the default user group.
 ifdef::upstream,self-managed[]
 .. Log in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 .. Log in to the OpenShift web console.
 endif::[]
 .. Click *User Management* -> *Groups*.
@@ -47,12 +47,12 @@ endif::[]
 ifdef::upstream,self-managed[]
 The {openshift-platform} cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 The OpenShift cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
 
 .Diagnosis
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 . Log in to the OpenShift web console.
 endif::[]
 ifdef::upstream,self-managed[]
@@ -69,7 +69,7 @@ If the notebook server pod for the user does not exist, continue with diagnosis.
 ifdef::upstream,self-managed[]
 . Check the resources currently available in the {openshift-platform} cluster against the resources required by the selected notebook server image.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 . Check the resources currently available in the OpenShift cluster against the resources required by the selected notebook server image.
 endif::[]
 +
@@ -84,7 +84,7 @@ If worker nodes with sufficient CPU and RAM are available for scheduling in the 
 ifdef::upstream,self-managed[]
 * If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the {openshift-platform} cluster, or choose a smaller image size.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 * If the notebook server does not have sufficient resources to run the selected notebook server image, either add more resources to the OpenShift cluster, or choose a smaller image size.
 endif::[]
 ifndef::upstream[]
@@ -104,7 +104,7 @@ The user might have run out of storage space on their notebook server.
 ifdef::upstream,self-managed[]
 .. Log in to the {openshift-platform} web console.
 endif::[]
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 .. Log in to the OpenShift web console.
 endif::[]
 .. Click *Workloads* -> *Pods* and set the *Project* to `rhods-notebooks`.

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -21,7 +21,12 @@ Check whether the user is part of the default user group.
 . Find the names of groups allowed access to Jupyter.
 ifndef::upstream[]
 --
+ifdef::self-managed[]
 .. Log in to {openshift-platform} web console.
+endif::[]
+ifndef::self-managed[]
+.. Log in to OpenShift web console.
+endif::[]
 --
 endif::[]
 ifdef::upstream[]
@@ -47,17 +52,27 @@ endif::[]
 == A user's notebook server does not start
 
 .Problem
-
+ifdef::upstream[]
 The {openshift-platform} cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
-
+endif::[]
+ifndef::upstream[]
+--
+ifndef::self-managed[]
+The OpenShift cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
+endif::[]
+ifdef:self-managed[]
+The {openshift-platform} cluster that hosts the user's notebook server might not have access to enough resources, or the Jupyter pod may have failed.
+endif::[]
+--
+endif::[]
 .Diagnosis
 ifndef::upstream[]
 --
 ifndef::self-managed[]
-. Log in to {openshift-platform} web console.
+. Log in to the OpenShift web console.
 endif::[]
 ifdef::self-managed[]
-. Log in to {openshift-platform} web console.
+. Log in to the {openshift-platform} web console.
 endif::[]
 --
 endif::[]
@@ -99,7 +114,12 @@ The user might have run out of storage space on their notebook server.
 . Log in to Jupyter and start the notebook server that belongs to the user having problems. If the notebook server does not start, follow these steps to check whether the user has run out of storage space:
 ifndef::upstream[]
 --
+ifdef::self-managed[]
 .. Log in to {openshift-platform} web console.
+endif::[]
+ifndef::self-managed[]
+.. Log in to your OpenShift web console.
+endif::[]
 --
 endif::[]
 ifdef::upstream[]

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -25,10 +25,10 @@ If your administrator has configured specialized user groups for {productname-sh
 ifndef::upstream[]
 --
 ifndef::self-managed[]
-The {openshift-platform} cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
+The OpenShift cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
 ifdef::self-managed[]
-The OpenShift Platform Container cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
+The {openshift-platform} cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
 --
 endif::[]

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -22,7 +22,7 @@ If your administrator has configured specialized user groups for {productname-sh
 == My notebook server does not start
 
 .Problem
-ifndef::upstream,self-managed[]
+ifdef::cloud-service[]
 The OpenShift cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
 ifdef::upstream,self-managed[]

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -22,18 +22,10 @@ If your administrator has configured specialized user groups for {productname-sh
 == My notebook server does not start
 
 .Problem
-ifndef::upstream[]
---
-ifndef::self-managed[]
+ifndef::upstream,self-managed[]
 The OpenShift cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
-ifdef::self-managed[]
-The {openshift-platform} cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
-endif::[]
---
-endif::[]
-
-ifdef::upstream[]
+ifdef::upstream,self-managed[]
 The {openshift-platform} cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
 endif::[]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-1540
Replacing {openshift-platform) attribute with plaintext Openshift for cloud service docs only. 

## How Has This Been Tested?
Local build upstream, also tested downstream, previews attached below:
**Upstream**
<img width="565" alt="disabling_services_upstream" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/f0852133-b3f6-4e3c-b6a0-85bc475a44f2">

**Self-managed**
<img width="448" alt="Disabling applications self-managed" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/a21ea021-a2aa-4e9f-9282-d9e404dca63c">

**Cloud Service (with cloud service attribute)**
![Disabling_service_Cloud_service_new](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/49aaf61a-e289-4aab-a5d9-603a5fc2bc5b)







