### PR TITLE
RHOAIENG-1916:Adding references to ROSA and updating links

### DIFF
--- a/modules/accessing-notebook-servers-owned-by-other-users.adoc
+++ b/modules/accessing-notebook-servers-owned-by-other-users.adoc
@@ -21,7 +21,7 @@ ifdef::self-managed[]
 endif::[]
 
 ifdef::cloud-service[]
-* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users for in OpenShift].
+* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift].
 
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]

--- a/modules/accessing-notebook-servers-owned-by-other-users.adoc
+++ b/modules/accessing-notebook-servers-owned-by-other-users.adoc
@@ -14,8 +14,14 @@ ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 
-ifndef::upstream[]
+ifdef::self-managed[]
 * You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+
+* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
+endif::[]
+
+ifdef::cloud-service[]
+* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users for in OpenShift].
 
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]

--- a/modules/accessing-the-jupyter-administration-interface.adoc
+++ b/modules/accessing-the-jupyter-administration-interface.adoc
@@ -11,9 +11,14 @@ ifdef::upstream[]
 * You are part of the {openshift-platform} administrator group.
 endif::[]
 
-ifndef::upstream[]
+ifdef::self-managed[]
 * You are part of the {openshift-platform} administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
 endif::[]
+
+ifdef::cloud-service[]
+* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
+endif::[]
+
 
 .Procedure
 ** To access the Jupyter administration interface from {productname-short}, perform the following actions:

--- a/modules/accessing-the-jupyter-administration-interface.adoc
+++ b/modules/accessing-the-jupyter-administration-interface.adoc
@@ -12,11 +12,11 @@ ifdef::upstream[]
 endif::[]
 
 ifdef::self-managed[]
-* You are part of the {openshift-platform} administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
 endif::[]
 
 ifdef::cloud-service[]
-* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
+* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift].
 endif::[]
 
 

--- a/modules/cleaning-up-after-deleting-users.adoc
+++ b/modules/cleaning-up-after-deleting-users.adoc
@@ -5,10 +5,10 @@
 
 [role='_abstract']
 ifdef::upstream,self-managed[]
-After removing a user's access to {productname-long} or Jupyter, you must also delete their associated configuration files from {openshift-platform}.
+After you remove a user's access to {productname-long} or Jupyter, you must also delete the configuration files for the user from {openshift-platform}.
 endif::[]
 ifdef::cloud-service[]
-After removing a user's access to {productname-long} or Jupyter, you must also delete their associated configuration files from OpenShift.
+After you remove a user's access to {productname-long} or Jupyter, you must also delete the configuration files for the user from OpenShift.
 endif::[]
 Red Hat recommends that you back up the user's data before removing their configuration files.
 
@@ -19,12 +19,12 @@ Red Hat recommends that you back up the user's data before removing their config
 
 ifdef::cloud-service[]
 * You have backed up the user's storage data from Amazon EBS or Google Persistent Disk.
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift].
 endif::[]
 
 ifdef::self-managed[]
 * You have backed up the user's storage data.
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
 endif::[]
 
 ifdef::upstream,self-managed[]

--- a/modules/cleaning-up-after-deleting-users.adoc
+++ b/modules/cleaning-up-after-deleting-users.adoc
@@ -4,24 +4,37 @@
 = Cleaning up after deleting users
 
 [role='_abstract']
-
+ifdef::upstream,self-managed[]
 After removing a user's access to {productname-long} or Jupyter, you must also delete their associated configuration files from {openshift-platform}.
-
+endif::[]
+ifdef::cloud-service[]
+After removing a user's access to {productname-long} or Jupyter, you must also delete their associated configuration files from OpenShift.
+endif::[]
 Red Hat recommends that you back up the user's data before removing their configuration files.
 
 .Prerequisites
+
 * (Optional) If you want to completely remove the user's access to {productname-short}, you have removed their credentials from your identity provider.
 * You have revoked the user's access to Jupyter.
-ifndef::upstream[]
-ifndef::self-managed[]
+
+ifdef::cloud-service[]
 * You have backed up the user's storage data from Amazon EBS or Google Persistent Disk.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
 endif::[]
