### PR TITLE
RHOAIENG-730: RStudio Server notebook images

### DIFF
--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -67,12 +67,11 @@ ifndef::upstream[]
 ifdef::cloud-service[]
 == Building the RStudio Server notebook images
 
-[Disclaimer] 
+[IMPORTANT] 
 ====
+*Disclaimer:* 
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ==== 
-
-To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
 [IMPORTANT]
 ====
@@ -84,6 +83,8 @@ These features provide early access to upcoming product features, enabling custo
 
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
+
+To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
 .Prerequisites
 * Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -83,7 +83,6 @@ Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAM
 ----
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
 ----
---
 . Start the build:
 .. To start the lightweight RStudio Server build: 
 ----
@@ -95,7 +94,7 @@ oc start-build cuda-rhel9 -n redhat-ods-applications --follow
 ----
 +
 The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
---
+
 . Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
 +
 ----
@@ -105,4 +104,4 @@ oc get builds -n redhat-ods-applications
 .Verification
 
 * You can see *RStudio Server* and *CUDA - RStudio Server* images on the *Applications* -> *Enabled* menu in the {productname-long} dashboard.
-* You can see *R Studio Server * or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.
+* You can see *R Studio Server* or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -63,7 +63,6 @@ The extension you installed appears in the *Browser - Installed* list on the *Ex
 
 See link:https://open-vsx.org/[Open VSX Registry] for available third-party extensions that you can consider installing.
 
-ifndef::upstream[]
 == Building the RStudio Server notebook images
 
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig.
@@ -108,5 +107,3 @@ oc get builds -n redhat-ods-applications
 After the builds complete successfully, you can select the *RStudio Server* and *CUDA - RStudio Server* images when you create a workbench from the {productname-long} dashboard.
 
 You can create a workbench from the *Applications* -> *Enabled* menu, or by selecting *RStudio Server * or *CUDA - RStudio Server* from the *Data Science Projects* -> Workbenches -> *Create workbench* menu.
-
-endif::[]

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -102,6 +102,17 @@ The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-
 ----
 oc get builds -n redhat-ods-applications
 ----
+. After the builds complete successfully, use the following commands to make the notebook images available in the {productname-short} UI.
+.. To enable the RStudio Server notebook image:
++
+----
+oc label -n redhat-ods-applications imagestream rstudio-rhel9 opendatahub.io/notebook-image='true'
+----
+.. To enable the CUDA - RStudio Server notebook image:
++
+----
+oc label -n redhat-ods-applications imagestream cuda-rstudio-rhel9 opendatahub.io/notebook-image='true'
+----
 
 .Verification
 

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -73,11 +73,11 @@ To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you mus
 * Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
 * You are logged in to your OpenShift cluster.
 * You have the `cluster-admin` role in {openshift-platform}, to the namespace `rhoai-applications`, or with cluster-wide role binding.
-* You have an active Red Hat Enterprise Linux (RHEL) subscription.
+* You have an active {org-name} Enterprise Linux (RHEL) subscription.
 
 .Procedure
 
-. Create a secret with subscription manager credentials. These are usually your Red Hat Customer Portal username and password.
+. Create a secret with subscription manager credentials. These are usually your {org-name} Customer Portal username and password.
 +
 Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAME` and `PASSWORD` within it must be in capital letters. 
 +

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -64,22 +64,21 @@ The extension you installed appears in the *Browser - Installed* list on the *Ex
 See link:https://open-vsx.org/[Open VSX Registry] for available third-party extensions that you can consider installing.
 
 ifndef::upstream[]
+ifdef::cloud-service[]
 == Building the RStudio Server notebook images
 
-To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` imagestreams.
+To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
 .Prerequisites
-
 * Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
 * You are logged in to your OpenShift cluster.
 * You have the `cluster-admin` role in {openshift-platform}, to the namespace `rhoai-applications`, or with cluster-wide role binding.
 * You have an active {org-name} Enterprise Linux (RHEL) subscription.
 
 .Procedure
-
-. Create a secret with subscription manager credentials. These are usually your {org-name} Customer Portal username and password.
+. Create a secret with Subscription Manager credentials. These are usually your {org-name} Customer Portal username and password.
 +
-Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAME` and `PASSWORD` within it must be in capital letters. 
+Note: The secret must be named `rhel-subscription-secret`, and its `USERNAME` and `PASSWORD` keys must be in capital letters. 
 +
 ----
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
@@ -115,8 +114,8 @@ oc label -n redhat-ods-applications imagestream cuda-rstudio-rhel9 opendatahub.i
 ----
 
 .Verification
-
 * You can see *RStudio Server* and *CUDA - RStudio Server* images on the *Applications* -> *Enabled* menu in the {productname-long} dashboard.
 * You can see *R Studio Server* or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.
 
+endif::[]
 endif::[]

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -69,7 +69,7 @@ To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you mus
 
 .Prerequisites
 
-* *Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
+* Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
 * You are logged in to your OpenShift cluster.
 * You have the `cluster-admin` role in {openshift-platform}, to the namespace `rhoai-applications`, or with cluster-wide role binding.
 * You have an active Red Hat Enterprise Linux (RHEL) subscription.
@@ -78,18 +78,18 @@ To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you mus
 
 . Create a secret with subscription manager credentials. These are usually your Red Hat Customer Portal username and password.
 +
-Note: The secret must be named rhel-subscription-secret, and the keys `USERNAME` and `PASSWORD` within it must be in capital letters. 
+Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAME` and `PASSWORD` within it must be in capital letters. 
 +
 ----
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
 ----
 . Start the build:
-    . To start the lightweight RStudio Server build:
+    .. To start the lightweight RStudio Server build:
     +
     ----
     oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
     ----
-    . To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig:
+    .. To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig:
     +
     ----
     oc start-build cuda-rhel9 -n redhat-ods-applications --follow
@@ -106,5 +106,4 @@ oc get builds -n redhat-ods-applications
 .Verification
 
 * You can see *RStudio Server* and *CUDA - RStudio Server* images on the *Applications* -> *Enabled* menu in the {productname-long} dashboard.
-
 * You can see *R Studio Server * or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -83,6 +83,7 @@ Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAM
 ----
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
 ----
+--
 . Start the build:
 .. To start the lightweight RStudio Server build: 
 ----
@@ -94,6 +95,7 @@ oc start-build cuda-rhel9 -n redhat-ods-applications --follow
 ----
 +
 The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
+--
 . Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
 +
 ----

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -66,7 +66,7 @@ See link:https://open-vsx.org/[Open VSX Registry] for available third-party exte
 ifndef::upstream[]
 == Building RStudio Server
 
-To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build RStudio Server by creating a secret and triggering the BuildConfig.
+To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig.
 
 .Prerequisites
 

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -72,6 +72,9 @@ To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you mus
 
 . Before starting the RStudio Server build process, you have at least 1 CPU available for `rstudio-server-rhel9`, and 1.5 CPUs for `cuda-rstudio-server-rhel9` on your cluster.
 . You are logged in to your OpenShift cluster.
+. You have a subscription to [PLACEHOLDER].
++
+Contact your {org-name} account manager to purchase new subscriptions. If you do not yet have an account manager, complete the form at link:https://www.redhat.com/en/contact/[https://www.redhat.com/en/contact] to request one.
 
 .Procedure
 

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -63,6 +63,7 @@ The extension you installed appears in the *Browser - Installed* list on the *Ex
 
 See link:https://open-vsx.org/[Open VSX Registry] for available third-party extensions that you can consider installing.
 
+ifndef::upstream[]
 == Building the RStudio Server notebook images
 
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` imagestreams.
@@ -106,3 +107,5 @@ oc get builds -n redhat-ods-applications
 
 * You can see *RStudio Server* and *CUDA - RStudio Server* images on the *Applications* -> *Enabled* menu in the {productname-long} dashboard.
 * You can see *R Studio Server* or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.
+
+endif::[]

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -67,6 +67,11 @@ ifndef::upstream[]
 ifdef::cloud-service[]
 == Building the RStudio Server notebook images
 
+[Disclaimer] 
+====
+{org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
+==== 
+
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
 [IMPORTANT]

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -85,13 +85,15 @@ oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<usern
 ----
 . Start the build:
 .. To start the lightweight RStudio Server build: 
-    ----
-    oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
-    ----
++
+----
+oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
+----
 .. To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig: 
-    ----
-    oc start-build cuda-rhel9 -n redhat-ods-applications --follow
-    ----
++
+----
+oc start-build cuda-rhel9 -n redhat-ods-applications --follow
+----
 +
 The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
 . Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -84,19 +84,16 @@ Note: The secret must be named `rhel-subscription-secret`, and the keys `USERNAM
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
 ----
 . Start the build:
