### PR TITLE
2024a workbench image updates

### DIFF
--- a/modules/enabling-habana-gaudi-devices.adoc
+++ b/modules/enabling-habana-gaudi-devices.adoc
@@ -59,4 +59,5 @@ The *Add toleration* dialog opens.
 
 [role='_additional-resources']
 .Additional resources
-* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift]. 
+* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift]. 
+* link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift]. 

--- a/modules/habana-gaudi-integration.adoc
+++ b/modules/habana-gaudi-integration.adoc
@@ -4,9 +4,9 @@
 = Habana Gaudi integration
 
 [role='_abstract']
-To accelerate your high-performance deep learning (DL) models, you can integrate Habana Gaudi devices in {productname-short}. {productname-short} also includes the HabanaAI notebook image. This notebook image is pre-built and ready for your data scientists to use after you install or upgrade {productname-short}. 
+To accelerate your high-performance deep learning (DL) models, you can integrate Habana Gaudi devices in {productname-short}. {productname-short} also includes the HabanaAI workbench image, which is pre-built and ready for your data scientists to use after you install or upgrade {productname-short}. 
 
-Before you can enable Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and the version of the HabanaAI Operator that matches the Habana version of the HabanaAI notebook image in your deployment. This allows your data scientists to use Habana libraries and software associated with Habana Gaudi devices from their notebooks. 
+Before you can enable Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and the version of the HabanaAI Operator that matches the Habana version of the HabanaAI workbench image in your deployment. This allows your data scientists to use Habana libraries and software associated with Habana Gaudi devices from their workbench. 
 
 For more information about how to enable your OpenShift environment for Habana Gaudi devices, see link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift] and link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift].
 
@@ -19,7 +19,7 @@ You can use Habana Gaudi accelerators on {productname-short} with versions 1.10.
 For information about the supported configurations for versions 1.10 and 1.13 of the Habana Gaudi Operator, see link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.10.0.html#support-matrix-1-10-0[Support Matrix v1.10.0] and link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.13.0.html#support-matrix-1-13-0[Support Matrix v1.13.0].
 ====
 
-You can use Habana Gaudi devices in an Amazon EC2 DL1 instance on OpenShift. Therefore, your OpenShift platform must support EC2 DL1 instances. Habana Gaudi accelerators are available to your data scientists when they create a workbench, serve a model, and create a workbench. 
+You can use Habana Gaudi devices in an Amazon EC2 DL1 instance on OpenShift. Therefore, your OpenShift platform must support EC2 DL1 instances. Habana Gaudi accelerators are available to your data scientists when they create a workbench instance or serve a model.
 
 To identify the Habana Gaudi devices present in your deployment, use the `lspci` utility. For more information, see link:https://linux.die.net/man/8/lspci[lspci(8) - Linux man page].
 

--- a/modules/habana-gaudi-integration.adoc
+++ b/modules/habana-gaudi-integration.adoc
@@ -6,18 +6,20 @@
 [role='_abstract']
 To accelerate your high-performance deep learning (DL) models, you can integrate Habana Gaudi devices in {productname-short}. {productname-short} also includes the HabanaAI notebook image. This notebook image is pre-built and ready for your data scientists to use after you install or upgrade {productname-short}. 
 
-Before you can successfully enable Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and install the HabanaAI Operator. This allows your data scientists to use Habana libraries and software associated with Habana Gaudi devices from their notebooks. For more information about how to enable your OpenShift environment for Habana Gaudi devices, see link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift].
+Before you can enable Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and the version of the HabanaAI Operator that matches the Habana version of the HabanaAI notebook image in your deployment. This allows your data scientists to use Habana libraries and software associated with Habana Gaudi devices from their notebooks. 
+
+For more information about how to enable your OpenShift environment for Habana Gaudi devices, see link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift] and link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift].
 
 [IMPORTANT]
 ====
 Currently, Habana Gaudi integration is only supported in OpenShift {ocp-minimum-version}. 
 
-You can use Habana Gaudi accelerators on {productname-short} with version 1.10.0 of the Habana Gaudi Operator. For information about the supported configurations for version 1.10 of the Habana Gaudi Operator, see link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.10.0.html#support-matrix-1-10-0[Support Matrix v1.10.0].
+You can use Habana Gaudi accelerators on {productname-short} with versions 1.10.0 and 1.13.0 of the Habana Gaudi Operator. The version of the HabanaAI Operator that you install must match the Habana version of the HabanaAI workbench image in your deployment. This means that only one version of HabanaAI workbench image will work for you at a time.
 