+
 ifdef::self-managed[]
 * You have backed up the user's storage data.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
 endif::[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, `{oai-admin-group}`). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
-endif::[]
+
+ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
+endif::[]
+
+ifdef::cloud-service[]
+* You have logged in to the OpenShift web console.
+endif::[]
+
 * You have logged in to {productname-short}.
 
 .Procedure

--- a/modules/starting-notebook-servers-owned-by-other-users.adoc
+++ b/modules/starting-notebook-servers-owned-by-other-users.adoc
@@ -14,8 +14,13 @@ ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 
-ifndef::upstream[]
+ifdef::self-managed[]
 * You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
+endif::[]
+
+ifdef::cloud-service[]
+* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift].
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -8,7 +8,7 @@ Administrators can stop notebook servers that are owned by other users to reduce
 
 .Prerequisites
 ifdef::upstream[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {odh-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
 endif::[]
 
 ifdef::self-managed[]

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -8,11 +8,11 @@ Administrators can stop notebook servers that are owned by other users to reduce
 
 .Prerequisites
 ifdef::upstream,self-managed[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. 
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
 endif::[]
 
 ifdef::cloud-service[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group.
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift].
 endif::[]
 
 ifdef::upstream[]
@@ -20,12 +20,10 @@ ifdef::upstream[]
 endif::[]
 
 ifdef::self-managed[]
-* See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 
 ifdef::cloud-service[]
-* See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -7,17 +7,26 @@
 Administrators can stop notebook servers that are owned by other users to reduce resource consumption on the cluster, or as part of removing a user and their resources from the cluster.
 
 .Prerequisites
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, `{oai-admin-group}`). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. 
+ifdef::upstream,self-managed[]
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. 
+endif::[]
+
+ifdef::cloud-service[]
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group.
+endif::[]
 
 ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 
-ifndef::upstream[]
-
+ifdef::self-managed[]
 * See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}] for more information.
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
+endif::[]
 
+ifdef::cloud-service[]
+* See link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-in-openshift_install[Adding administrative users in OpenShift] for more information.
+* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#launching-jupyter-and-starting-a-notebook-server_get-started[Launching Jupyter and starting a notebook server].
 endif::[]
 
 * The notebook server that you want to stop is running.

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -7,7 +7,11 @@
 Administrators can stop notebook servers that are owned by other users to reduce resource consumption on the cluster, or as part of removing a user and their resources from the cluster.
 
 .Prerequisites
-ifdef::upstream,self-managed[]
+ifdef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
+endif::[]
+
+ifdef::self-managed[]
 * If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
 endif::[]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the following sections of the managing users and managing resources guide to include references to ROSA, and also replace the _Adding administrative users in OSD_ to the _Adding administrative users in OpenShift_

Managing Users

- modules/cleaning-up-after-deleting-users.adoc

Managing Resources

-    modules/accessing-notebook-servers-owned-by-other-users.adoc
-    modules/accessing-the-jupyter-administration-interface.adoc
-    modules/starting-notebook-servers-owned-by-other-users.adoc
-    modules/stopping-notebook-servers-owned-by-other-users.adoc
## How Has This Been Tested?
Local Upstream build and downstream previews with ccutil.

Upstream Preview [UPDATED FEB 1]:
![Screenshot 2024-02-01 at 12 55 24 PM](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/112db390-fe75-4b18-81f8-5abee1a8c36b)
![Screenshot 2024-02-01 at 12 55 38 PM](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/b8b50943-ccfc-4b1b-9b87-539271a70827)



Downstream Previews:
[CS-Managing resources.pdf](https://github.com/opendatahub-io/opendatahub-documentation/files/14116607/CS-Managing.resources.pdf)
[CS-Managing users.pdf](https://github.com/opendatahub-io/opendatahub-documentation/files/14116608/CS-Managing.users.pdf)
[SM-Managing resources-preview.pdf](https://github.com/opendatahub-io/opendatahub-documentation/files/14116609/SM-Managing.resources-preview.pdf)
[SM-Managing users.pdf](https://github.com/opendatahub-io/opendatahub-documentation/files/14116611/SM-Managing.users.pdf)
![Screenshot 2024-02-01 at 12 56 06 PM](https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/2fefe590-0262-484d-93d0-43f77a902ad8)