-    .. To start the lightweight RStudio Server build:
-    +
-    ----
-    oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
-    ----
-    .. To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig:
-    +
-    ----
-    oc start-build cuda-rhel9 -n redhat-ods-applications --follow
-    ----
-    +
-    The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
-
+.. To start the lightweight RStudio Server build: 
+----
+oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
+----
+.. To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig: 
+----
+oc start-build cuda-rhel9 -n redhat-ods-applications --follow
+----
++
+The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
 . Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
 +
 ----

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -73,7 +73,6 @@ To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you mus
 . Before starting the RStudio Server build process, you have at least 1 CPU available for `rstudio-server-rhel9`, and 1.5 CPUs for `cuda-rstudio-server-rhel9` on your cluster.
 . You are logged in to your OpenShift cluster.
 
-
 .Procedure
 
 . Create a secret with subscription manager credentials. These are usually your Red Hat Customer Portal username and password.
@@ -87,7 +86,7 @@ oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<usern
     . To start the lightweight RStudio Server build:
     +
     ----
-    oc start-build rstudio--server-rhel9 -n redhat-ods-applications --follow
+    oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
     ----
     . To start the CUDA-enabled RStudio Server build:
     +

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -65,15 +65,14 @@ See link:https://open-vsx.org/[Open VSX Registry] for available third-party exte
 
 == Building the RStudio Server notebook images
 