-In addition, the version of the HabanaAI Operator that you install must match the version of the HabanaAI notebook image in your deployment.
+For information about the supported configurations for versions 1.10 and 1.13 of the Habana Gaudi Operator, see link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.10.0.html#support-matrix-1-10-0[Support Matrix v1.10.0] and link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.13.0.html#support-matrix-1-13-0[Support Matrix v1.13.0].
 ====
 
-You can use Habana Gaudi devices in an Amazon EC2 DL1 instance on OpenShift. Therefore, your OpenShift platform must support EC2 DL1 instances. Habana Gaudi accelerators are available to your data scientists when they create a workbench, serve a model, and create a notebook. 
+You can use Habana Gaudi devices in an Amazon EC2 DL1 instance on OpenShift. Therefore, your OpenShift platform must support EC2 DL1 instances. Habana Gaudi accelerators are available to your data scientists when they create a workbench, serve a model, and create a workbench. 
 
 To identify the Habana Gaudi devices present in your deployment, use the `lspci` utility. For more information, see link:https://linux.die.net/man/8/lspci[lspci(8) - Linux man page].
 
@@ -30,8 +32,10 @@ Before you can use your Habana Gaudi devices, you must enable them in your OpenS
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift]
+* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift]
+* link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift]
 * link:https://linux.die.net/man/8/lspci[lspci(8) - Linux man page] 
 * link:https://aws.amazon.com/ec2/instance-types/dl1/[Amazon EC2 DL1 Instances]
 * link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.10.0.html#support-matrix-1-10-0[Support Matrix v1.10.0]
+* link:https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix_v1.13.0.html#support-matrix-1-13-0[Support Matrix v1.13.0]
 * link:https://access.redhat.com/solutions/4870701[What version of the Kubernetes API is included with each OpenShift 4.x release?]

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -68,8 +68,12 @@ a| * CUDA 11.4
 * Notebook 6.4
 
 .3+| Minimal Python (default)
+| 2024.1 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.6
+* Notebook 6.5
 
-| 2023.2 (Recommended)
+| 2023.2
 a| * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5
@@ -85,7 +89,30 @@ a| * Python 3.8
 * Notebook 6.4
 
 .3+| PyTorch
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * CUDA 11.8
+* Python 3.9
+* PyTorch 2.2
+* JupyterLab 3.6
+* Notebook 6.5
+* TensorBoard 2.16
+* Boto3 1.34
+* Kafka-Python 2.0
+* Kfp-tekton 1.5 
+* Matplotlib 3.8
+* Numpy 1.26
+* Pandas 2.2
+* Scikit-learn 1.4
+* SciPy 1.12
+* Elyra 3.15
+* PyMongo 4.6
+* Pyodbc 5.1 
+* Codeflare-SDK 0.14
+* Sklearn-onnx 1.16
+* Psycopg 3.1 
+* MySQL Connector/Python 8.3
+
+| 2023.2
 a| * CUDA 11.8
 * Python 3.9
 * PyTorch 2.0
@@ -145,19 +172,19 @@ a| * CUDA 11.4
 a| * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5
-* Boto3 1.28
+* Boto3 1.34
 * Kafka-Python 2.0
 * Kfp-tekton 1.5
 * Matplotlib 3.8
 * Pandas 2.2
 * Numpy 1.26
-* Scikit-learn 1.3
+* Scikit-learn 1.4
 * SciPy 1.12
 * Elyra 3.15
 * PyMongo 4.6 
 * Pyodbc 5.1 
-* Codeflare-SDK 0.12
-* Sklearn-onnx 1.15
+* Codeflare-SDK 0.14
+* Sklearn-onnx 1.16
 * Psycopg 3.1 
 * MySQL Connector/Python 8.3
 
@@ -221,7 +248,7 @@ a| * CUDA 12.1
 * Matplotlib 3.8
 * Numpy 1.26
 * Pandas 2.2
