### PR TITLE
Break long code lines in upstream model serving docs

### DIFF
--- a/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
+++ b/modules/accessing-api-endpoints-for-models-deployed-on-single-model-server.adoc
@@ -42,6 +42,25 @@ As indicated by the paths shown, the single model serving platform uses the HTTP
 
 . Use the endpoints to make API requests to your deployed model, as shown in the following example commands:
 +
+ifdef::upstream[]
+--
+*Caikit TGIS ServingRuntime for KServe*
+[source]
+----
+curl --json '{"model_id": "<model_name>", "inputs": "At what temperature does water boil?"}' \
+https://<inference_endpoint_url>:443/api/v1/task/server-streaming-text-generation
+----
+
+*TGIS Standalone ServingRuntime for KServe*
+[source]
+----
+grpcurl -proto text-generation-inference/proto/generation.proto -d \
+'{"requests": [{"text":"At what temperature does water boil?"}]}' \
+-H 'mm-model-id: <model_name>' -insecure <inference_url>:443 fmaas.GenerationService/Generate
+----
+--
+endif::[]
+ifdef::self-managed,cloud-service[]
 --
 *Caikit TGIS ServingRuntime for KServe*
 [source]
@@ -55,6 +74,7 @@ curl --json '{"model_id": "<model_name>", "inputs": "At what temperature does wa
 grpcurl -proto text-generation-inference/proto/generation.proto -d '{"requests": [{"text":"At what temperature does water boil?"}]}' -H 'mm-model-id: <model_name>' -insecure <inference_url>:443 fmaas.GenerationService/Generate
 ----
 --
+endif::[]
 
 //[role='_additional-resources']
 //.Additional resources


### PR DESCRIPTION
Verified with local builds both upstream and downstream.  Downstream doesn't require explicit line breaks - this is handled nicely by our styling.

**Upstream**

![image](https://github.com/opendatahub-io/opendatahub-documentation/assets/47602095/eb9387cc-70aa-40fd-b67f-28ab505b98f8)

**Downstream**

![image](https://github.com/opendatahub-io/opendatahub-documentation/assets/47602095/f2b1cd29-b4f6-491a-a988-8574d485e23a)
