### PR TITLE
DS-3001-update-references-to-dsp-ui-in-wider-docs-set - changes made …

### DIFF
--- a/assemblies/working-on-data-science-projects.adoc
+++ b/assemblies/working-on-data-science-projects.adoc
@@ -14,6 +14,7 @@ As a data scientist, you can organize your data science work into a single proje
 Workbenches:: Creating a workbench allows you to add a Jupyter notebook to your project.
 Cluster storage:: For data science projects that require data retention, you can add cluster storage to the project.
 Data connections:: Adding a data connection to your project allows you to connect data inputs to your workbenches.
+Pipelines:: Standardize and automate machine learning workflows to enable you to further enhance and deploy your data science models.
 Models and model servers:: Deploy a trained data science model to serve intelligent applications. Your model is deployed with an endpoint that allows applications to send requests to the model.
 ifdef::upstream[]
 Bias metrics for models:: Creating bias metrics allows you to monitor your machine learning models for bias.
@@ -69,13 +70,13 @@ include::modules/updating-cluster-storage.adoc[leveloffset=+2]
 
 include::modules/deleting-cluster-storage-from-a-data-science-project.adoc[leveloffset=+2]
 
-//== Configuring data science pipelines
+== Configuring data science pipelines
 
-//include::modules/configuring-a-pipeline-server.adoc[leveloffset=+2]
+include::modules/configuring-a-pipeline-server.adoc[leveloffset=+2]
 
-//include::modules/defining-a-pipeline.adoc[leveloffset=+2]
+include::modules/defining-a-pipeline.adoc[leveloffset=+2]
 
-//include::modules/importing-a-data-science-pipeline.adoc[leveloffset=+2]
+include::modules/importing-a-data-science-pipeline.adoc[leveloffset=+2]
 
 == Configuring access to data science projects
 

--- a/modules/creating-a-data-science-project.adoc
+++ b/modules/creating-a-data-science-project.adoc
@@ -9,6 +9,7 @@ To start your data science work, create a data science project. Creating a proje
 * Workbenches
 * Storage for your project's cluster
 * Data connections
+* Data science pipelines
 * Model servers
 ifdef::upstream[]
 * Bias monitoring for your models

--- a/modules/deleting-a-data-science-project.adoc
+++ b/modules/deleting-a-data-science-project.adoc
@@ -28,7 +28,7 @@ The *Delete project* dialog opens.
 
 .Verification
 * The data science project that you deleted is no longer displayed on the *Data Science Projects* page.
-* Deleting a data science project deletes any associated workbenches, cluster storage, and data connections. This data is permanently deleted and is not recoverable.
+* Deleting a data science project deletes any associated workbenches, data science pipelines, cluster storage, and data connections. This data is permanently deleted and is not recoverable.
 
 //[role='_additional-resources']
 //.Additional resources

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -12,7 +12,7 @@ You can use the OpenShift web console to install specific components of Open Dat
 ifdef::upstream[]
 * If you want to use the `trustyai` component, you must enable user workload monitoring as described in link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects].
 endif::[]
-* If you want to use the `kserve`, `datasciencepipeline`, `distributedworkloads`, or `modelmesh` components, you must have already installed the following Operator or Operators for the component. For information about installing an Operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
+* If you want to use the `kserve`, `distributedworkloads`, or `modelmesh` components, you must have already installed the following Operator or Operators for the component. For information about installing an Operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
 
 .Required Operators for components
 [cols="3]
@@ -21,10 +21,6 @@ endif::[]
 
 | kserve
 | Red Hat OpenShift Serverless Operator, Red Hat OpenShift Service Mesh Operator, Red Hat Authorino Operator
-| Red Hat
-
-| datasciencepipeline
-| Red Hat OpenShift Pipelines Operator
 | Red Hat
 
 | distributedworkloads


### PR DESCRIPTION
…to ODH docs to update references to pipelines in wider docs set

<!--- Provide a general summary of your changes in the Title above -->

## Description
There were some modules in the wider ODH that need updating to mention pipelines. Also, the OpenShift Pipelines Operator is no longer required, so references to that have been removed from required operators section.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
Approval from peer reviewer from the RHOAI docs team. 

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
