### PR TITLE
RHOAIENG-4564: Moving model performance section under multi-model

### DIFF
--- a/assemblies/serving-small-and-medium-sized-models.adoc
+++ b/assemblies/serving-small-and-medium-sized-models.adoc
@@ -29,7 +29,7 @@ endif::[]
 
 include::modules/viewing-metrics-for-the-multi-model-serving-platform.adoc[leveloffset=+1]
 
-== Monitoring deployed models
+== Monitoring model performance
 include::modules/viewing-performance-metrics-for-model-server.adoc[leveloffset=+2]
 include::modules/viewing-http-request-metrics-for-a-deployed-model.adoc[leveloffset=+2]
 

--- a/serving-models.adoc
+++ b/serving-models.adoc
@@ -23,6 +23,3 @@ include::assemblies/serving-small-and-medium-sized-models.adoc[leveloffset=+1]
 
 :context: serving-large-models
 include::assemblies/serving-large-models.adoc[leveloffset=+1]
-
-:context: monitoring-model-performance
-include::assemblies/monitoring-model-performance.adoc[leveloffset=+1]


### PR DESCRIPTION


## Description
The _Monitoring deployed models_ chapter under **Serving small and medium-sized models**  duplicates the _Monitoring model performance_ chapter under **Serving Models**.  This commit has the following changes:

- Removed the _Monitoring model performance_ chapter under **Serving Models**.
- Changed the title of the _Monitoring deployed models_ chapter to  _Monitoring model performance_ under the **Serving small and medium-sized models** section.


## How Has This Been Tested?
Local Build


