### PR TITLE
DS-3025 Add downstream-only RN link

### DIFF
--- a/modules/about-the-single-model-serving-platform.adoc
+++ b/modules/about-the-single-model-serving-platform.adoc
@@ -32,7 +32,6 @@ When you have installed KServe, you can use the {productname-short} dashboard to
 * A composite Caikit-TGIS runtime
 * OpenVINO Model Server
  
-
 ifdef::upstream[]
 [NOTE]
 ==== 

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -58,6 +58,10 @@ The *Deploy model* dialog opens.
 ... Select *Existing data connection*.
 ... From the *Name* list, select a data connection that you previously defined.
 ... In the *Path* field, enter the folder path that contains the model in your specified data source.
+ifdef::self-managed,cloud-service[]
++
+IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.7/html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
+endif::[]
 
 * *To use a new data connection*
 ... To define a new data connection that your model can access, select *New data connection*.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -68,6 +68,10 @@ The *Deploy model* dialog opens.
 ... In the *Region* field, enter the default region of your S3-compatible object storage account.
 ... In the *Bucket* field, enter the name of your S3-compatible object storage bucket.
 ... In the *Path* field, enter the folder path in your S3-compatible object storage that contains your data file.
+ifdef::self-managed,cloud-service[]
++
+IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.7/html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
+endif::[]
 --
 .. Click *Deploy*.
 

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -1,4 +1,6 @@
 :_module-type: PROCEDURE
+:rhoaidocshome: https://access.redhat.com/documentation/en-us/{url-productname-long}/2.7/
+:self-managed:
 
 [id="deploying-models-on-the-single-model-serving-platform_{context}"]
 = Deploying models on the single model serving platform
@@ -60,7 +62,7 @@ The *Deploy model* dialog opens.
 ... In the *Path* field, enter the folder path that contains the model in your specified data source.
 ifdef::self-managed,cloud-service[]
 +
-IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.7/html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
+IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:{rhoaidocshome}html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
 endif::[]
 
 * *To use a new data connection*
@@ -74,7 +76,7 @@ endif::[]
 ... In the *Path* field, enter the folder path in your S3-compatible object storage that contains your data file.
 ifdef::self-managed,cloud-service[]
 +
-IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_self-managed/2.7/html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
+IMPORTANT: The OpenVINO Model Server runtime has specific requirements for how you specify the model path. For more information, see known issue link:{rhoaidocshome}html-single/release_notes/index#known-issues_RHOAIENG-3025_relnotes[RHOAIENG-3025] in the {productname-short} release notes.
 endif::[]
 --
 .. Click *Deploy*.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -1,6 +1,4 @@
 :_module-type: PROCEDURE
-:rhoaidocshome: https://access.redhat.com/documentation/en-us/{url-productname-long}/2.7/
-:self-managed:
 
 [id="deploying-models-on-the-single-model-serving-platform_{context}"]
 = Deploying models on the single model serving platform


### PR DESCRIPTION
In _Deploying models on the single model serving platform_ procedure, add a downstream note pointing to known issue RHOAIENG-3025 in the downstream release notes.

Verified with local build of ODH website.