### PR TITLE
DS-2999 - removed references to Tekton and the kfp-tekton SDK

### DIFF
--- a/assemblies/working-with-data-science-pipelines.adoc
+++ b/assemblies/working-with-data-science-pipelines.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 [role='_abstract']
 As a data scientist, you can enhance your data science projects on {productname-short} by building portable machine learning (ML) workflows with data science pipelines, using Docker containers. This enables you to standardize and automate machine learning workflows to enable you to develop and deploy your data science models.
 
-For example, the steps in a machine learning workflow might include items such as data extraction, data processing, feature extraction, model training, model validation, and model serving. Automating these activities enables your organization to develop a continuous process of retraining and updating a model based on newly received data. This can help address challenges related to building an integrated machine learning deployment and continuously operating it in production.
+For example, the steps in a machine learning workflow might include items such as data extraction, data processing, feature extraction, model training, model validation, and model serving. Automating these activities enables your organization to develop a continuous process of retraining and updating a model based on newly received data. This can help resolve challenges related to building an integrated machine learning deployment and continuously operating it in production.
 
 ifndef::upstream[]
 You can also use the Elyra JupyterLab extension to create and run data science pipelines within JupyterLab. For more information, see link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#working_with_pipelines_in_jupyterlab[Working with pipelines in JupyterLab].
@@ -23,13 +23,13 @@ A data science pipeline in {productname-short} consists of the following compone
 
 * Pipeline server: A server that is attached to your data science project and hosts your data science pipeline.
 * Pipeline: A pipeline defines the configuration of your machine learning workflow and the relationship between each component in the workflow.
-** Pipeline code: A definition of your pipeline in a Tekton-formatted YAML file.
+** Pipeline code: A definition of your pipeline in a YAML file.
 ** Pipeline graph: A graphical illustration of the steps executed in a pipeline run and the relationship between them.
 * Pipeline run: An execution of your pipeline.
 ** Triggered run: A previously executed pipeline run.
 ** Scheduled run: A pipeline run scheduled to execute at least once.
 
-This feature is based on Kubeflow Pipelines v1. Use the Kubeflow Pipelines SDK to build your data science pipeline in Python code. After you have built your pipeline, compile it into Tekton-formatted YAML code using kfp-tekton SDK (version 1.5.x only). The {productname-short} user interface enables you to track and manage pipelines and pipeline runs.
+This feature is based on Kubeflow Pipelines v1. Use the Kubeflow Pipelines SDK to build your data science pipeline in Python code. After you have built your pipeline, compile it into YAML code using the KubeFlow Pipelines compiler. The {productname-short} user interface enables you to track and manage pipelines and pipeline runs.
 
 ifdef::upstream[]
 Before you can use data science pipelines, you must install the Data Science Pipelines operator as described in link:https://github.com/opendatahub-io/data-science-pipelines-operator[Data Science Pipelines Operator].
@@ -119,6 +119,7 @@ include::modules/exporting-a-pipeline-in-jupyterlab.adoc[leveloffset=+2]
 
 [role='_additional-resources']
 == Additional resources
+* link:https://pypi.org/project/kfp/[KubeFlow Pipelines SDK]
 * link:https://www.kubeflow.org/docs/components/pipelines/v1/[Kubeflow Pipelines v1 Documentation]
 ifndef::upstream[]
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#working_with_pipelines_in_jupyterlab[Working with pipelines in JupyterLab].

--- a/modules/creating-a-runtime-configuration.adoc
+++ b/modules/creating-a-runtime-configuration.adoc
@@ -43,7 +43,6 @@ The *Add new Data Science Pipelines runtime configuration* page opens.
 You can obtain the Data Science Pipelines API endpoint from the *Data Science Pipelines* -> *Runs* page in the dashboard. Copy the relevant end point and enter it in the *Public Data Science Pipelines API Endpoint* field.
 ====
 ... Optional: In the *Data Science Pipelines User Namespace* field, enter the relevant user namespace to run pipelines.
-... From the *Data Science Pipelines engine* list, select `Tekton`.
 ... From the *Authentication Type* list, select the authentication type required to authenticate your pipeline.
 +
 [IMPORTANT]

--- a/modules/defining-a-pipeline.adoc
+++ b/modules/defining-a-pipeline.adoc
@@ -4,19 +4,16 @@
 = Defining a pipeline
 
 [role='_abstract']
-The Kubeflow Pipelines SDK enables you to define end-to-end machine learning and data pipelines. Use the Kubeflow Pipelines SDK to build your data science pipeline in Python code. After you have built your pipeline, compile it into Tekton-formatted YAML code using kfp-tekton SDK (version 1.5.x only). After defining the pipeline, you can import the YAML file to the {productname-short} dashboard to enable you to configure its execution settings. For more information about installing and using Kubeflow Pipelines SDK for Tetkon, see link:https://kubeflow.org/docs/components/pipelines/v1/sdk/pipelines-with-tekton/[Kubeflow Pipelines SDK for Tekton].
+The Kubeflow Pipelines SDK enables you to define end-to-end machine learning and data pipelines. Use the Kubeflow Pipelines SDK to build your data science pipeline in Python code. After you have built your pipeline, compile it into YAML code by using the KubeFlow Pipelines compiler. After defining the pipeline, you can import the YAML file to the {productname-short} dashboard to enable you to configure its execution settings. 
 
 ifdef::upstream[]