-* Scikit-learn 1.3
+* Scikit-learn 1.4
 * SciPy 1.12
 * Elyra 3.15
 * PyMongo 4.6 
@@ -287,7 +314,28 @@ a| * CUDA 11.4
 * SciPy 1.6
 
 .2+| TrustyAI
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.6
+* Notebook 6.5
+* TrustyAI 0.5
+* Boto3 1.34
+* Kafka-Python 2.0
+* Kfp-tekton 1.5
+* Matplotlib 3.6
+* Numpy 1.24
+* Pandas 1.5
+* Scikit-learn 1.4
+* SciPy 1.12
+* Elyra 3.15
+* PyMongo 4.6
+* Pyodbc 5.1 
+* Codeflare-SDK 0.14
+* Sklearn-onnx 1.16
+* Psycopg 3.1 
+* MySQL Connector/Python 8.3
+
+| 2023.2
 a| * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -90,7 +90,7 @@ a| * Python 3.8
 
 .4+| PyTorch
 | 2024.1 (Recommended)
-a| * CUDA 11.8
+a| * CUDA 12.1
 * Python 3.9
 * PyTorch 2.2
 * JupyterLab 3.6
@@ -104,7 +104,7 @@ a| * CUDA 11.8
 * Pandas 2.2
 * Scikit-learn 1.4
 * SciPy 1.12
-* Elyra 3.15
+* Odh-elyra 3.16
 * PyMongo 4.6
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -180,7 +180,7 @@ a| * Python 3.9
 * Numpy 1.26
 * Scikit-learn 1.4
 * SciPy 1.12
-* Elyra 3.15
+* Odh-elyra 3.16
 * PyMongo 4.6 
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -250,7 +250,7 @@ a| * CUDA 12.1
 * Pandas 2.2
 * Scikit-learn 1.4
 * SciPy 1.12
-* Elyra 3.15
+* Odh-elyra 3.16
 * PyMongo 4.6 
 * Pyodbc 5.1
 * Codeflare-SDK 0.14
@@ -327,7 +327,7 @@ a| * Python 3.9
 * Pandas 1.5
 * Scikit-learn 1.4
 * SciPy 1.12
-* Elyra 3.15
+* Odh-elyra 3.16
 * PyMongo 4.6
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -386,7 +386,7 @@ a| * Python 3.8
 * Scikit-learn 1.2
 * SciPy 1.10
 * PyTorch 2.0
-* Elyra 3.15
+* Odh-elyra 3.16
 
 ifndef::upstream[]
 .2+| code-server (Technology Preview)

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -86,7 +86,7 @@ a| * CUDA 12.1
 * TensorBoard 2.16
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 2.7
+* Kfp 2.7
 * Matplotlib 3.8
 * Numpy 1.26
 * Pandas 2.2
@@ -147,7 +147,7 @@ a| * Python 3.9
 * Notebook 6.5
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 2.7
+* Kfp 2.7
 * Matplotlib 3.8
 * Pandas 2.2
 * Numpy 1.26
@@ -205,7 +205,7 @@ a| * CUDA 12.1
 * TensorBoard 2.15
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 2.7
+* Kfp 2.7
 * Matplotlib 3.8
 * Numpy 1.26
 * Pandas 2.2
@@ -267,7 +267,7 @@ a| * Python 3.9
 * TrustyAI 0.5
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 2.7
+* Kfp 2.7
 * Matplotlib 3.6
 * Numpy 1.24
 * Pandas 1.5
@@ -324,7 +324,7 @@ a|* Python 3.8
 * JupyterLab 3.6
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 2.7
+* Kfp 2.7
 * Matplotlib 3.7
 * Numpy 1.23
 * Pandas 2.0

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -43,7 +43,13 @@ endif::[]
 | Image name | Image version | Preinstalled packages
 
 .3+| CUDA
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * CUDA 11.8
+* Python 3.9
+* JupyterLab 3.6
+* Notebook 6.5
+
+| 2023.2
 a| * CUDA 11.8
 * Python 3.9
 * JupyterLab 3.6
