### PR TITLE
RHOAIENG-4508: Updating the dspa value.

### DIFF
--- a/modules/using-certificates-with-data-science-pipelines.adoc
+++ b/modules/using-certificates-with-data-science-pipelines.adoc
@@ -78,7 +78,7 @@ oc login
 . Set the `dspa` value:
 +
 ----
-dspa=pipelines-definition
+dspa=dspa
 ----
 . Set the `dsProject` value, replacing `$YOUR_DS_PROJECT` with the name of your data science project:
 +


### PR DESCRIPTION
From 2.9 the dspa metadata.name used by dashboard is "dspa". 

This change updates steps to provide a CA bundle specifically for DSP witht he new name.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
