### PR TITLE
 remove-bias-references-2-19

### DIFF
--- a/assemblies/working-on-data-science-projects.adoc
+++ b/assemblies/working-on-data-science-projects.adoc
@@ -15,7 +15,9 @@ Workbenches:: Creating a workbench allows you to add a Jupyter notebook to your 
 Cluster storage:: For data science projects that require data retention, you can add cluster storage to the project.
 Data connections:: Adding a data connection to your project allows you to connect data inputs to your workbenches.
 Models and model servers:: Deploy a trained data science model to serve intelligent applications. Your model is deployed with an endpoint that allows applications to send requests to the model.
+ifdef::upstream[]
 Bias metrics for models:: Creating bias metrics allows you to monitor your machine learning models for bias. 
+endif::[]
 
 [IMPORTANT]
 ====

--- a/modules/creating-a-data-science-project.adoc
+++ b/modules/creating-a-data-science-project.adoc
@@ -10,7 +10,9 @@ To start your data science work, create a data science project. Creating a proje
 * Storage for your project's cluster
 * Data connections
 * Model servers
+ifdef::upstream[]
 * Bias monitoring for your models
+endif::[]
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
+++ b/modules/deploying-a-model-using-the-multi-model-serving-platform.adoc
@@ -56,12 +56,10 @@ NOTE: The *Model framework* list shows only the frameworks that are supported by
 .Verification
 * Confirm that the deployed model is shown in the *Models and model servers* section of your project, and on the *Model Serving* page of the dashboard with a checkmark in the *Status* column.
 
+ifdef::upstream[]
 [role='_additional-resources']
 .Additional resources
-ifndef::upstream[]
-* To learn how to monitor your model for bias, see link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/index[Monitoring data science models].
-endif::[]
-ifdef::upstream[]
+
 * To learn how to monitor your model for bias, see link:{odhdocshome}/monitoring-data-science-models[Monitoring data science models].
 endif::[]
 

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -9,7 +9,9 @@ You can use the OpenShift web console to install specific components of Open Dat
 .Prerequisites
 * You have installed version 2 of the Open Data Hub Operator.
 * You can log in as a user with `cluster-admin` privileges.
+ifdef::upstream[]
 * If you want to use the `trustyai` component, you must enable user workload monitoring as described in link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects].
+endif::[]
 * If you want to use the `kserve`, `datasciencepipeline`, `distributedworkloads`, or `modelmesh` components, you must have already installed the following Operator or Operators for the component. For information about installing an Operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
 
 .Required Operators for components

--- a/modules/sending-training-data-to-a-model.adoc
+++ b/modules/sending-training-data-to-a-model.adoc
@@ -40,5 +40,5 @@ endif::[]
 
 ifdef::upstream[]
 .Next step
-link:{odhdocshome}/monitoring_data_science_models/configuring-bias-metrics-for-a-model_bias-monitoring[Configuring bias metrics for a model]
+link:{odhdocshome}/monitoring-data-science-models/#configuring-bias-metrics-for-a-model_bias-monitoring[Configuring bias metrics for a model]
 endif::[]

--- a/modules/sending-training-data-to-a-model.adoc
+++ b/modules/sending-training-data-to-a-model.adoc
@@ -38,7 +38,7 @@ endif::[]
 . Optional: Select a refresh interval from the list in the upper-right corner. For example, select *15 seconds*. 
 . Optional: Select a time range from the list above the graph. For example, select *5m*.
 
-ifndef::upstream[]
+ifdef::upstream[]
 .Next step
-link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/configuring-bias-metrics-for-a-model_bias-monitoring[Configuring bias metrics for a model]
+link:{odhdocshome}/monitoring_data_science_models/configuring-bias-metrics-for-a-model_bias-monitoring[Configuring bias metrics for a model]
 endif::[]

--- a/modules/viewing-a-deployed-model.adoc
+++ b/modules/viewing-a-deployed-model.adoc
@@ -26,11 +26,9 @@ For each model, the page shows details such as the model name, the project in wh
 .Verification
 * A list of previously deployed data science models is displayed on the *Deployed models* page.
 
+ifdef::upstream[]
 [role='_additional-resources']
 .Additional resources
-ifndef::upstream[]
-* To learn how to monitor your model for bias, see link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/index[Monitoring data science models].
-endif::[]
-ifdef::upstream[]
+
 * To learn how to monitor your model for bias, see link:{odhdocshome}/monitoring-data-science-models[Monitoring data science models].
 endif::[]


### PR DESCRIPTION
conditionalized references to the TrustyAI/bias metrics feature so that they only appear in the upstream documentation.

References to the TrustyAI in the notebook image are not impacted