@@ -135,7 +141,27 @@ a| * CUDA 11.4
 * SciPy 1.6
 
 .3+| Standard Data Science
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * Python 3.9
+* JupyterLab 3.6
+* Notebook 6.5
+* Boto3 1.28
+* Kafka-Python 2.0
+* Kfp-tekton 1.5
+* Matplotlib 3.8
+* Pandas 2.2
+* Numpy 1.26
+* Scikit-learn 1.3
+* SciPy 1.12
+* Elyra 3.15
+* PyMongo 4.6 
+* Pyodbc 5.1 
+* Codeflare-SDK 0.12
+* Sklearn-onnx 1.15
+* Psycopg 3.1 
+* MySQL Connector/Python 8.3
+
+| 2023.2
 a| * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5
@@ -182,7 +208,30 @@ a| * Python 3.8
 * SciPy 1.6
 
 .3+| TensorFlow
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * CUDA 12.1
+* Python 3.9
+* JupyterLab 3.6
+* Notebook 6.5
+* TensorFlow 2.15
+* TensorBoard 2.15
+* Boto3 1.34
+* Kafka-Python 2.0
+* Kfp-tekton 1.5
+* Matplotlib 3.8
+* Numpy 1.26
+* Pandas 2.2
+* Scikit-learn 1.3
+* SciPy 1.12
+* Elyra 3.15
+* PyMongo 4.6 
+* Pyodbc 5.1
+* Codeflare-SDK 0.14
+* Sklearn-onnx 1.16
+* Psycopg 3.1 
+* MySQL Connector/Python 8.3
+
+| 2023.2
 a| * CUDA 11.8
 * Python 3.9
 * JupyterLab 3.6
@@ -297,7 +346,22 @@ endif::[]
 ifdef::upstream[]
 | code-server
 endif::[]
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * Python 3.9
+* Boto3 1.29
+* Kafka-Python 2.0
+* Matplotlib 3.8
+* Numpy 1.26
+* Pandas 2.1
+* Plotly 5.18
+* Scikit-learn 1.3
+* Scipy 1.11
+* Sklearn-onnx 1.15
+* Ipykernel 6.26
+* (code-server plugin) Python 2023.14.0
+* (code-server plugin) Jupyter 2023.3.100
+
+| 2023.2
 a| * Python 3.9
 * Boto3 1.29
 * Kafka-Python 2.0
@@ -335,6 +399,11 @@ endif::[]
 
 ifdef::upstream[]
 | CUDA - RStudio Server
+| 2024.1 (Recommended)
+a| * Python 3.9
+* CUDA 12.1
+* R 4.3
+
 | 2023.2 (Recommended)
 a| * Python 3.9
 * CUDA 11.8
@@ -344,7 +413,13 @@ endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
 | CUDA - RStudio Server (Technology preview)
-| 2023.2 (Recommended)
+| 2024.1 (Recommended)
+a| * Python 3.9
+* CUDA 12.1
+* R 4.3
+
+| CUDA - RStudio Server (Technology preview)
+| 2023.2
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -86,7 +86,7 @@ a| * CUDA 12.1
 * TensorBoard 2.16
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 1.5 
+* Kfp-tekton 2.7
 * Matplotlib 3.8
 * Numpy 1.26
 * Pandas 2.2
@@ -147,7 +147,7 @@ a| * Python 3.9
 * Notebook 6.5
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 1.5
+* Kfp-tekton 2.7
 * Matplotlib 3.8
 * Pandas 2.2
 * Numpy 1.26
@@ -205,7 +205,7 @@ a| * CUDA 12.1
 * TensorBoard 2.15
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 1.5
+* Kfp-tekton 2.7
 * Matplotlib 3.8
 * Numpy 1.26
 * Pandas 2.2
@@ -267,7 +267,7 @@ a| * Python 3.9
 * TrustyAI 0.5
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 1.5
+* Kfp-tekton 2.7
 * Matplotlib 3.6
 * Numpy 1.24
 * Pandas 1.5
@@ -319,11 +319,12 @@ a| * Python 3.9
 
 .2+| HabanaAI
 | 2024.1 (Recommended)
-a|* Python 3.9
+a|* Python 3.8
 * Habana 1.13
 * JupyterLab 3.6
 * Boto3 1.34
 * Kafka-Python 2.0
+* Kfp-tekton 2.7
 * Matplotlib 3.7
 * Numpy 1.23
 * Pandas 2.0

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -234,7 +234,7 @@ a| * Python 3.8
 * Scikit-learn 0.24
 * SciPy 1.6
 
