### PR TITLE
DS-759-accelerator-profiles-phase-two completed draft of accelerator …

### DIFF
--- a/assemblies/working-with-accelerators.adoc
+++ b/assemblies/working-with-accelerators.adoc
@@ -20,7 +20,7 @@ include::modules/updating-an-accelerator-profile.adoc[leveloffset=+2]
 
 include::modules/deleting-an-accelerator-profile.adoc[leveloffset=+2]
 
-//include::modules/configuring-recommended-accelerators.adoc[leveloffset=+2] - need to write concept for this
+include::modules/viewing-accelerator-profiles.adoc[leveloffset=+2]
 
 include::modules/configuring-a-recommended-accelerator-for-notebook-images.adoc[leveloffset=+2]
 

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -5,7 +5,7 @@
 
 [role='_abstract']
 ifdef::upstream[]
-You can configure custom notebook images that cater to your project's specific requirements.
+You can configure custom notebook images that cater to your project's specific requirements. From the *Notebook image settings* page, you can enable or disable a previously imported notebook image and create an accelerator profile as a recommended accelerator for existing notebook images.
 endif::[]
 ifndef::upstream[]
 In addition to notebook images provided and supported by {org-name} and independent software vendors (ISVs), you can configure custom notebook images that cater to your project's specific requirements.
@@ -26,7 +26,7 @@ endif::[]
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
 +
-The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column.
+The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column. Click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
 . Click *Import new image*. Alternatively, if no previously imported images were found, click *Import image*.
 +
 The *Import Notebook images* dialog appears.
@@ -34,7 +34,8 @@ The *Import Notebook images* dialog appears.
 `docker.io/my-repo/my-image:tag`.
 
 . In the *Name* field, enter an appropriate name for the notebook image.
-. In the *Description* field, enter an appropriate description for the notebook image.
+. Optional: In the *Description* field, enter an appropriate description for the notebook image.
+. Optional: From the *Accelerator identifier* list, select the relevant identifier to designate its accelerator as recommended with the notebook image.
 . Optional: Add software to the notebook image. After the import has completed, the software is added to the notebook image's meta-data and displayed on the Jupyter server creation page.
 .. Click the *Software* tab.
 .. Click the *Add software* button.

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -34,8 +34,8 @@ The *Import Notebook images* dialog appears.
 `docker.io/my-repo/my-image:tag`.
 
 . In the *Name* field, enter an appropriate name for the notebook image.
-. Optional: In the *Description* field, enter an appropriate description for the notebook image.
-. Optional: From the *Accelerator identifier* list, select the relevant identifier to designate its accelerator as recommended with the notebook image.
+. Optional: In the *Description* field, enter an description for the notebook image.
+. Optional: From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image.
 . Optional: Add software to the notebook image. After the import has completed, the software is added to the notebook image's meta-data and displayed on the Jupyter server creation page.
 .. Click the *Software* tab.
 .. Click the *Add software* button.

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -24,9 +24,14 @@ endif::[]
 * Your custom notebook image exists in an image registry and is accessible.
 
 .Procedure
-. From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
+. From the {productname-short} dashboard, click *Settings* -> *Notebook image settings*.
 +
-The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column. Click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
+The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column. 
++ 
+[NOTE]
+====
+If you have already configured an accelerator identifier for a notebook image, you can specify a recommended accelerator for the notebook image by creating an associated accelerator profile. To do this, click *Create profile* on the row containing the notebook image and complete the relevant fields. If the notebook image does not contain an accelerator identifier, you must manually configure one before creating an associated accelerator profile.  
+====
 . Click *Import new image*. Alternatively, if no previously imported images were found, click *Import image*.
 +
 The *Import Notebook images* dialog appears.
@@ -35,7 +40,7 @@ The *Import Notebook images* dialog appears.
 
 . In the *Name* field, enter an appropriate name for the notebook image.
 . Optional: In the *Description* field, enter a description for the notebook image.
-. Optional: From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image.
+. Optional: From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image. If the notebook image contains only one accelerator identifier, the identifier name displays by default.
 . Optional: Add software to the notebook image. After the import has completed, the software is added to the notebook image's meta-data and displayed on the Jupyter server creation page.
 .. Click the *Software* tab.
 .. Click the *Add software* button.

--- a/modules/configuring-a-custom-notebook.adoc
+++ b/modules/configuring-a-custom-notebook.adoc
@@ -34,7 +34,7 @@ The *Import Notebook images* dialog appears.
 `docker.io/my-repo/my-image:tag`.
 
 . In the *Name* field, enter an appropriate name for the notebook image.
-. Optional: In the *Description* field, enter an description for the notebook image.
+. Optional: In the *Description* field, enter a description for the notebook image.
 . Optional: From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image.
 . Optional: Add software to the notebook image. After the import has completed, the software is added to the notebook image's meta-data and displayed on the Jupyter server creation page.
 .. Click the *Software* tab.