-To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig.
+To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` imagestreams.
 
 .Prerequisites
 
-. Before starting the RStudio Server build process, you have at least 1 CPU available for `rstudio-server-rhel9`, and 1.5 CPUs for `cuda-rstudio-server-rhel9` on your cluster.
-. You are logged in to your OpenShift cluster.
-. You have a subscription to [PLACEHOLDER].
-+
-Contact your {org-name} account manager to purchase new subscriptions. If you do not yet have an account manager, complete the form at link:https://www.redhat.com/en/contact/[https://www.redhat.com/en/contact] to request one.
+* *Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
+* You are logged in to your OpenShift cluster.
+* You have the `cluster-admin` role in {openshift-platform}, to the namespace `rhoai-applications`, or with cluster-wide role binding.
+* You have an active Red Hat Enterprise Linux (RHEL) subscription.
 
 .Procedure
 
@@ -84,26 +83,28 @@ Note: The secret must be named rhel-subscription-secret, and the keys `USERNAME`
 ----
 oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
 ----
-. Build RStudio Server
+. Start the build:
     . To start the lightweight RStudio Server build:
     +
     ----
     oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
     ----
-    . To start the CUDA-enabled RStudio Server build:
+    . To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig:
     +
     ----
     oc start-build cuda-rhel9 -n redhat-ods-applications --follow
     ----
+    +
+    The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
 
-.Verification
-
-Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
-
+. Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
++
 ----
 oc get builds -n redhat-ods-applications
 ----
 
-After the builds complete successfully, you can select the *RStudio Server* and *CUDA - RStudio Server* images when you create a workbench from the {productname-long} dashboard.
+.Verification
 
-You can create a workbench from the *Applications* -> *Enabled* menu, or by selecting *RStudio Server * or *CUDA - RStudio Server* from the *Data Science Projects* -> Workbenches -> *Create workbench* menu.
+* You can see *RStudio Server* and *CUDA - RStudio Server* images on the *Applications* -> *Enabled* menu in the {productname-long} dashboard.
+
+* You can see *R Studio Server * or *CUDA - RStudio Server* in the *Data Science Projects* -> *Workbenches* -> *Create workbench* -> *Notebook image* -> *Image selection* dropdown list.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -69,6 +69,17 @@ ifdef::cloud-service[]
 
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
+[IMPORTANT]
+====
+The *RStudio Server* and *CUDA - RStudio Server* notebook images are currently available in {productname-long} as Technology Preview features.
+
+Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
+Red{nbsp}Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+
 .Prerequisites
 * Before starting the RStudio Server build process, you have at least 1 CPU and 2Gi memory available for `rstudio-server-rhel9`, and 1.5 CPUs and 8Gi memory available for `cuda-rstudio-server-rhel9` on your cluster.
 * You are logged in to your OpenShift cluster.

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -63,3 +63,48 @@ The extension you installed appears in the *Browser - Installed* list on the *Ex
 
 See link:https://open-vsx.org/[Open VSX Registry] for available third-party extensions that you can consider installing.
 
+ifndef::upstream[]
+== Building RStudio Server
+
+To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build RStudio Server by creating a secret and triggering the BuildConfig.
+
+.Prerequisites
+
+. Before starting the RStudio Server build process, you have at least 1 CPU available for `rstudio-server-rhel9`, and 1.5 CPUs for `cuda-rstudio-server-rhel9` on your cluster.
+. You are logged in to your OpenShift cluster.
+
+
+.Procedure
+
+. Create a secret with subscription manager credentials. These are usually your Red Hat Customer Portal username and password.
++
+Note: The secret must be named rhel-subscription-secret, and the keys `USERNAME` and `PASSWORD` within it must be in capital letters. 
++
+----
+oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<username> --from-literal=PASSWORD=<password> -n redhat-ods-applications
+----
+. Build RStudio Server
+    . To start the lightweight RStudio Server build:
+    +
+    ----
+    oc start-build rstudio--server-rhel9 -n redhat-ods-applications --follow
+    ----
+    . To start the CUDA-enabled RStudio Server build:
+    +
+    ----
+    oc start-build cuda-rhel9 -n redhat-ods-applications --follow
+    ----
+
+.Verification
+
+Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
+
+----
+oc get builds -n redhat-ods-applications
+----
+
+After the builds complete successfully, you can select the *RStudio Server* and *CUDA - RStudio Server* images when you create a workbench from the {productname-long} dashboard.
+
+You can create a workbench from the *Applications* -> *Enabled* menu, or by selecting *RStudio Server * or *CUDA - RStudio Server* from the *Data Science Projects* -> Workbenches -> *Create workbench* menu.
+
+endif::[]

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -64,7 +64,7 @@ The extension you installed appears in the *Browser - Installed* list on the *Ex
 See link:https://open-vsx.org/[Open VSX Registry] for available third-party extensions that you can consider installing.
 
 ifndef::upstream[]
-== Building RStudio Server
+== Building the RStudio Server notebook images
 
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig.
 

--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -85,16 +85,15 @@ oc create secret generic rhel-subscription-secret --from-literal=USERNAME=<usern
 ----
 . Start the build:
 .. To start the lightweight RStudio Server build: 
-----
-oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
-----
+    ----
+    oc start-build rstudio-server-rhel9 -n redhat-ods-applications --follow
+    ----
 .. To start the CUDA-enabled RStudio Server build, trigger the `cuda-rhel9` BuildConfig: 
-----
-oc start-build cuda-rhel9 -n redhat-ods-applications --follow
-----
+    ----
+    oc start-build cuda-rhel9 -n redhat-ods-applications --follow
+    ----
 +
 The cuda-rhel9 build is a prerequisite for cuda-rstudio-rhel9. The cuda-rstudio-rhel9 build starts automatically.
-
 . Confirm that the build process has completed successfully using the following command. Successful builds appear as `Complete`.
 +
 ----

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -22,7 +22,14 @@ ifdef::self-managed[]
 See the table in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/creating-a-project-workbench_get-started#options-for-notebook-server-environments_get-started[Options for notebook server environments] for a complete list of packages and versions included in these images.
 endif::[]
 
-{productname-long} contains the following notebook images that are available by default:
+{productname-long} contains the following notebook images that are available by default.
+
+ifndef::upstream[]
+[IMPORTANT]
+====
+Notebook images denoted with `(Technology Preview)` in this table are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete. {org-name} does not recommend using Technology Preview features in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of {org-name} Technology Preview features, see Technology Preview Features Support Scope.
+====
+endif::[]
 
 .Default notebook images
 [cols="1,5"]

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -83,7 +83,7 @@ endif::[]
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` imagestream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 
 | CUDA - RStudio Server