-.3+| TensorFlow
+.4+| TensorFlow
 | 2024.1 (Recommended)
 a| * CUDA 12.1
 * Python 3.9

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -371,8 +371,32 @@ a| * Python 3.9
 * SciPy 1.10
 * Elyra 3.15
 
-| HabanaAI
-| 2023.2 (Recommended)
+.2+| HabanaAI
+| 2024.1 (Recommended)
+a|* Python 3.9
+* Habana 1.13
+* JupyterLab 3.6
+* TensorFlow 2.13
+* Notebook 6.5
+* Boto3 1.34
+* Kafka-Python 2.0
+* Kfp-tekton 1.5
+* Matplotlib 3.8
+* Pandas 2.2
+* Numpy 1.26
+* Scikit-learn 1.4
+* SciPy 1.12
+* PyTorch 2.1
+* Odh-elyra 3.16
+* PyMongo 4.6 
+* Pyodbc 5.1 
+* Codeflare-SDK 0.14
+* Sklearn-onnx 1.16
+* Psycopg 3.1 
+* MySQL Connector/Python 8.3
+
+
+| 2023.2
 a| * Python 3.8
 * Habana 1.10
 * JupyterLab 3.5
@@ -386,7 +410,7 @@ a| * Python 3.8
 * Scikit-learn 1.2
 * SciPy 1.10
 * PyTorch 2.0
-* Odh-elyra 3.16
+* Elyra 3.15
 
 ifndef::upstream[]
 .2+| code-server (Technology Preview)

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -42,7 +42,7 @@ endif::[]
 |===
 | Image name | Image version | Preinstalled packages
 
-.3+| CUDA
+.4+| CUDA
 | 2024.1 (Recommended)
 a| * CUDA 12.1
 * Python 3.9
@@ -67,7 +67,7 @@ a| * CUDA 11.4
 * JupyterLab 3.2
 * Notebook 6.4
 
-.3+| Minimal Python (default)
+.4+| Minimal Python (default)
 | 2024.1 (Recommended)
 a| * Python 3.9
 * JupyterLab 3.6
@@ -88,7 +88,7 @@ a| * Python 3.8
 * JupyterLab 3.2
 * Notebook 6.4
 
-.3+| PyTorch
+.4+| PyTorch
 | 2024.1 (Recommended)
 a| * CUDA 11.8
 * Python 3.9
@@ -167,7 +167,7 @@ a| * CUDA 11.4
 * Scikit-learn 0.24
 * SciPy 1.6
 
-.3+| Standard Data Science
+.4+| Standard Data Science
 | 2024.1 (Recommended)
 a| * Python 3.9
 * JupyterLab 3.6
@@ -313,7 +313,7 @@ a| * CUDA 11.4
 * Scikit-learn 0.24
 * SciPy 1.6
 
-.2+| TrustyAI
+.3+| TrustyAI
 | 2024.1 (Recommended)
 a| * Python 3.9
 * JupyterLab 3.6
@@ -389,10 +389,10 @@ a| * Python 3.8
 * Elyra 3.15
 
 ifndef::upstream[]
-| code-server (Technology Preview)
+.2+| code-server (Technology Preview)
 endif::[]
 ifdef::upstream[]
-| code-server
+.2+| code-server
 endif::[]
 | 2024.1 (Recommended)
 a| * Python 3.9
@@ -426,7 +426,7 @@ a| * Python 3.9
 
 ifdef::upstream[]
 | RStudio Server
-| 2023.2 (Recommended)
+| 2023.2  (Recommended)
 a| * Python 3.9
 * R 4.3
 endif::[]
@@ -434,7 +434,7 @@ endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
 | RStudio Server (Technology preview)
-| 2023.2 (Recommended)
+| 2023.2
 a| * Python 3.9
 * R 4.3
 [IMPORTANT] 
@@ -446,13 +446,13 @@ endif::[]
 endif::[]
 
 ifdef::upstream[]
-| CUDA - RStudio Server
+.2+| CUDA - RStudio Server
 | 2024.1 (Recommended)
 a| * Python 3.9
 * CUDA 12.1
 * R 4.3
 
-| 2023.2 (Recommended)
+| 2023.2
 a| * Python 3.9
 * CUDA 11.8
 * R 4.3
