### PR TITLE
removed reference to accelerator profiles being at technology preview

### DIFF
--- a/modules/working-with-accelerator-profiles.adoc
+++ b/modules/working-with-accelerator-profiles.adoc
@@ -4,8 +4,6 @@
 = Working with accelerator profiles
 
 [role='_abstract']
-The accelerator profiles feature is currently available as a Technology Preview. For further information about the scope of Technology Preview status, and the associated support implications, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-
 To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. An accelerator profile is a custom resource definition (CRD) on OpenShift that has an AcceleratorProfile resource, and defines the specification of the accelerator. You can create and manage accelerator profiles by selecting *Settings* -> *Accelerator profiles* on the {productname-short} dashboard.
 
 For accelerators that are new to your deployment, you must manually configure an accelerator profile for each accelerator. If your deployment contains an accelerator before you upgrade, the associated accelerator profile remains after the upgrade. You can manage the accelerators that appear to your data scientists by assigning specific accelerator profiles to your custom notebook images. This example shows the code for a Habana Gaudi 1 accelerator profile:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have removed the notice that the accelerator profiles feature is at tech preview from the "Working with accelerator profiles" page. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
