### PR TITLE
RHOAIENG-3024_2: Pipelines self-signed cert QE feedback updates.

### DIFF
--- a/modules/managing-certificates.adoc
+++ b/modules/managing-certificates.adoc
@@ -5,7 +5,7 @@
 
 [role='_abstract']
 After installing {productname-short}, the {productname-long} Operator creates the `odh-trusted-ca-bundle` configuration file (ConfigMap) that contains the trusted CA bundle and adds it to all new and existing non-reserved namespaces in the cluster. 
-By default, the {productname-long} Operator manages the `odh-trusted-ca-bundle` ConfigMap and automatically updates it if any changes are made to the CA bundle. You can choose to manage the `odh-trusted-ca-bundle` ConfigMap instead of allowing the (productname-long) Operator to manage it.
+By default, the {productname-long} Operator manages the `odh-trusted-ca-bundle` ConfigMap and automatically updates it if any changes are made to the CA bundle. You can choose to manage the `odh-trusted-ca-bundle` ConfigMap instead of allowing the {productname-long} Operator to manage it.
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.

--- a/modules/using-certificates-with-data-science-pipelines.adoc
+++ b/modules/using-certificates-with-data-science-pipelines.adoc
@@ -5,6 +5,8 @@
 
 ifdef::upstream[]
 If you want to use self-signed certificates, you have added them to a central Certificate Authority (CA) bundle as described in link:{odhdocshome}/installing-open-data-hub/#understanding-certificates_certs[Understanding certificates in {productname-short}].
+
+No additional configuration is necessary to use those certificates with data science pipelines.
 endif::[]
 ifdef::cloud-service[]
 If you want to use self-signed certificates, you have added them to a central Certificate Authority (CA) bundle as described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs[Working with certificates].

--- a/modules/using-certificates-with-data-science-pipelines.adoc
+++ b/modules/using-certificates-with-data-science-pipelines.adoc
@@ -96,7 +96,3 @@ pod=$(oc get pod -n ${dsProject} -l app=ds-pipeline-${dspa} --no-headers | awk '
 oc -n ${dsProject} exec $pod -- cat /dsp-custom-certs/dsp-ca.crt
 ----
 . Verify that your CA bundle is present within this file.
-
-== Creating data science pipelines with Elyra and self-signed certificates
-
-To create pipelines using a workbench that contains the Elyra extension and which uses self-signed certificates, see the link:https://access.redhat.com/solutions/7046302[Workbench workaround for executing a pipeline using Elyra in a disconnected environment] knowledgebase article.

--- a/modules/using-certificates-with-data-science-pipelines.adoc
+++ b/modules/using-certificates-with-data-science-pipelines.adoc
@@ -3,6 +3,20 @@
 [id='using-certificates-with-data-science-pipelines_{context}']
 = Using certificates with data science pipelines 
 
+ifdef::upstream[]
+If you want to use self-signed certificates, you have added them to a central Certificate Authority (CA) bundle as described in link:{odhdocshome}/installing-open-data-hub/#understanding-certificates_certs[Understanding certificates in {productname-short}].
+endif::[]
+ifdef::cloud-service[]
+If you want to use self-signed certificates, you have added them to a central Certificate Authority (CA) bundle as described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs[Working with certificates].
+
+No additional configuration is necessary to use those certificates with data science pipelines.
+endif::[]
+ifdef::self-managed[]
+If you want to use self-signed certificates, you have added them to a central Certificate Authority (CA) bundle as described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs[Working with certificates] (for disconnected environments, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/working-with-certificates_certs[Working with certificates]).
+
+No additional configuration is necessary to use those certificates with data science pipelines.
+endif::[]
+
 == Providing a CA bundle only for data science pipelines
 
 Perform the following steps to provide a Certificate Authority (CA) bundle just for data science pipelines.


### PR DESCRIPTION
This change:

- adds text advising that no additional config is required to use centrally-configured self-signed certs with data science pipelines
- corrects brackets on a productname attribute
- removes a section from 'Using certificates with data science pipelines' based on QE feedback.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