@@ -460,7 +460,7 @@ endif::[]
 
 ifndef::upstream[]
 ifdef::cloud-service[]
-| CUDA - RStudio Server (Technology preview)
+.2+| CUDA - RStudio Server (Technology preview)
 | 2024.1 (Recommended)
 a| * Python 3.9
 * CUDA 12.1

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -389,7 +389,7 @@ a| * Python 3.9
 
 ifdef::upstream[]
 | RStudio Server
-| 2023.2  (Recommended)
+| 2024.1 (Recommended)
 a| * Python 3.9
 * R 4.3
 endif::[]
@@ -397,7 +397,7 @@ endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
 | RStudio Server (Technology preview)
-| 2023.2
+| 2024.1 (Recommended)
 a| * Python 3.9
 * R 4.3
 [IMPORTANT] 
@@ -409,30 +409,21 @@ endif::[]
 endif::[]
 
 ifdef::upstream[]
-.2+| CUDA - RStudio Server
+| CUDA - RStudio Server
 | 2024.1 (Recommended)
 a| * Python 3.9
 * CUDA 12.1
-* R 4.3
-
-| 2023.2
-a| * Python 3.9
-* CUDA 11.8
 * R 4.3
 endif::[]
 
 ifndef::upstream[]
 ifdef::cloud-service[]
-.2+| CUDA - RStudio Server (Technology preview)
+| CUDA - RStudio Server (Technology preview)
 | 2024.1 (Recommended)
 a| * Python 3.9
 * CUDA 12.1
 * R 4.3
 
-| 2023.2
-a| * Python 3.9
-* CUDA 11.8
-* R 4.3
 [IMPORTANT] 
 ====
 *Disclaimer:* +

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -21,10 +21,9 @@ ifndef::upstream[]
 --
 Notebook images are supported for a minimum of one year. Major updates to preconfigured notebook images occur about every six months. Therefore, two supported notebook image versions are typically available at any given time. Legacy notebook image versions, that is, not the two most recent versions, might still be available for selection. Legacy image versions include a label that indicates the image is out-of-date. 
 
-From {productname-short} 2.5, version 1.2 of notebook images is no longer supported. Notebooks that are already running on version 1.2 of an image will continue to work normally, but it is not available to select for new users or notebooks. 
+Versions 1.2 and 2023.1 of notebook images are no longer supported. Notebooks that are already running on versions 1.2 or 2023.1 of an image will continue to work normally, but they are not available to select for new users or notebooks.
 
 To use the latest package versions, {org-name} recommends that you use the most recently added notebook image.
-
 --
 endif::[]
 +
@@ -42,7 +41,7 @@ endif::[]
 |===
 | Image name | Image version | Preinstalled packages
 
-.4+| CUDA
+.3+| CUDA
 | 2024.1 (Recommended)
 a| * CUDA 12.1
 * Python 3.9
@@ -55,19 +54,13 @@ a| * CUDA 11.8
 * JupyterLab 3.6
 * Notebook 6.5
 
-| 2023.1 
+| 2023.1 (Deprecated)
 a| * CUDA 11.8
 * Python 3.9
 * JupyterLab 3.5
 * Notebook 6.5
 
-| 1.2
-a| * CUDA 11.4
-* Python 3.8
-* JupyterLab 3.2
-* Notebook 6.4
-
-.4+| Minimal Python (default)
+.3+| Minimal Python (default)
 | 2024.1 (Recommended)
 a| * Python 3.9
 * JupyterLab 3.6
@@ -78,17 +71,12 @@ a| * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5
 
-| 2023.1 
+| 2023.1 (Deprecated)
 a| * Python 3.9
 * JupyterLab 3.5
 * Notebook 6.5
 
-| 1.2
-a| * Python 3.8
-* JupyterLab 3.2
-* Notebook 6.4
-
-.4+| PyTorch
+.3+| PyTorch
 | 2024.1 (Recommended)
 a| * CUDA 12.1
 * Python 3.9
@@ -135,7 +123,7 @@ a| * CUDA 11.8
 * Psycopg 3.1 
 * MySQL Connector/Python 8.0
 
-| 2023.1
+| 2023.1 (Deprecated)
 a| * CUDA 11.8
 * Python 3.9
 * PyTorch 1.13
