### PR TITLE
Add upstream link, modify wording, and re-target downstream links

### DIFF
--- a/modules/deploying-models-using-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-using-the-single-model-serving-platform.adoc
@@ -1,21 +1,28 @@
 :_module-type: CONCEPT
 
 [id="deploying-models-using-the-single-model-serving-platform_{context}"]
-= Deploying models by using the single model serving platform
+= Deploying models by using the single-model serving platform
 
 [role='_abstract']
-On the single model serving platform, each model is deployed on its own model server. This helps you to deploy, monitor, scale, and maintain large models that require increased resources.
+On the single-model serving platform, each model is deployed on its own model server. This helps you to deploy, monitor, scale, and maintain large models that require increased resources.
+
+ifdef::upstream[]
+[IMPORTANT]
+====
+If you want to use the single-model serving platform to deploy a model from S3-compatible storage that uses a self-signed SSL certificate, you must install a certificate authority (CA) bundle on your OpenShift cluster. For more information, see link:{odhdocshome}/installing-open-data-hub/#understanding-certificates_certs[Understanding certificates in {productname-short}].
+====
+endif::[]
 
 ifdef::self-managed[]
 [IMPORTANT]
 ====
-If you want to use a self-signed certificate with the single-model serving platform, you must install a certificate authority (CA) bundle on your {openshift-platform} cluster. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs#adding-a-ca-bundle_certs[Adding a CA bundle] ({productname-short} Self-Managed) or link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/working-with-certificates_certs#adding-a-ca-bundle_certs[Adding a CA bundle] ({productname-short} Self-Managed in a disconnected environment). 
+If you want to use the single-model serving platform to deploy a model from S3-compatible storage that uses a self-signed SSL certificate, you must install a certificate authority (CA) bundle on your {openshift-platform} cluster. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs[Working with certificates] ({productname-short} Self-Managed) or link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/working-with-certificates_certs[Working with certificates] ({productname-short} Self-Managed in a disconnected environment).
 ====
 endif::[]
 
 ifdef::cloud-service[]
 [IMPORTANT]
 ====
-If you want to use a self-signed certificate with the single-model serving platform, you must install a certificate authority (CA) bundle on your OpenShift cluster. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs#adding-a-ca-bundle_certs[Adding a CA bundle].
+If you want to use the single-model serving platform to deploy a model from S3-compatible storage that uses a self-signed SSL certificate, you must install a certificate authority (CA) bundle on your OpenShift cluster. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/working-with-certificates_certs[Working with certificates].
 ====
 endif::[]


### PR DESCRIPTION
**Changes**

- Modify wording about using a self-signed cert to deploy from S3-compatible storage
- Add upstream link
- Re-target downstream links

Changes validated with local build.