@@ -91,7 +91,7 @@ endif::[]
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` imagestreams. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 |===
 

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -95,8 +95,8 @@ a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NV
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 endif::[]
 
-ifndef::upstream[]
-ifdef::cloud-service[]
+//ifndef::upstream[]
+//ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
 a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -78,6 +78,13 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 ====
 endif::[]
 
+| RStudio Server 
+| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+
+| RStudio Server (CUDA-enabled)
+| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+
+
 |===
 
 ifndef::upstream[]

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -78,12 +78,13 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 ====
 endif::[]
 
+ifdef::cloud-service[]
 | RStudio Server 
 | Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` imagestream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 
 | CUDA - RStudio Server
@@ -91,7 +92,8 @@ endif::[]
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` imagestreams. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+endif::[]
 endif::[]
 |===
 

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -96,8 +96,8 @@ a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NV
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 endif::[]
 
-//ifndef::upstream[]
-//ifdef::cloud-service[]
+ifndef::upstream[]
+ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
 a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -80,8 +80,9 @@ ifdef::cloud-service[]
 a| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
-[Disclaimer] 
+[IMPORTANT] 
 ====
+*Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
 
@@ -101,8 +102,9 @@ endif::[]
 a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
-[Disclaimer] 
+[IMPORTANT] 
 ====
+*Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
 

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -80,13 +80,13 @@ ifdef::cloud-service[]
 a| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
+To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+
 [IMPORTANT] 
 ====
 *Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
-
-NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 endif::[]
 
@@ -102,13 +102,13 @@ endif::[]
 a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
+To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
+
 [IMPORTANT] 
 ====
 *Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
-
-NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 endif::[]
 |===

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -80,12 +80,19 @@ endif::[]
 
 | RStudio Server 
 | Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
-See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+
+ifndef::upstream[]
+NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:[{rhoaidocshome}{default-format-url}/getting-started-with-open-data-hub/#_building_the_rstudio_server_notebook_images] for more information.
+endif::[]
 
 | CUDA - RStudio Server
 | Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
-See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
+ifndef::upstream[]
+NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:[{rhoaidocshome}{default-format-url}/getting-started-with-open-data-hub/#_building_the_rstudio_server_notebook_images] for more information.
+endif::[]
 |===
 
 ifndef::upstream[]

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -80,10 +80,12 @@ endif::[]
 
 | RStudio Server 
 | Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.
 
-| RStudio Server (CUDA-enabled)
-| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 
+| CUDA - RStudio Server
+| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.
 
 |===
 

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -82,7 +82,6 @@ endif::[]
 | Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.
 
-
 | CUDA - RStudio Server
 | Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information.

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -71,14 +71,19 @@ NOTE: Elyra-based pipelines are not available with the code-server notebook imag
 
 ifdef::upstream[]
 | RStudio Server 
-| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+a| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
 | RStudio Server (Technology preview)
-| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+a| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+
+[Disclaimer] 
+====
+{org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
+====
 
 NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
@@ -86,15 +91,20 @@ endif::[]
 
 ifdef::upstream[]
 | CUDA - RStudio Server
-| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
+a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 endif::[]
 
 ifndef::upstream[]
 ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
-| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
+a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+
+[Disclaimer] 
+====
+{org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
+====
 
 NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -83,7 +83,7 @@ endif::[]
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:[{rhoaidocshome}{default-format-url}/getting-started-with-open-data-hub/#_building_the_rstudio_server_notebook_images] for more information.
+NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 
 | CUDA - RStudio Server
@@ -91,7 +91,7 @@ endif::[]
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
 
 ifndef::upstream[]
-NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:[{rhoaidocshome}{default-format-url}/getting-started-with-open-data-hub/#_building_the_rstudio_server_notebook_images] for more information.
+NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 |===
 

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -78,20 +78,33 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 ====
 endif::[]
 
-ifdef::cloud-service[]
+ifdef::upstream[]
 | RStudio Server 
 | Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
-
+endif::[]
 ifndef::upstream[]
+ifdef::cloud-service[]
+| RStudio Server (Technology preview)
+| Use the RStudio Server notebook image to access the RStudio IDE, an integrated development environment for R, a programming language for statistical computing and graphics.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+
 NOTE: To use the *RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
+endif::[]
 
+ifdef::upstream[]
 | CUDA - RStudio Server
 | Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+endif::[]
 
 ifndef::upstream[]
+ifdef::cloud-service[]
+| CUDA - RStudio Server (Technology preview)
+| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
+See link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site] for more information. +
+
 NOTE: To use the *CUDA - RStudio Server* notebook image, you must first build it by creating a secret and triggering the BuildConfig, and then enable it in the {productname-short} UI by editing the `cuda-rstudio-rhel9` image stream. See link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/configuring-your-ide_get-started#building_the_rstudio_server_notebook_images[Building the RStudio Server notebook images] for more information.
 endif::[]
 endif::[]

--- a/modules/notebook-images-for-data-scientists.adoc
+++ b/modules/notebook-images-for-data-scientists.adoc
@@ -68,22 +68,6 @@ endif::[]
 a| With the code-server notebook image, you can customize your notebook environment to meet your needs using a variety of extensions to add new languages, themes, debuggers, and connect to additional services. Enhance the efficiency of your data science work with syntax highlighting, auto-indentation, and bracket matching, as well as an automatic task runner for seamless automation. See link:https://github.com/coder/code-server[code-server in GitHub] for more information. +
 
 NOTE: Elyra-based pipelines are not available with the code-server notebook image.
- 
-ifndef::upstream[]
-[IMPORTANT]
-====
-ifdef::self-managed[]
-The code-server notebook image is currently available in {productname-long} {vernum} as a Technology Preview feature.
-endif::[]
-ifdef::cloud-service[]
-The code-server notebook image is currently available in {productname-long} as a Technology Preview feature.
-endif::[]
-Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
-Red{nbsp}Hat does not recommend using them in production.
-These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::[]
 
 ifdef::upstream[]
 | RStudio Server 

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -312,18 +312,31 @@ a| * Python 3.9
 * (code-server plugin) Python 2023.14.0
 * (code-server plugin) Jupyter 2023.3.100
 
-ifdef::cloud-service[]
+ifdef::upstream[]
 | RStudio Server
+endif::[]
+ifndef::upstream[]
+ifdef::cloud-service[]
+| RStudio Server (Technology preview)
+endif::[]
+endif::[]
 | 2023.2 (Recommended)
 a| * Python 3.9
 * R 4.3
 
+ifdef::upstream[]
 | CUDA - RStudio Server
+endif::[]
+ifndef::upstream[]
+ifdef::cloud-service[]
+| CUDA - RStudio Server (Technology preview)
+endif::[]
+endif::[]
 | 2023.2 (Recommended)
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3
-endif::[]
+
 
 |===
 

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -315,34 +315,13 @@ a| * Python 3.9
 | RStudio Server
 | 2023.2 (Recommended)
 a| * Python 3.9
-* Boto3 1.29
-* Kafka-Python 2.0
-* Matplotlib 3.8
-* Numpy 1.26
-* Pandas 2.1
-* Plotly 5.18
-* Scikit-learn 1.3
-* Scipy 1.11
-* Sklearn-onnx 1.15
-* Ipykernel 6.26
-* (code-server plugin) Python 2023.14.0
-* (code-server plugin) Jupyter 2023.3.100
+* R 4.3
 
-| RStudio Server (CUDA-enabled)
+| CUDA - RStudio Server
 | 2023.2 (Recommended)
 a| * Python 3.9
-* Boto3 1.29
-* Kafka-Python 2.0
-* Matplotlib 3.8
-* Numpy 1.26
-* Pandas 2.1
-* Plotly 5.18
-* Scikit-learn 1.3
-* Scipy 1.11
-* Sklearn-onnx 1.15
-* Ipykernel 6.26
-* (code-server plugin) Python 2023.14.0
-* (code-server plugin) Jupyter 2023.3.100
+* CUDA 11.8
+* R 4.3
 
 |===
 

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -319,8 +319,8 @@ a| * Python 3.9
 * R 4.3
 endif::[]
 
-//ifndef::upstream[]
-//ifdef::cloud-service[]
+ifndef::upstream[]
+ifdef::cloud-service[]
 | RStudio Server (Technology preview)
 | 2023.2 (Recommended)
 a| * Python 3.9
@@ -341,8 +341,8 @@ a| * Python 3.9
 * R 4.3
 endif::[]
 
-//ifndef::upstream[]
-//ifdef::cloud-service[]
+ifndef::upstream[]
+ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
 | 2023.2 (Recommended)
 a| * Python 3.9

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -312,6 +312,38 @@ a| * Python 3.9
 * (code-server plugin) Python 2023.14.0
 * (code-server plugin) Jupyter 2023.3.100
 
+| RStudio Server
+| 2023.2 (Recommended)
+a| * Python 3.9
+* Boto3 1.29
+* Kafka-Python 2.0
+* Matplotlib 3.8
+* Numpy 1.26
+* Pandas 2.1
+* Plotly 5.18
+* Scikit-learn 1.3
+* Scipy 1.11
+* Sklearn-onnx 1.15
+* Ipykernel 6.26
+* (code-server plugin) Python 2023.14.0
+* (code-server plugin) Jupyter 2023.3.100
+
+| RStudio Server (CUDA-enabled)
+| 2023.2 (Recommended)
+a| * Python 3.9
+* Boto3 1.29
+* Kafka-Python 2.0
+* Matplotlib 3.8
+* Numpy 1.26
+* Pandas 2.1
+* Plotly 5.18
+* Scikit-learn 1.3
+* Scipy 1.11
+* Sklearn-onnx 1.15
+* Ipykernel 6.26
+* (code-server plugin) Python 2023.14.0
+* (code-server plugin) Jupyter 2023.3.100
+
 |===
 
 Deployment size:: specifies the compute resources available on your notebook server.

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -312,6 +312,7 @@ a| * Python 3.9
 * (code-server plugin) Python 2023.14.0
 * (code-server plugin) Jupyter 2023.3.100
 
+ifdef::cloud-service[]
 | RStudio Server
 | 2023.2 (Recommended)
 a| * Python 3.9
@@ -322,6 +323,7 @@ a| * Python 3.9
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3
+endif::[]
 
 |===
 

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -319,14 +319,15 @@ a| * Python 3.9
 * R 4.3
 endif::[]
 
-ifndef::upstream[]
-ifdef::cloud-service[]
+//ifndef::upstream[]
+//ifdef::cloud-service[]
 | RStudio Server (Technology preview)
 | 2023.2 (Recommended)
 a| * Python 3.9
 * R 4.3
-[Disclaimer] 
+[IMPORTANT] 
 ====
+*Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
 endif::[]
@@ -340,15 +341,16 @@ a| * Python 3.9
 * R 4.3
 endif::[]
 
-ifndef::upstream[]
-ifdef::cloud-service[]
+//ifndef::upstream[]
+//ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
 | 2023.2 (Recommended)
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3
-[Disclaimer] 
+[IMPORTANT] 
 ====
+*Disclaimer:* +
 {org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
 ====
 endif::[]

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -314,29 +314,45 @@ a| * Python 3.9
 
 ifdef::upstream[]
 | RStudio Server
-endif::[]
-ifndef::upstream[]
-ifdef::cloud-service[]
-| RStudio Server (Technology preview)
-endif::[]
-endif::[]
 | 2023.2 (Recommended)
 a| * Python 3.9
 * R 4.3
+endif::[]
+
+ifndef::upstream[]
+ifdef::cloud-service[]
+| RStudio Server (Technology preview)
+| 2023.2 (Recommended)
+a| * Python 3.9
+* R 4.3
+[Disclaimer] 
+====
+{org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
+====
+endif::[]
+endif::[]
 
 ifdef::upstream[]
 | CUDA - RStudio Server
-endif::[]
-ifndef::upstream[]
-ifdef::cloud-service[]
-| CUDA - RStudio Server (Technology preview)
-endif::[]
-endif::[]
 | 2023.2 (Recommended)
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3
+endif::[]
 
+ifndef::upstream[]
+ifdef::cloud-service[]
+| CUDA - RStudio Server (Technology preview)
+| 2023.2 (Recommended)
+a| * Python 3.9
+* CUDA 11.8
+* R 4.3
+[Disclaimer] 
+====
+{org-name} supports managing workbenches in {productname-short}. However, {org-name} does not provide support for the RStudio software. RStudio Server is available through link:rstudio.org[rstudio.org] and is subject to their licensing terms, which should be reviewed prior to use of this sample workbench.
+====
+endif::[]
+endif::[]
 
 |===
 


### PR DESCRIPTION
Adds entries for the RStudio Server and CUDA - RStudio Server notebook images in modules/notebook-images-for-data-scientists.adoc and modules/options-for-notebook-server-environments.adoc. 


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
