### PR TITLE
Adding the Authorino Operator to prerequisites for 2.x components installation

### DIFF
--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -19,7 +19,7 @@ endif::[]
 |===
 | Component | Required Operators | Catalog
 
-| ksersve
+| kserve
 | Red Hat OpenShift Serverless Operator, Red Hat OpenShift Service Mesh Operator, Red Hat Authorino Operator
 | Red Hat
 

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -20,7 +20,7 @@ endif::[]
 | Component | Required Operators | Catalog
 
 | ksersve
-| Red Hat OpenShift Serverless Operator, Red Hat OpenShift Service Mesh Operator 
+| Red Hat OpenShift Serverless Operator, Red Hat OpenShift Service Mesh Operator, Red Hat Authorino Operator
 | Red Hat
 
 | datasciencepipeline


### PR DESCRIPTION
Adding the Authorino Operator to prerequisites for 2.x components installation.

## Description
The prerequisites don't mention the Authorino operator as a prerequisite. 
Once the ODH Operator is installed, though, the user is required (a UI banner asks for this) to create a `DSCInitialization` CR, which uses the Authorino operator and would fail if it is not installed.

## How Has This Been Tested?
Just displaying the rendered page.
 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
