### PR TITLE
Amend note about using self-signed certs with KServe

### DIFF
--- a/modules/deploying-models-using-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-using-the-single-model-serving-platform.adoc
@@ -6,4 +6,10 @@
 [role='_abstract']
 On the single model serving platform, each model is deployed from its own model server. This helps you to deploy, monitor, scale, and maintain LLMs that require increased resources.
 
-IMPORTANT: The single model serving platform does not support self-signed certificates. Therefore, to deploy a model from S3 storage, you need to follow a workaround to disable SSL authentication. For more information, see the following Red Hat Solution article: link:https://access.redhat.com/solutions/7047512[How to skip the validation of SSL for KServe^].
+[IMPORTANT]
+==== 
+If you want to use a self-signed certificate to deploy a model from S3-compatible storage, the single model serving platform (which uses KServe) requires some additional configuration. For more information, see the Red Hat Knowledgebase solution article link:https://access.redhat.com/solutions/7053013[How to use self-signed certificates with KServe^].
+
+Alternatively, you can disable SSL authentication for KServe. For more information, see the Red Hat Knowledgebase solution article link:https://access.redhat.com/solutions/7047512[How to skip the validation of SSL for KServe^].
+====
+

--- a/modules/deploying-models-using-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-using-the-single-model-serving-platform.adoc
@@ -8,7 +8,7 @@ On the single model serving platform, each model is deployed from its own model 
 
 [IMPORTANT]
 ==== 
-If you want to use a self-signed certificate to deploy a model from S3-compatible storage, the single model serving platform (which uses KServe) requires some additional configuration. For more information, see the Red Hat Knowledgebase solution article link:https://access.redhat.com/solutions/7053013[How to use self-signed certificates with KServe^].
+If you want to use a self-signed certificate to deploy a model from S3-compatible storage, the single model serving platform (which uses KServe) requires additional configuration. For more information, see the Red Hat Knowledgebase solution article link:https://access.redhat.com/solutions/7053013[How to use self-signed certificates with KServe^].
 
 Alternatively, you can disable SSL authentication for KServe. For more information, see the Red Hat Knowledgebase solution article link:https://access.redhat.com/solutions/7047512[How to skip the validation of SSL for KServe^].
 ====


### PR DESCRIPTION
Amend note about using self-signed certs with KServe. There are now two possible actions that users can take, both documented in Solution articles.