-You can also use the Elyra JupyterLab extension to create and run data science pipelines within JupyterLab. For more information on the Elyra JupyterLab extension, see link:https://elyra.readthedocs.io/en/stable/getting_started/overview.html[Elyra Documentation].
+You can also use the Elyra JupyterLab extension to create and run data science pipelines within JupyterLab. For more information about the Elyra JupyterLab extension, see link:https://elyra.readthedocs.io/en/stable/getting_started/overview.html[Elyra Documentation].
 endif::[]
 
 ifndef::upstream[]
-You can also use the Elyra JupyterLab extension to create and run data science pipelines within JupyterLab. For more information on creating pipelines in JupyterLab, see link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#working_with_pipelines_in_jupyterlab[Working with pipelines in JupyterLab]. For more information on the Elyra JupyterLab extension, see link:https://elyra.readthedocs.io/en/stable/getting_started/overview.html[Elyra Documentation].
+You can also use the Elyra JupyterLab extension to create and run data science pipelines within JupyterLab. For more information about creating pipelines in JupyterLab, see link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#working_with_pipelines_in_jupyterlab[Working with pipelines in JupyterLab]. For more information about the Elyra JupyterLab extension, see link:https://elyra.readthedocs.io/en/stable/getting_started/overview.html[Elyra Documentation].
 endif::[]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://github.com/kubeflow/kfp-tekton/tree/master/sdk[Kubeflow Pipelines SDK for Tekton]
-* link:https://github.com/kubeflow/kfp-tekton/tree/master/samples[KFP Tekton samples and compiler samples]
-* link:https://www.kubeflow.org/docs/components/pipelines/v1/[Kubeflow Pipelines v1 Documentation]
 * link:https://elyra.readthedocs.io/en/stable/getting_started/overview.html[Elyra Documentation]

--- a/modules/importing-a-data-science-pipeline.adoc
+++ b/modules/importing-a-data-science-pipeline.adoc
@@ -4,7 +4,7 @@
 = Importing a data science pipeline
 
 [role='_abstract']
-To help you begin working with data science pipelines in {productname-short}, you can import a YAML file containing your pipeline's code to an active pipeline server. This file contains a Kubeflow pipeline compiled with the Tekton compiler. After you have imported the pipeline to a pipeline server, you can execute the pipeline by creating a pipeline run.
+To help you begin working with data science pipelines in {productname-short}, you can import a YAML file containing your pipeline's code to an active pipeline server. This file contains a Kubeflow pipeline compiled with the KubeFlow Pipelines compiler. After you have imported the pipeline to a pipeline server, you can execute the pipeline by creating a pipeline run.
 
 .Prerequisites
 * You have installed the OpenShift Pipelines operator.

--- a/modules/updating-a-runtime-configuration.adoc
+++ b/modules/updating-a-runtime-configuration.adoc
@@ -34,7 +34,6 @@ The *Data Science Pipelines runtime configuration* page opens.
 ... In the *Data Science Pipelines API Endpoint* field, update the API endpoint of your data science pipeline, if applicable. Do not specify the pipelines namespace in this field.
 ... In the *Public Data Science Pipelines API Endpoint* field, update the API endpoint of your data science pipeline, if applicable.
 ... Optional: In the *Data Science Pipelines User Namespace* field, update the relevant user namespace to run pipelines, if applicable.
-... From the *Data Science Pipelines engine* list, select `Tekton`.
 ... From the *Authentication Type* list, select a new authentication type required to authenticate your pipeline, if applicable.
 +
 [IMPORTANT]

--- a/modules/uploading-a-pipeline-version.adoc
+++ b/modules/uploading-a-pipeline-version.adoc
@@ -4,7 +4,7 @@
 = Uploading a pipeline version
 
 [role='_abstract']
-You can upload a YAML file to an active pipeline server that contains the latest version of your pipeline. This file consists of a Kubeflow pipeline compiled with the Tekton compiler. After you upload a pipeline version to a pipeline server, you can execute it by creating a pipeline run.
+You can upload a YAML file to an active pipeline server that contains the latest version of your pipeline. This file consists of a Kubeflow pipeline compiled using the KubeFlow Pipelines compiler. After you upload a pipeline version to a pipeline server, you can execute it by creating a pipeline run.
 
 .Prerequisites
 * You have installed the OpenShift Pipelines operator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tekton is used as the backing workflow engine for DSP v1. At DSP v2, Tekton will no longer be used, and we will switch to using the Argo Workflows. The user documentation contained several references to Tekton, all of which have been removed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
The user documentation contains no further several references to Tekton, all of which have been removed. 

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