@@ -152,22 +140,7 @@ a| * CUDA 11.8
 * SciPy 1.10
 * Elyra 3.15
 
-| 1.2
-a| * CUDA 11.4
-* Python 3.8
-* PyTorch 1.8
-* JupyterLab 3.2
-* Notebook 6.4
-* TensorBoard 2.6
-* Boto3 1.17
-* Kafka-Python 2.0
-* Matplotlib 3.4
-* Numpy 1.19
-* Pandas 1.2
-* Scikit-learn 0.24
-* SciPy 1.6
-
-.4+| Standard Data Science
+.3+| Standard Data Science
 | 2024.1 (Recommended)
 a| * Python 3.9
 * JupyterLab 3.6
@@ -208,7 +181,7 @@ a| * Python 3.9
 * Psycopg 3.1 
 * MySQL Connector/Python 8.0
 
-| 2023.1
+| 2023.1 (Deprecated)
 a| * Python 3.9
 * JupyterLab 3.5
 * Notebook 6.5
@@ -222,19 +195,7 @@ a| * Python 3.9
 * SciPy 1.10
 * Elyra 3.15
 
-| 1.2
-a| * Python 3.8
-* JupyterLab 3.2
-* Notebook 6.4
-* Boto3 1.17
-* Kafka-Python 2.0
-* Matplotlib 3.4
-* Pandas 1.2
-* Numpy 1.19
-* Scikit-learn 0.24
-* SciPy 1.6
-
-.4+| TensorFlow
+.3+| TensorFlow
 | 2024.1 (Recommended)
 a| * CUDA 12.1
 * Python 3.9
@@ -281,7 +242,7 @@ a| * CUDA 11.8
 * Psycopg 3.1 
 * MySQL Connector/Python 8.0
 
-| 2023.1 
+| 2023.1 (Deprecated)
 a| * CUDA 11.8
 * Python 3.9
 * JupyterLab 3.5
@@ -297,21 +258,6 @@ a| * CUDA 11.8
 * Scikit-learn 1.2
 * SciPy 1.10
 * Elyra 3.15
-
-| 1.2
-a| * CUDA 11.4
-* Python 3.8
-* JupyterLab 3.2
-* Notebook 6.4
-* TensorFlow 2.7
-* TensorBoard 2.6
-* Boto3 1.17
-* Kafka-Python 2.0
-* Matplotlib 3.4
-* Numpy 1.19
-* Pandas 1.2
-* Scikit-learn 0.24
-* SciPy 1.6
 
 .3+| TrustyAI
 | 2024.1 (Recommended)
@@ -356,7 +302,7 @@ a| * Python 3.9
 * Psycopg 3.1 
 * MySQL Connector/Python 8.0
 
-| 2023.1
+| 2023.1 (Deprecated)
 a| * Python 3.9
 * JupyterLab 3.5
 * Notebook 6.5

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -44,7 +44,7 @@ endif::[]
 
 .3+| CUDA
 | 2024.1 (Recommended)
-a| * CUDA 11.8
+a| * CUDA 12.1
 * Python 3.9
 * JupyterLab 3.6
 * Notebook 6.5
@@ -406,8 +406,8 @@ a| * Python 3.9
 * Scipy 1.11
 * Sklearn-onnx 1.15
 * Ipykernel 6.26
-* (code-server plugin) Python 2023.14.0
-* (code-server plugin) Jupyter 2023.3.100
+* (code-server plugin) Python 2024.2.1
+* (code-server plugin) Jupyter 2023.9.100
 
 | 2023.2
 a| * Python 3.9
@@ -466,7 +466,6 @@ a| * Python 3.9
 * CUDA 12.1
 * R 4.3
 
-| CUDA - RStudio Server (Technology preview)
 | 2023.2
 a| * Python 3.9
 * CUDA 11.8

--- a/modules/options-for-notebook-server-environments.adoc
+++ b/modules/options-for-notebook-server-environments.adoc
@@ -92,7 +92,7 @@ a| * CUDA 12.1
 * Pandas 2.2
 * Scikit-learn 1.4
 * SciPy 1.12
-* Odh-elyra 3.16
+* ODH-Elyra 3.16
 * PyMongo 4.6
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -153,7 +153,7 @@ a| * Python 3.9
 * Numpy 1.26
 * Scikit-learn 1.4
 * SciPy 1.12
