### PR TITLE
RHOAIENG-4167: adding dashboard options as prereqs

### DIFF
--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -14,7 +14,7 @@ endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[]
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select ModelMesh as a serving platform. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the multi-model serving platform, which uses the ModelMesh component. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Settings* → *Cluster settings*.

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -14,6 +14,15 @@ endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[]
+* Your cluster administrator has set the value of the `disableModelMesh` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR).
++
+[source]
+----
+spec:
+  dashboardConfig:
+    disableModelMesh: false
+----
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Settings* → *Cluster settings*.

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -14,15 +14,7 @@ endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[]
-* Your cluster administrator has set the value of the `disableModelMesh` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR).
-+
-[source]
-----
-spec:
-  dashboardConfig:
-    disableModelMesh: false
-----
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select ModelMesh as a serving platform. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Settings* → *Cluster settings*.

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -1,10 +1,10 @@
 :_module-type: PROCEDURE
 
 [id="enabling-the-single-model-serving-platform_{context}"]
-= Enabling the single model serving platform
+= Enabling the single-model serving platform
 
 [role="_abstract"]
-When you have installed KServe, you can use the {productname-long} dashboard to enable the single model serving platform. You can also use the dashboard to enable model-serving runtimes for the platform.
+When you have installed KServe, you can use the {productname-long} dashboard to enable the single-model serving platform. You can also use the dashboard to enable model-serving runtimes for the platform.
 
 .Prerequisites
 * You have logged in to {productname-long}.
@@ -15,14 +15,14 @@ ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[] 
 * You have installed KServe.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select KServe as a serving platform. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the single-model serving platform, which uses the KServe component. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
  
 .Procedure
-. Enable the single model serving platform as follows:
+. Enable the single-model serving platform as follows:
 .. In the left menu, click *Settings* -> *Cluster settings*.
 .. Locate the *Model serving platforms* section.
-.. To enable the single model serving platform for projects, select the *Single model serving platform* checkbox.
+.. To enable the single-model serving platform for projects, select the *Single-model serving platform* checkbox.
 .. Click *Save changes*.
 . Enable pre-installed runtimes for the single-model serving platform as follows:
 .. In the left menu of the {productname-short} dashboard, click *Settings* -> *Serving runtimes*. 
@@ -34,7 +34,7 @@ The *Serving runtimes* page shows any custom runtimes that you have added, as we
 ** *TGIS Standalone ServingRuntime for KServe*
 .. Set the runtime that you want to use to *Enabled*.
 +
-The single model serving platform is now available for model deployments. 
+The single-model serving platform is now available for model deployments. 
 
 // [role="_additional-resources"]
 // .Additional resources

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -15,7 +15,17 @@ ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[] 
 * You have installed KServe.
+* Your cluster administrator has set the value of the `disableKServe` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR). 
++
+[source]
+----
+spec:
+  dashboardConfig:
+    disableKServe: false
+----
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
+ 
 .Procedure
 . Enable the single model serving platform as follows:
 .. In the left menu, click *Settings* -> *Cluster settings*.

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -15,15 +15,7 @@ ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
 endif::[] 
 * You have installed KServe.
-* Your cluster administrator has set the value of the `disableKServe` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR). 
-+
-[source]
-----
-spec:
-  dashboardConfig:
-    disableKServe: false
-----
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select KServe as a serving platform. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
  
 .Procedure

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -11,7 +11,15 @@ You can view a graph that illustrates the HTTP requests that have failed or succ
 * You have installed {productname-long}.
 
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
-
+* Your cluster administrator has set the value of the `disablePerformanceMetrics` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR).
++
+[source]
+----
+spec:
+  dashboardConfig:
+    disablePerformanceMetrics: false
+----
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 * You have logged in to {productname-short}.
 ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -11,15 +11,7 @@ You can view a graph that illustrates the HTTP requests that have failed or succ
 * You have installed {productname-long}.
 
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
-* Your cluster administrator has set the value of the `disablePerformanceMetrics` dashboard configuration to `false` in the `OdhDashboardConfig` custom resource (CR).
-+
-[source]
-----
-spec:
-  dashboardConfig:
-    disablePerformanceMetrics: false
-----
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to hide the *Endpoint Performance* tab on the *Model Serving* page. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 * You have logged in to {productname-short}.
 ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.


### PR DESCRIPTION
## Description
Adding a few dashboard configuration options as prerequisites within the serving models section, where relevant.
https://issues.redhat.com/browse/RHOAIENG-4167
## How Has This Been Tested?
Local build

# Preview
<img width="611" alt="Screenshot 2024-03-25 at 4 09 17 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/9b92fe4b-3d1a-4abf-82d9-350285e5d3cb">
<img width="602" alt="Screenshot 2024-03-25 at 4 11 00 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/3f58eb8e-42a8-4563-9e5e-651ec2dc72bd">
<img width="583" alt="Screenshot 2024-03-25 at 4 12 05 PM" src="https://github.com/opendatahub-io/opendatahub-documentation/assets/149716269/b251b9f9-0d7a-424f-afd3-b53da0554fe8">
