### PR TITLE
4524: Removing branch workaround note.

### DIFF
--- a/modules/configuring-your-ide.adoc
+++ b/modules/configuring-your-ide.adoc
@@ -83,11 +83,6 @@ These features provide early access to upcoming product features, enabling custo
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-[IMPORTANT]
-====
-Complete the workaround steps described in the link:https://access.redhat.com/solutions/7060469[Branch workaround for RStudio image BuildConfig definition] knowledgebase article before performing the following manual build steps.
-====
-
 To use the *RStudio Server* and *CUDA - RStudio Server* notebook images, you must first build them by creating a secret and triggering the BuildConfig, and then enable them in the {productname-short} UI by editing the `rstudio-rhel9` and `cuda-rstudio-rhel9` image streams.
 
 .Prerequisites


### PR DESCRIPTION
Removes a downstream note added in previous release, linking to a branch workaround for RStudio images. This is resolved in 2.9.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