--- a/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
@@ -12,18 +12,18 @@ To help you indicate the most suitable accelerators to your data scientists, you
 * You have existing notebook images in your deployment.
 
 .Procedure
-. From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
+. From the {productname-short} dashboard, click *Settings* -> *Notebook image settings*.
 +
 The *Notebook image settings* page appears. Previously imported notebook images are displayed. 
 . Click the action menu (&#8942;) and select *Edit* from the list.
 +
 The *Update notebook image* dialog opens.
-. From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image.
+. From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image. If the notebook image contains only one accelerator identifier, the identifier name displays by default.
 . Click *Update*.
 +
 [NOTE]
 ====
-If the accelerator profile does not exist in your deployment, click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
+If you have already configured an accelerator identifier for a notebook image, you can specify a recommended accelerator for the notebook image by creating an associated accelerator profile. To do this, click *Create profile* on the row containing the notebook image and complete the relevant fields. If the notebook image does not contain an accelerator identifier, you must manually configure one before creating an associated accelerator profile.  
 ====
 
 .Verification

--- a/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
@@ -9,25 +9,22 @@ To help you indicate the most suitable accelerators to your data scientists, you
 .Prerequisites
 * You have logged in to {openshift-platform}.
 * You have the `cluster-admin` role in {openshift-platform}.
-* You have configured an ImageStream that contains your notebook image settings.  
+* You have existing notebook images in your deployment.
 
 .Procedure
-. In the {openshift-platform} web console, in the *Administrator* perspective, click *Builds* -> *ImageStreams*.
-. Click the ImageStream that you want to a recommended accelerator tag to. 
+. From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
 +
-A details page opens.
-. Click the *YAML* tab.
-+ 
-A page with an embedded YAML editor opens.
-. In the editor, enter or paste the YAML code directly to apply the annotation `opendatahub.io/recommended-accelerators`. The excerpt in this example shows the annotation to set a recommended tag for an NVIDIA GPU accelerator:
+The *Notebook image settings* page appears. Previously imported notebook images are displayed. 
+. Click the action menu (&#8942;) and select *Edit* from the list.
 +
-[source,yaml]
----
-metadata:
-	annotations:
-		opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
----
-. Click *Save*.
+The *Update notebook image* dialog opens.
+. From the *Accelerator identifier* list, select the relevant identifier to designate its accelerator as recommended with the notebook image.
+. Click *Update*.
++
+[NOTE]
+====
+If the accelerator's profile does not exist in your deployment, click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
+====
 
 .Verification
 * When your data scientists select an accelerator with a specific notebook image, a tag appears next to the corresponding accelerator indicating its compatibility. 

--- a/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
@@ -18,12 +18,12 @@ The *Notebook image settings* page appears. Previously imported notebook images 
 . Click the action menu (&#8942;) and select *Edit* from the list.
 +
 The *Update notebook image* dialog opens.
-. From the *Accelerator identifier* list, select the relevant identifier to designate its accelerator as recommended with the notebook image.
+. From the *Accelerator identifier* list, select an identifier to set its accelerator as recommended with the notebook image.
 . Click *Update*.
 +
 [NOTE]
 ====
-If the accelerator's profile does not exist in your deployment, click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
+If the accelerator profile does not exist in your deployment, click *Create profile* on the row containing the relevant notebook image to create an accelerator profile as the image's recommended accelerator.  
 ====
 
 .Verification

--- a/modules/creating-an-accelerator-profile.adoc
+++ b/modules/creating-an-accelerator-profile.adoc
@@ -18,18 +18,18 @@ endif::[]
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *Accelerator profiles* page appears that shows existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+The *Accelerator profiles* page appears, displaying existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
 . Click *Create accelerator profile*. 
 +
 The *Create accelerator profile* dialog appears.
-. In the *Name* field, enter an appropriate name for the accelerator profile.
+. In the *Name* field, enter a name for the accelerator profile.
 . In the *Identifier* field, enter a unique string that identifies the hardware accelerator associated with the accelerator profile.
-. Optional: In the *Description* field, enter an appropriate description for the accelerator profile.
+. Optional: In the *Description* field, enter a description for the accelerator profile.
 . To enable or disable the accelerator profile immediately after creation, click the toggle in the *Enable* column.
 . Optional: Add a toleration to schedule pods with matching taints.
 .. Click *Add toleration*. 
 +
-The *Add toleration* dialog appears.
+The *Add toleration* dialog opens.
 .. From the *Operator* list, select one of the following options:
 * *Equal* - The *key/value/effect* parameters must match. This is the default.
 * *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
@@ -41,13 +41,13 @@ The *Add toleration* dialog appears.
 .. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
-** *Forever* - Pods stays permanently bound to nodes. 
-** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+** *Forever* - Pods stays permanently bound to a node. 
+** *Custom value* - Enter a value in seconds before pods can remain bound to a node.
 .. Click *Add*.
 . Click *Create accelerator profile*.
 
 .Verification
-* The accelerator profile appears on the *Accelerator profiles* page
+* The accelerator profile appears on the *Accelerator profiles* page.
 * The *Accelerator* list appears on the *Start a notebook server* page. After you select an accelerator, the *Number of accelerators* field appears, which you can use to choose the number of accelerators for your notebook server.
 * The accelerator profile appears on the *Instances* tab on the details page for the `AcceleratorProfile` custom resource definition (CRD).
 

--- a/modules/creating-an-accelerator-profile.adoc
+++ b/modules/creating-an-accelerator-profile.adoc
@@ -42,7 +42,7 @@ The *Add toleration* dialog opens.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
 ** *Forever* - Pods stays permanently bound to a node. 
-** *Custom value* - Enter a value in seconds before pods can remain bound to a node.
+** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.
 .. Click *Add*.
 . Click *Create accelerator profile*.
 

--- a/modules/creating-an-accelerator-profile.adoc
+++ b/modules/creating-an-accelerator-profile.adoc
@@ -7,45 +7,47 @@
 To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. 
 
 .Prerequisites
-* You have logged in to {openshift-platform}.
-* You have the `cluster-admin` role in {openshift-platform}.
-* The `AcceleratorProfile` custom resource definition (CRD) exists in your deployment.
-* You are aware of the correct namespace to create the accelerator profile in. 
+* You have logged in to {productname-long}.
+ifndef::self-managed[]
+* You are part of the `dedicated-admins` user group in {openshift-platform}.
+endif::[]
+ifdef::self-managed[]
+* You are assigned the `cluster-admin` role in {openshift-platform}.
+endif::[]
 
 .Procedure
-. In the {openshift-platform} web console, in the *Administrator* perspective, click *Administration* -> *CustomResourceDefinitions*.
-. In the search bar, enter `acceleratorprofile` to search by name.
+. From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *CustomResourceDefinitions* page reloads to display the search results.
+The *Accelerator profiles* page appears that shows existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+. Click *Create accelerator profile*. 
 +
-. Click the `AcceleratorProfile` custom resource definition (CRD).
+The *Create accelerator profile* dialog appears.
+. In the *Name* field, enter an appropriate name for the accelerator profile.
+. In the *Identifier* field, enter a unique string that identifies the hardware accelerator associated with the accelerator profile.
+. Optional: In the *Description* field, enter an appropriate description for the accelerator profile.
+. To enable or disable the accelerator profile immediately after creation, click the toggle in the *Enable* column.
+. Optional: Add a toleration to schedule pods with matching taints.
+.. Click *Add toleration*. 
 +
-A details page for the custom resource definition (CRD) opens.
-. Click the *Instances* tab.
-. Click *Create AcceleratorProfile*. 
-+ 
-The *Create AcceleratorProfile* page opens with an embedded YAML editor. 
-. Enter or paste your accelerator profile YAML code directly in the embedded editor. This example shows the code for a Habana Gaudi 1 accelerator profile:
-+
-[source,yaml]
----
-apiVersion: dashboard.opendatahub.io/v1alpha
-kind: AcceleratorProfile
-metadata:
-  name: hpu-profile-first-gen-gaudi
-spec:
-  displayName: Habana HPU - 1st Gen Gaudi
-  description: First Generation Habana Gaudi device
-  enabled: true
-  identifier: habana.ai/gaudi
-  tolerations:
-    - effect: NoSchedule
-      key: habana.ai/gaudi
-      operator: Exists
----
-. Click *Create*.
+The *Add toleration* dialog appears.
+.. From the *Operator* list, select one of the following options:
+* *Equal* - The *key/value/effect* parameters must match. This is the default.
+* *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
+.. From the *Effect* list, select one of the following options:
+* *None* 
+* *NoSchedule* - New pods that do not match the taint are not scheduled onto that node. Existing pods on the node remain.
+* *PreferNoSchedule* - New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to. Existing pods on the node remain.
+* *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
+.. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
+** *Forever* - Pods stays permanently bound to nodes. 
+** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+.. Click *Add*.
+. Click *Create accelerator profile*.
 
 .Verification
+* The accelerator profile appears on the *Accelerator profiles* page
 * The *Accelerator* list appears on the *Start a notebook server* page. After you select an accelerator, the *Number of accelerators* field appears, which you can use to choose the number of accelerators for your notebook server.
 * The accelerator profile appears on the *Instances* tab on the details page for the `AcceleratorProfile` custom resource definition (CRD).
 

--- a/modules/deleting-an-accelerator-profile.adoc
+++ b/modules/deleting-an-accelerator-profile.adoc
@@ -19,7 +19,7 @@ endif::[]
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *Accelerator profiles* page appears that shows existing accelerator profiles.
+The *Accelerator profiles* page appears, displaying existing accelerator profiles.
 . Click the action menu (*&#8942;*) beside the accelerator profile that you want to delete and click *Delete*.
 +
 The *Delete accelerator profile* dialog opens.

--- a/modules/deleting-an-accelerator-profile.adoc
+++ b/modules/deleting-an-accelerator-profile.adoc
@@ -7,28 +7,27 @@
 To discard accelerator profiles that you no longer require, you can delete them so that they do not appear on the dashboard.
 
 .Prerequisites
-* You have logged in to {openshift-platform}.
-* You have the `cluster-admin` role in {openshift-platform}.
-* The `AcceleratorProfile` custom resource definition (CRD) exists in your deployment and has an accelerator profile.
+* You have logged in to {productname-long}.
+ifndef::self-managed[]
+* You are part of the `dedicated-admins` user group in {openshift-platform}.
+endif::[]
+ifdef::self-managed[]
+* You are assigned the `cluster-admin` role in {openshift-platform}.
+endif::[]
+* The accelerator profile that you want to delete exists in your deployment. 
 
 .Procedure
-. In the {openshift-platform} web console, in the *Administrator* perspective, click *Administration* -> *CustomResourceDefinitions*.
-. In the search bar, enter `acceleratorprofile` to search by name.
+. From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *CustomResourceDefinitions* page reloads to display the search results.
-+
-. Click the `AcceleratorProfile` custom resource definition (CRD).
-+
-A details page for the custom resource definition (CRD) opens.
-. Click the *Instances* tab.
-. Click the action menu (*&#8942;*) beside the accelerator profile that you want to delete and click *Delete AcceleratorProfile*.
+The *Accelerator profiles* page appears that shows existing accelerator profiles.
+. Click the action menu (*&#8942;*) beside the accelerator profile that you want to delete and click *Delete*.
 +
 The *Delete accelerator profile* dialog opens.
-. Click *Delete*.
+. Enter the name of the accelerator profile in the text field to confirm that you intend to delete it.
+. Click *Delete*. 
 
 .Verification
-* The accelerator profile no longer appears in the *Accelerator* list on the *Start a notebook server* page.   
-* The accelerator profile no longer appears on the *Instances* tab on the details page for the `AcceleratorProfile` custom resource definition (CRD).
+* The accelerator profile no longer appears on the *Accelerator profiles* page.
 
 [role='_additional-resources']
 .Additional resources

--- a/modules/enabling-habana-gaudi-devices.adoc
+++ b/modules/enabling-habana-gaudi-devices.adoc
@@ -14,18 +14,18 @@ Before you can use Habana Gaudi devices in {productname-short}, you must install
 . To enable Habana Gaudi devices in {productname-short}, follow the instructions at link:https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift].
 . From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *Accelerator profiles* page appears that shows existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+The *Accelerator profiles* page appears, displaying existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
 . Click *Create accelerator profile*. 
 +
-The *Create accelerator profile* dialog appears.
-. In the *Name* field, enter an appropriate name for the Habana Gaudi device.
+The *Create accelerator profile* dialog opens.
+. In the *Name* field, enter a name for the Habana Gaudi device.
 . In the *Identifier* field, enter a unique string that identifies the Habana Gaudi device, for example, `habana.ai/gaudi`. 
-. Optional: In the *Description* field, enter an appropriate description for the Habana Gaudi device.
+. Optional: In the *Description* field, enter a description for the Habana Gaudi device.
 . To enable or disable the accelerator profile for the Habana Gaudi device immediately after creation, click the toggle in the *Enable* column.
 . Optional: Add a toleration to schedule pods with matching taints.
 .. Click *Add toleration*. 
 +
-The *Add toleration* dialog appears.
+The *Add toleration* dialog opens.
 .. From the *Operator* list, select one of the following options:
 * *Equal* - The *key/value/effect* parameters must match. This is the default.
 * *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
@@ -37,8 +37,8 @@ The *Add toleration* dialog appears.
 .. In the *Key* field, enter the toleration key `habana.ai/gaudi`. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
-** *Forever* - Pods stays permanently bound to nodes. 
-** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+** *Forever* - Pods stays permanently bound to a node. 
+** *Custom value* - Enter a value (in seconds) before pods can remain bound to a node.
 .. Click *Add*.
 . Click *Create accelerator profile*.
 

--- a/modules/enabling-habana-gaudi-devices.adoc
+++ b/modules/enabling-habana-gaudi-devices.adoc
@@ -38,7 +38,7 @@ The *Add toleration* dialog opens.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
 ** *Forever* - Pods stays permanently bound to a node. 
-** *Custom value* - Enter a value (in seconds) before pods can remain bound to a node.
+** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.
 .. Click *Add*.
 . Click *Create accelerator profile*.
 

--- a/modules/enabling-habana-gaudi-devices.adoc
+++ b/modules/enabling-habana-gaudi-devices.adoc
@@ -4,7 +4,7 @@
 = Enabling Habana Gaudi devices
 
 [role='_abstract']
-Before you can use Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and deploy the HabanaAI Operator in your deployment. 
+Before you can use Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and deploy the HabanaAI Operator. 
 
 .Prerequisites
 * You have logged in to {openshift-platform}.
@@ -12,45 +12,43 @@ Before you can use Habana Gaudi devices in {productname-short}, you must install
 
 .Procedure
 . To enable Habana Gaudi devices in {productname-short}, follow the instructions at link:https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift].
-. Create an accelerator profile for your Habana Gaudi device. 
-.. In the {openshift-platform} web console in the *Administrator* perspective, click *Administration* -> *CustomResourceDefinitions*.
-.. In the search bar, enter `acceleratorprofile` to search by name.
+. From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *CustomResourceDefinitions* page reloads to display the search results.
+The *Accelerator profiles* page appears that shows existing accelerator profiles. To enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+. Click *Create accelerator profile*. 
 +
-.. Click the `AcceleratorProfile` custom resource definition (CRD).
+The *Create accelerator profile* dialog appears.
+. In the *Name* field, enter an appropriate name for the Habana Gaudi device.
+. In the *Identifier* field, enter a unique string that identifies the Habana Gaudi device, for example, `habana.ai/gaudi`. 
+. Optional: In the *Description* field, enter an appropriate description for the Habana Gaudi device.
+. To enable or disable the accelerator profile for the Habana Gaudi device immediately after creation, click the toggle in the *Enable* column.
+. Optional: Add a toleration to schedule pods with matching taints.
+.. Click *Add toleration*. 
 +
-A details page for the custom resource definition (CRD) opens.
-.. Click the *Instances* tab.
-.. Click *Create AcceleratorProfile*. 
-+ 
-The *Create AcceleratorProfile* page opens with an embedded YAML editor.
-.. Enter or paste your accelerator profile YAML code directly in the embedded editor. This example shows the code for a Habana Gaudi 1 accelerator profile:
-+
-[source,yaml]
----
-apiVersion: dashboard.opendatahub.io/v1alpha
-kind: AcceleratorProfile
-metadata:
-  name: hpu-profile-first-gen-gaudi
-spec:
-  displayName: Habana HPU - 1st Gen Gaudi
-  description: First Generation Habana Gaudi device
-  enabled: true
-  identifier: habana.ai/gaudi
-  tolerations:
-    - effect: NoSchedule
-      key: habana.ai/gaudi
-      operator: Exists
----
-.. Click *Create*.
+The *Add toleration* dialog appears.
+.. From the *Operator* list, select one of the following options:
+* *Equal* - The *key/value/effect* parameters must match. This is the default.
+* *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
+.. From the *Effect* list, select one of the following options:
+* *None* 
+* *NoSchedule* - New pods that do not match the taint are not scheduled onto that node. Existing pods on the node remain.
+* *PreferNoSchedule* - New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to. Existing pods on the node remain.
+* *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
+.. In the *Key* field, enter the toleration key `habana.ai/gaudi`. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
+** *Forever* - Pods stays permanently bound to nodes. 
+** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+.. Click *Add*.
+. Click *Create accelerator profile*.
 
 .Verification
 * From the *Administrator* perspective, the following Operators appear on the *Operators* -> *Installed Operators* page.
 ** HabanaAI
 ** Node Feature Discovery (NFD)
 ** Kernel Module Management (KMM)
-* The *Accelerator* list displays the Habana Gaudi accelerator on the *Start a notebook server* page.  
+* The *Accelerator* list displays the Habana Gaudi accelerator on the *Start a notebook server* page. After you select an accelerator, the *Number of accelerators* field appears, which you can use to choose the number of accelerators for your notebook server. 
+* The accelerator profile appears on the *Accelerator profiles* page
 * The accelerator profile appears on the *Instances* tab on the details page for the `AcceleratorProfile` custom resource definition (CRD).
 
 [role='_additional-resources']

--- a/modules/overview-of-accelerators.adoc
+++ b/modules/overview-of-accelerators.adoc
@@ -20,7 +20,7 @@ If you work with large data sets, you can use accelerators to optimize the perfo
 ** Habana, an Intel company, provides hardware accelerators intended for deep learning workloads. You can use Habana Gaudi accelerators on {productname-short} with version 1.10.0 of the Habana Gaudi Operator. 
 ** You can enable Habana Gaudi devices on-premises or with AWS DL1 compute nodes on an AWS instance.
 
-Before you can use an accelerator in {productname-short}, your OpenShift instance must contain an associated accelerator profile . For accelerators that are new to your deployment, you must manually configure an accelerator profile for the accelerator in context. If you use NVIDIA GPUs, an accelerator profile is automatically created after you upgrade to the latest version of {productname-short}.
+Before you can use an accelerator in {productname-short}, your OpenShift instance must contain an associated accelerator profile. For accelerators that are new to your deployment, you must configure an accelerator profile for the accelerator in context. You can create an accelerator profile from the *Settings* -> *Accelerator profiles* page on the {productname-short} dashboard. If your deployment contains existing accelerators that had associated accelerator profiles already configured, an accelerator profile is automatically created after you upgrade to the latest version of {productname-short}.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -83,7 +83,7 @@ Settings -> Cluster settings::  The *Cluster settings* page allows you perform t
 * Schedule notebook pods on tainted nodes by adding tolerations.
 
 Settings -> Accelerator profiles:: The *Accelerator profiles* page allows you perform the following administrative tasks on your accelerator profiles:
-* Enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+* Enable or disable an existing accelerator profile.
 * Create, update, or delete accelerator profiles. 
 * Schedule pods on tainted nodes by adding tolerations.
 

--- a/modules/the-open-data-hub-user-interface.adoc
+++ b/modules/the-open-data-hub-user-interface.adoc
@@ -82,6 +82,11 @@ Settings -> Cluster settings::  The *Cluster settings* page allows you perform t
 * Reduce resource usage in your {productname-short} deployment by stopping notebook servers that have been idle.
 * Schedule notebook pods on tainted nodes by adding tolerations.
 
+Settings -> Accelerator profiles:: The *Accelerator profiles* page allows you perform the following administrative tasks on your accelerator profiles:
+* Enable or disable an existing accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+* Create, update, or delete accelerator profiles. 
+* Schedule pods on tainted nodes by adding tolerations.
+
 Settings -> Serving runtimes:: The *Serving runtimes* page allows you to manage the model-serving runtimes in your {productname-short} deployment. You can use this page to add, edit, and enable or disable model-serving runtimes. You specify a model-serving runtime when you configure a model server on the *Data Science Projects* page.
 
 Settings -> User management:: The *User and group settings* page allows you to define {productname-short} user group and admin group membership.

--- a/modules/updating-an-accelerator-profile.adoc
+++ b/modules/updating-an-accelerator-profile.adoc
@@ -43,7 +43,7 @@ The *Add toleration* dialog opens.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
 ** *Forever* - Pods stays permanently bound to a node. 
-** *Custom value* - Enter a value in seconds before pods can remain bound to a node.
+** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.
 .. Click *Add*.
 . If your accelerator profile contains existing tolerations, you can edit them.
 .. Click the action menu (&#8942;) on the row containing the toleration that you want to edit and select *Edit* from the list.

--- a/modules/updating-an-accelerator-profile.adoc
+++ b/modules/updating-an-accelerator-profile.adoc
@@ -23,14 +23,14 @@ The *Notebook image settings* page appears. Previously imported notebook images 
 . Click the action menu (&#8942;) and select *Edit* from the list.
 +
 The *Edit accelerator profile* dialog opens.
-. In the *Name* field, update the accelerator profile name, if applicable.
+. In the *Name* field, update the accelerator profile name.
 . In the *Identifier* field, update the unique string that identifies the hardware accelerator associated with the accelerator profile, if applicable.
-. Optional: In the *Description* field, update the accelerator profile, if applicable.
+. Optional: In the *Description* field, update the accelerator profile.
 . To enable or disable the accelerator profile immediately after creation, click the toggle in the *Enable* column.
-. Optional: Add a toleration to schedule pods with matching taints, if applicable.
+. Optional: Add a toleration to schedule pods with matching taints.
 .. Click *Add toleration*. 
 +
-The *Add toleration* dialog appears.
+The *Add toleration* dialog opens.
 .. From the *Operator* list, select one of the following options:
 * *Equal* - The *key/value/effect* parameters must match. This is the default.
 * *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
@@ -42,10 +42,10 @@ The *Add toleration* dialog appears.
 .. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
-** *Forever* - Pods stays permanently bound to nodes. 
-** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+** *Forever* - Pods stays permanently bound to a node. 
+** *Custom value* - Enter a value in seconds before pods can remain bound to a node.
 .. Click *Add*.
-. If your accelerator profile contains existing tolerations, you can edit them, if applicable.
+. If your accelerator profile contains existing tolerations, you can edit them.
 .. Click the action menu (&#8942;) on the row containing the toleration that you want to edit and select *Edit* from the list.
 .. Complete the applicable fields to update the details of the toleration.
 .. Click *Update*.

--- a/modules/updating-an-accelerator-profile.adoc
+++ b/modules/updating-an-accelerator-profile.adoc
@@ -7,25 +7,49 @@
 You can update the existing accelerator profiles in your deployment. You might want to change important identifying information, such as the display name, the identifier, or the description. 
 
 .Prerequisites
-* You have logged in to {openshift-platform}.
-* You have the `cluster-admin` role in {openshift-platform}.
-* The `AcceleratorProfile` custom resource definition (CRD) exists in your deployment and has an accelerator profile.
+* You have logged in to {productname-long}.
+ifndef::self-managed[]
+* You are part of the `dedicated-admins` user group in {openshift-platform}.
+endif::[]
+ifdef::self-managed[]
+* You are assigned the `cluster-admin` role in {openshift-platform}.
+endif::[]
+* The accelerator profile exists in your deployment.
 
 .Procedure
-. In the {openshift-platform} web console, in the *Administrator* perspective, click *Administration* -> *CustomResourceDefinitions*.
-. In the search bar, enter `acceleratorprofile` to search by name.
+. From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
 +
-The *CustomResourceDefinitions* page reloads to display the search results.
+The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column.
+. Click the action menu (&#8942;) and select *Edit* from the list.
 +
-. Click the `AcceleratorProfile` custom resource definition (CRD).
+The *Edit accelerator profile* dialog opens.
+. In the *Name* field, update the accelerator profile name, if applicable.
+. In the *Identifier* field, update the unique string that identifies the hardware accelerator associated with the accelerator profile, if applicable.
+. Optional: In the *Description* field, update the accelerator profile, if applicable.
+. To enable or disable the accelerator profile immediately after creation, click the toggle in the *Enable* column.
+. Optional: Add a toleration to schedule pods with matching taints, if applicable.
+.. Click *Add toleration*. 
 +
-A details page for the custom resource definition (CRD) opens.
-. Click the *Instances* tab.
-. Click the accelerator profile that you want to update. 
-+ 
-A details page for the accelerator profile opens. 
-. Update the YAML code in the embedded editor.
-. Click *Save*.
+The *Add toleration* dialog appears.
+.. From the *Operator* list, select one of the following options:
+* *Equal* - The *key/value/effect* parameters must match. This is the default.
+* *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
+.. From the *Effect* list, select one of the following options:
+* *None* 
+* *NoSchedule* - New pods that do not match the taint are not scheduled onto that node. Existing pods on the node remain.
+* *PreferNoSchedule* - New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to. Existing pods on the node remain.
+* *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
+.. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
+** *Forever* - Pods stays permanently bound to nodes. 
+** *Custom value* - Enter a value (in seconds) before pods can remain bound to a nodes.
+.. Click *Add*.
+. If your accelerator profile contains existing tolerations, you can edit them, if applicable.
+.. Click the action menu (&#8942;) on the row containing the toleration that you want to edit and select *Edit* from the list.
+.. Complete the applicable fields to update the details of the toleration.
+.. Click *Update*.
+. Click *Update accelerator profile*.
 
 .Verification
 * If your accelerator profile has new identifying information, this information appears in the *Accelerator* list on the *Start a notebook server* page. 

--- a/modules/updating-an-accelerator-profile.adoc
+++ b/modules/updating-an-accelerator-profile.adoc
@@ -17,7 +17,7 @@ endif::[]
 * The accelerator profile exists in your deployment.
 
 .Procedure
-. From the {productname-short} dashboard, click *Settings* -> *Notebook images*.
+. From the {productname-short} dashboard, click *Settings* -> *Notebook image settings*.
 +
 The *Notebook image settings* page appears. Previously imported notebook images are displayed. To enable or disable a previously imported notebook image, on the row containing the relevant notebook image, click the toggle in the *Enable* column.
 . Click the action menu (&#8942;) and select *Edit* from the list.

--- a/modules/viewing-accelerator-profiles.adoc
+++ b/modules/viewing-accelerator-profiles.adoc
@@ -2,7 +2,7 @@
 
 [id='viewing-accelerator-profiles_{context}']
 = Viewing accelerator profiles
-If you have defined accelerator profiles for {productname-short}, you can view them from the *Accelerator profiles* page. You can also  enable or disable an accelerator profile from this page. 
+If you have defined accelerator profiles for {productname-short}, you can view, enable, and disable them from the *Accelerator profiles* page.
 
 .Prerequisites
 * You have logged in to {productname-long}.
@@ -17,9 +17,9 @@ endif::[]
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
 +
-The *Accelerator profiles* page appears that shows existing accelerator profiles. 
-. Inspect the list of accelerator profiles. To enable or disable an accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+The *Accelerator profiles* page appears, displaying existing accelerator profiles. 
+. Inspect the list of accelerator profiles. To enable or disable an accelerator profile, on the row containing the accelerator profile, click the toggle in the *Enable* column.
 
 .Verification
-* The *Accelerator profiles* page appears that shows existing accelerator profiles.
+* The *Accelerator profiles* page appears appears, displaying existing accelerator profiles.
 

--- a/modules/viewing-accelerator-profiles.adoc
+++ b/modules/viewing-accelerator-profiles.adoc
@@ -1,0 +1,25 @@
+:_module-type: PROCEDURE
+
+[id='viewing-accelerator-profiles_{context}']
+= Viewing accelerator profiles
+If you have defined accelerator profiles for {productname-short}, you can view them from the *Accelerator profiles* page. You can also  enable or disable an accelerator profile from this page. 
+
+.Prerequisites
+* You have logged in to {productname-long}.
+ifndef::self-managed[]
+* You are part of the `dedicated-admins` user group in {openshift-platform}.
+endif::[]
+ifdef::self-managed[]
+* You are assigned the `cluster-admin` role in {openshift-platform}.
+endif::[]
+* Your deployment contains existing accelerator profiles. 
+
+.Procedure
+. From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.
++
+The *Accelerator profiles* page appears that shows existing accelerator profiles. 
+. Inspect the list of accelerator profiles. To enable or disable an accelerator profile, on the row containing the relevant accelerator profile, click the toggle in the *Enable* column.
+
+.Verification
+* The *Accelerator profiles* page appears that shows existing accelerator profiles.
+

--- a/modules/working-with-accelerator-profiles.adoc
+++ b/modules/working-with-accelerator-profiles.adoc
@@ -8,7 +8,7 @@ The accelerator profiles feature is currently available as a Technology Preview.
 
 To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. An accelerator profile is a custom resource definition (CRD) on OpenShift that has an AcceleratorProfile resource, and defines the specification of the accelerator. You can create and manage accelerator profiles by selecting *Settings* -> *Accelerator profiles* on the {productname-short} dashboard.
 
-For accelerators that are new to your deployment, you must manually configure an accelerator profile for each accelerator. If your deployment contained an accelerator before you upgrade, the associated accelerator profile preserves after the upgrade. You can manage the accelerators that appear to your data scientists by assigning specific accelerator profiles to your custom notebook images. This example shows the code for a Habana Gaudi 1 accelerator profile:
+For accelerators that are new to your deployment, you must manually configure an accelerator profile for each accelerator. If your deployment contains an accelerator before you upgrade, the associated accelerator profile remains after the upgrade. You can manage the accelerators that appear to your data scientists by assigning specific accelerator profiles to your custom notebook images. This example shows the code for a Habana Gaudi 1 accelerator profile:
 [source,yaml]
 ---
 apiVersion: dashboard.opendatahub.io/v1alpha

--- a/modules/working-with-accelerator-profiles.adoc
+++ b/modules/working-with-accelerator-profiles.adoc
@@ -6,11 +6,27 @@
 [role='_abstract']
 The accelerator profiles feature is currently available as a Technology Preview. For further information about the scope of Technology Preview status, and the associated support implications, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
-To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. An accelerator profile is a custom resource definition (CRD) on OpenShift that has an AcceleratorProfile resource, and defines the specification of the accelerator.  
+To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. An accelerator profile is a custom resource definition (CRD) on OpenShift that has an AcceleratorProfile resource, and defines the specification of the accelerator. You can create and manage accelerator profiles by selecting *Settings* -> *Accelerator profiles* on the {productname-short} dashboard.
 
-For accelerators that are new to your deployment, you must manually configure an accelerator profile for each accelerator. If your deployment contained an accelerator before you upgrade, the associated accelerator profile preserves after the upgrade. You can manage the accelerators that appear to your data scientists by assigning specific accelerator profiles to your custom notebook images.
+For accelerators that are new to your deployment, you must manually configure an accelerator profile for each accelerator. If your deployment contained an accelerator before you upgrade, the associated accelerator profile preserves after the upgrade. You can manage the accelerators that appear to your data scientists by assigning specific accelerator profiles to your custom notebook images. This example shows the code for a Habana Gaudi 1 accelerator profile:
+[source,yaml]
+---
+apiVersion: dashboard.opendatahub.io/v1alpha
+kind: AcceleratorProfile
+metadata:
+  name: hpu-profile-first-gen-gaudi
+spec:
+  displayName: Habana HPU - 1st Gen Gaudi
+  description: First Generation Habana Gaudi device
+  enabled: true
+  identifier: habana.ai/gaudi
+  tolerations:
+    - effect: NoSchedule
+      key: habana.ai/gaudi
+      operator: Exists
+---
 
-For more information about accelerator profile attributes, see the following table: 
+The accelerator profile code appears on the *Instances* tab on the details page for the `AcceleratorProfile` custom resource definition (CRD). For more information about accelerator profile attributes, see the following table: 
 
 [id="table-accelerator-profile-attributes_{context}"]
 
@@ -22,17 +38,17 @@ For more information about accelerator profile attributes, see the following tab
 | displayName
 | String
 | Required
-| The display name of the accelerator.
+| The display name of the accelerator profile.
 
 | description
 | String
 | Optional
-| Descriptive text defining the accelerator.
+| Descriptive text defining the accelerator profile.
 
 | identifier
 | String
 | Required
-| A unique identifier defining the accelerator.
+| A unique identifier defining the accelerator resource.
 
 | enabled
 | Boolean


### PR DESCRIPTION
…profiles - phase two

I have documented phase two of the accelerator profile feature in ODH. This phase implements an admin UI to the dashboard, allowing administrators to easily manage their accelerator profiles. 

## Description
Documentation has been provided on phase two of accelerator profiles for ODH. This includes the admin UI and how to create, update, view and delete accelerator profiles. You can also configure custom notebooks to display recommended accelerators next to each notebook. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
