### PR TITLE
RHOAIENG-4279: Adding note to external db connection section

### DIFF
--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -55,7 +55,7 @@ If you specify incorrect data connection settings, you cannot update these setti
 +
 [NOTE]
 ====
-The external database connection is secured by default. To specify an external database connection that is not secured with TLS, you will need to set the value of `database.customExtraParams.tls` to `false` in the `DataSciencePipelinesApplication` custom resource as shown here:
+The external database connection is secured by default. To specify an external database connection that is not secured with TLS, set the value of `database.customExtraParams.tls` to `false` in the `DataSciencePipelinesApplication` custom resource as shown here:
 
 [source]
 ----
@@ -67,7 +67,7 @@ spec:
        host: mysql:3306
        ... 
 ---- 
-For more information, see link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator] 
+For more information, see link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator]. 
 ====
 
 . Click *Configure*.

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -56,7 +56,7 @@ ifdef::upstream[]
 +
 [NOTE]
 ====
-The external database connection is secured by default. To specify an external database that is unencrypted, you will need to set the value of `database.customExtraParams.tls` to `false` in the `DataSciencePipelinesApplication` custom resource as shown here:
+The external database connection is secured by default. To specify an external database connection that is not secured with TLS, you will need to set the value of `database.customExtraParams.tls` to `false` in the `DataSciencePipelinesApplication` custom resource as shown here:
 
 [source]
 ----

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -67,7 +67,6 @@ spec:
        host: mysql:3306
        ... 
 ---- 
-For more information, see link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator]. 
 ====
 
 . Click *Configure*.

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -52,7 +52,6 @@ If you specify incorrect data connection settings, you cannot update these setti
 ... In the *Username* field, enter the default user name that is connected to the database.
 ... In the *Password* field, enter the password for the default user account.
 ... In the *Database* field, enter the database name.
-ifdef::upstream[]
 +
 [NOTE]
 ====
@@ -70,7 +69,6 @@ spec:
 ---- 
 For more information, see link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator] 
 ====
-endif::[]
 
 . Click *Configure*.
 

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -52,6 +52,26 @@ If you specify incorrect data connection settings, you cannot update these setti
 ... In the *Username* field, enter the default user name that is connected to the database.
 ... In the *Password* field, enter the password for the default user account.
 ... In the *Database* field, enter the database name.
+ifdef::upstream[]
++
+[NOTE]
+====
+The external database connection is secured by default. To specify an external database that is unencrypted, you will need to set the value of `database.customExtraParams.tls` to `false` in the `DataSciencePipelinesApplication` custom resource as shown here:
+
+[source]
+----
+spec:
+  database:
+    customExtraParams: |
+      {"tls": "false"}    
+    externalDB:
+       host: mysql:3306
+       ... 
+---- 
+For more information, see link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator] 
+====
+endif::[]
+
 . Click *Configure*.
 
 .Verification


### PR DESCRIPTION
## Description
As per https://issues.redhat.com/browse/RHOAIENG-4279, 

- Need to document that an external database connection is secured by default
- Users must modify the DataSciencePiplinesApplication CR to connect to an unencrypted database.

## How Has This Been Tested?
Local build

## Preview
<img width="622" alt="Screenshot 2024-03-08 at 9 45 40 AM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/219f9919-1078-457e-9a16-9d811a1182a2">