-* Odh-elyra 3.16
+* ODH-Elyra 3.16
 * PyMongo 4.6 
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -211,7 +211,7 @@ a| * CUDA 12.1
 * Pandas 2.2
 * Scikit-learn 1.4
 * SciPy 1.12
-* Odh-elyra 3.16
+* ODH-Elyra 3.16
 * PyMongo 4.6 
 * Pyodbc 5.1
 * Codeflare-SDK 0.14
@@ -273,7 +273,7 @@ a| * Python 3.9
 * Pandas 1.5
 * Scikit-learn 1.4
 * SciPy 1.12
-* Odh-elyra 3.16
+* ODH-Elyra 3.16
 * PyMongo 4.6
 * Pyodbc 5.1 
 * Codeflare-SDK 0.14
@@ -322,24 +322,16 @@ a| * Python 3.9
 a|* Python 3.9
 * Habana 1.13
 * JupyterLab 3.6
-* TensorFlow 2.13
-* Notebook 6.5
 * Boto3 1.34
 * Kafka-Python 2.0
-* Kfp-tekton 1.5
-* Matplotlib 3.8
-* Pandas 2.2
-* Numpy 1.26
-* Scikit-learn 1.4
-* SciPy 1.12
+* Matplotlib 3.7
+* Numpy 1.23
+* Pandas 2.0
+* Scikit-learn 1.3
+* Scipy 1.10
+* TensorFlow 2.13
 * PyTorch 2.1
-* Odh-elyra 3.16
-* PyMongo 4.6 
-* Pyodbc 5.1 
-* Codeflare-SDK 0.14
-* Sklearn-onnx 1.16
-* Psycopg 3.1 
-* MySQL Connector/Python 8.3
+* ODH-Elyra v3.16
 
 
 | 2023.2

--- a/modules/overview-of-accelerators.adoc
+++ b/modules/overview-of-accelerators.adoc
@@ -19,13 +19,15 @@ If you work with large data sets, you can use accelerators to optimize the perfo
 * Habana Gaudi devices (HPUs)
 ** Habana, an Intel company, provides hardware accelerators intended for deep learning workloads. You can use the Habana libraries and software associated with Habana Gaudi devices available from your notebook.
 ** Before you can successfully enable Habana Gaudi devices on {productname-short}, you must install the necessary dependencies and version 1.10 of the HabanaAI Operator. For more information about how to enable your OpenShift environment for Habana Gaudi devices, see link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift]. 
+** Before you can enable Habana Gaudi devices in {productname-short}, you must install the necessary dependencies and the version of the HabanaAI Operator that matches the Habana version of the HabanaAI workbench image in your deployment. For more information about how to enable your OpenShift environment for Habana Gaudi devices, see link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift] and link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift].
 ** You can enable Habana Gaudi devices on-premises or with AWS DL1 compute nodes on an AWS instance.
 
 Before you can use an accelerator in {productname-short}, your OpenShift instance must contain an associated accelerator profile. For accelerators that are new to your deployment, you must configure an accelerator profile for the accelerator in context. You can create an accelerator profile from the *Settings* -> *Accelerator profiles* page on the {productname-short} dashboard. If your deployment contains existing accelerators that had associated accelerator profiles already configured, an accelerator profile is automatically created after you upgrade to the latest version of {productname-short}.
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator for OpenShift]
+* link:https://docs.habana.ai/en/v1.10.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.10 for OpenShift]
+* link:https://docs.habana.ai/en/v1.13.0/Orchestration/HabanaAI_Operator/index.html[HabanaAI Operator v1.13 for OpenShift]
 * link:https://habana.ai/[Habana, an Intel Company]
 * link:https://aws.amazon.com/ec2/instance-types/dl1/[Amazon EC2 DL1 Instances]  
 * link:https://linux.die.net/man/8/lspci[lspci(8) - Linux man page]


### PR DESCRIPTION
## Description

- Adds the 2024.1 versions for workbench images.
- Removes the 1.2 versions for workbench images and labels 2023.1 as 'Deprecated'.
- Updates the Habana version to 1.13, and updates various notes and resource sections to refer to both the 1.10 and 1.13 Habana operator versions.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
