### PR TITLE
DSP 2.0 QE review updates

### DIFF
--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -23,7 +23,7 @@ Version 2 of the Open Data Hub Operator represents an alpha release, accessible 
 --
 [NOTE]
 --
-After you install {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution.
+After you install {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users do not install {productname-short} 2.10.0 until you are ready to migrate to the new pipelines solution.
 --
 [IMPORTANT]
 ====

--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -31,7 +31,7 @@ Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {pr
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
 ====
 
 include::modules/installing-the-odh-operator-v2.adoc[leveloffset=+1]

--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -31,7 +31,7 @@ Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {pr
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster. Data Science Pipelines will be enabled automatically. 
 ====
 
 include::modules/installing-the-odh-operator-v2.adoc[leveloffset=+1]

--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -21,14 +21,17 @@ Installing Open Data Hub involves the following tasks:
 --
 Version 2 of the Open Data Hub Operator represents an alpha release, accessible only on the *fast* channel. Later releases will change to the *rolling* channel when the Operator is more stable.
 --
-
+[NOTE]
+--
+After you install {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution.
+--
 [IMPORTANT]
 ====
-Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
+Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows. To install {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
 
-If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.10.0 with DSP will fail.
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
 
-To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
 ====
 
 include::modules/installing-the-odh-operator-v2.adoc[leveloffset=+1]

--- a/assemblies/upgrading-odh-v2.adoc
+++ b/assemblies/upgrading-odh-v2.adoc
@@ -14,13 +14,13 @@ For information about installing the Open Hub Operator, see link:{odhdocshome}/i
 
 [NOTE]
 --
-After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution.
+After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users do not install {productname-short} 2.10.0 until you are ready to migrate to the new pipelines solution.
 --
 [IMPORTANT]
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an Argo Workflows installation that is not installed by DSP exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 ====
 
 Note that Open Data Hub Operator versions 2.2 and later use an upgraded API version for a DataScienceCluster instance, resulting in the following differences.

--- a/assemblies/upgrading-odh-v2.adoc
+++ b/assemblies/upgrading-odh-v2.adoc
@@ -20,7 +20,7 @@ After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 ====
 
 Note that Open Data Hub Operator versions 2.2 and later use an upgraded API version for a DataScienceCluster instance, resulting in the following differences.

--- a/assemblies/upgrading-odh-v2.adoc
+++ b/assemblies/upgrading-odh-v2.adoc
@@ -20,7 +20,7 @@ After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
 ====
 
 Note that Open Data Hub Operator versions 2.2 and later use an upgraded API version for a DataScienceCluster instance, resulting in the following differences.

--- a/assemblies/upgrading-odh-v2.adoc
+++ b/assemblies/upgrading-odh-v2.adoc
@@ -16,9 +16,9 @@ For information about installing the Open Hub Operator, see link:{odhdocshome}/i
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
-If there is an existing installation of Argo workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.10.0 with DSP will fail.
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.10.0 with DSP will fail.
 
-To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo workflows exists on your cluster.
+To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
 ====
 
 Note that Open Data Hub Operator versions 2.2 and later use an upgraded API version for a DataScienceCluster instance, resulting in the following differences.

--- a/assemblies/upgrading-odh-v2.adoc
+++ b/assemblies/upgrading-odh-v2.adoc
@@ -12,13 +12,15 @@ You can upgrade the Open Data Hub Operator from version 2.0 or 2.1 to version 2.
 For information about upgrading from version 1 to version 2.2 or later, see link:{odhdocshome}/upgrading_open_data_hub/#upgrading-the-odh-operator-v1_upgradev1[Upgrading Open Data Hub version 1 to version 2].
 For information about installing the Open Hub Operator, see link:{odhdocshome}/installing_open_data_hub/#installing-the-odh-operator-v2_installv2[Installing Open Data Hub Operator version 2].
 
+[NOTE]
+--
+After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution.
+--
 [IMPORTANT]
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
-If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.10.0 with DSP will fail.
-
-To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
 ====
 
 Note that Open Data Hub Operator versions 2.2 and later use an upgraded API version for a DataScienceCluster instance, resulting in the following differences.

--- a/modules/configuring-a-pipeline-server.adoc
+++ b/modules/configuring-a-pipeline-server.adoc
@@ -8,8 +8,31 @@ Before you can successfully create a pipeline in {productname-short}, you must c
 
 [NOTE]
 ====
-After the pipeline server is created, the `/metadata` and `/artifacts` folders are automatically created in the default `root` folder. Therefore, you are not required to specify any storage directories when configuring a data connection for your pipeline server.
+You are not required to specify any storage directories when configuring a data connection for your pipeline server. When you import a pipeline, the `/pipelines` folder is created in the `root` folder of the bucket, containing a YAML file for the pipeline. If you upload a new version of the same pipeline, a new YAML file with a different ID is added to the `/pipelines` folder.  
+
+When you run a pipeline, the artifacts are stored in the `/pipeline-name` folder in the `root` folder of the bucket.
 ====
+
+ifdef::upstream[]
+[IMPORTANT]
+====
+If you use an external MySQL database and upgrade to {productname-short} 2.10.0, the database is migrated to DSP 2.0 format, making it incompatible with earlier versions of {productname-short}.
+====
+endif::[]
+ifndef::upstream[]
+ifdef::self-managed[]
+[IMPORTANT]
+====
+If you use an external MySQL database and upgrade to {productname-short} 2.9, the database is migrated to DSP 2.0 format, making it incompatible with earlier versions of {productname-short}.
+====
+endif::[]
+ifdef::cloud-service[]
+[IMPORTANT]
+====
+If you use an external MySQL database and upgrade to {productname-short} with DSP 2.0, the database is migrated to DSP 2.0 format, making it incompatible with earlier versions of {productname-short}.
+====
+endif::[]
+endif::[]
 
 .Prerequisites
 * You have installed the OpenShift Pipelines Operator.
@@ -22,6 +45,7 @@ ifdef::upstream[]
 endif::[]
 * You have created a data science project that you can add a pipeline server to.
 * You have an existing S3-compatible object storage bucket and you have configured write access to your S3 bucket on your storage account.
+* If you are configuring a pipeline server with an external MySQL database, your database must use MySQL version 5.x.
 
 .Procedure
 . From the {productname-short} dashboard, click *Data Science Projects*.

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -26,17 +26,18 @@ The `PipelineConf` class is deprecated, and there is no KFP 2.0 equivalent.
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
 ifdef::upstream[]
-To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
+To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that your cluster does not have an existing installation of Argo Workflows that is not installed by {productname-short}.
 endif::[]
 ifndef::upstream[]
 ifdef::self-managed[]
-To install or upgrade to {productname-short} 2.9 with DSP, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
+To install or upgrade to {productname-short} 2.9 with DSP, ensure that your cluster does not have an existing installation of Argo Workflows that is not installed by {productname-short}.
 endif::[]
 ifdef::cloud-service[]
-To install or upgrade to {productname-short} with DSP 2.0, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
+To install or upgrade to {productname-short} with DSP 2.0, ensure that your cluster does not have an existing installation of Argo Workflows that is not installed by {productname-short}.
 endif::[]
 endif::[]
 
+Remove the custom resource definitions (CRDs) for all Argo Workflows resources that are not created by {productname-short}.
 Argo Workflows resources that are created by {productname-short} have the following labels in the OpenShift Console under *Administration > CustomResourceDefinitions*, in the `argoproj.io` group:
 [source]
 ----
@@ -81,12 +82,12 @@ endif::[]
 ifdef::upstream[]
 [IMPORTANT]
 ====
-After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution. 
+After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users do not upgrade to {productname-short} 2.10.0 until you are ready to migrate to the new pipelines solution. 
 ====
 
 To upgrade to {productname-short} 2.10.0 with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an Argo Workflows installation that is not installed by DSP exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
@@ -161,7 +162,7 @@ Before removing the OpenShift Pipelines Operator, ensure that migration of your 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://pypi.org/project/kfp/[PyPI:]
+* link:https://pypi.org/project/kfp/[PyPI: kfp^]
 * link:https://kubeflow-pipelines.readthedocs.io[Kubeflow Pipelines SDK API Reference].
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#configuring-a-pipeline-server_ds-pipelines[Configuring a pipeline server]

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -16,19 +16,24 @@ Data science pipelines in {productname-short} are now based on link:https://www.
 endif::[]
 endif::[]
 
+[NOTE]
+====
+The `PipelineConf` class is deprecated, and there is no KFP 2.0 equivalent.
+====
+
 [IMPORTANT]
 ====
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
 ifdef::upstream[]
-To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
+To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
 endif::[]
 ifndef::upstream[]
 ifdef::self-managed[]
-To install or upgrade to {productname-short} 2.9 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
+To install or upgrade to {productname-short} 2.9 with DSP, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
 endif::[]
 ifdef::cloud-service[]
-To install or upgrade to {productname-short} with DSP 2.0, ensure that no separate installation of Argo Workflows exists on your cluster.
+To install or upgrade to {productname-short} with DSP 2.0, ensure that no installation of Argo Workflows that is not installed by {productname-short} exists on your cluster.
 endif::[]
 endif::[]
 
@@ -41,11 +46,6 @@ Argo Workflows resources that are created by {productname-short} have the follow
 ----
 ====
 
-[NOTE]
-====
-The `PipelineConf` class is deprecated, and there is no KFP 2.0 equivalent.
-====
-
 == Installing {productname-short} with DSP 2.0
 
 ifdef::upstream[]
@@ -53,7 +53,7 @@ To install {productname-short} 2.10.0, ensure that there is no installation of A
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster. Data Science Pipelines will be enabled automatically. 
 endif::[]
 
 ifndef::upstream[]
@@ -63,7 +63,7 @@ To install {productname-short} with DSP 2.0, ensure that there is no installatio
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short}.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster. Data Science Pipelines will be enabled automatically. 
 endif::[]
 
 //RHOAI self-managed & disconnected
@@ -72,7 +72,7 @@ To install {productname-short} 2.9, ensure that there is no installation of Argo
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.9 or later.
 
-To enable DSP, remove the separate installation of Argo Workflows from your cluster and restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster. Data Science Pipelines will be enabled automatically. 
 endif::[]
 endif::[]
 
@@ -98,7 +98,7 @@ After you upgrade to {productname-short} with DSP 2.0, pipelines created with DS
 
 To upgrade {productname-short}, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_cloud_service/index[Upgrading {productname-short } AI Cloud Service].
 
-If you upgrade to {productname-short} with DSP 2.0 enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
+If you upgrade to {productname-short} with DSP 2.0 enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows from your cluster. The component upgrade will complete automatically.
 endif::[]
 
 //RHOAI self-managed & disconnected
@@ -110,7 +110,7 @@ After you upgrade to {productname-short} 2.9 or later, pipelines created with DS
 
 To upgrade to {productname-short} 2.9, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed/index[Upgrading {productname-short} Self-Managed], or for disconnected environments, link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed_in_a_disconnected_environment/index[Upgrading {productname-long} in a disconnected environment].
 
-If you upgrade to {productname-short} 2.9 or later with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
+If you upgrade to {productname-short} 2.9 or later with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows from your cluster.  The component upgrade will complete automatically. 
 endif::[]
 endif::[]
 
@@ -127,6 +127,11 @@ ifdef::cloud-service[]
 endif::[]
 . Configure a new pipeline server. 
 . Update and recompile your DSP 1.0 pipelines as described in link:https://www.kubeflow.org/docs/components/pipelines/v2/migration/[Migrate from KFP SDK v1: v1 to v2 migration instructions and breaking changes].
++
+[NOTE]
+----
+DSP 2.0 does not use the `kfp-tekton` library. In most cases, you can replace usage of `kfp-tekton` with the `kfp` library.
+----
 . Import your updated pipelines to your new DSP 2.0-based data science project.
 . (Optional) Remove your DSP 1.0 pipeline server.
 
@@ -156,6 +161,7 @@ Before removing the OpenShift Pipelines Operator, ensure that migration of your 
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://pypi.org/project/kfp/[PyPI:]
 * link:https://kubeflow-pipelines.readthedocs.io[Kubeflow Pipelines SDK API Reference].
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#configuring-a-pipeline-server_ds-pipelines[Configuring a pipeline server]

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -86,8 +86,7 @@ After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 
 
 To upgrade to {productname-short} 2.10.0 with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
-
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 ifndef::upstream[]
 ifdef::cloud-service[]
 //RHOAI CS

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -87,6 +87,7 @@ After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 
 To upgrade to {productname-short} 2.10.0 with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
 If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
+endif::[]
 ifndef::upstream[]
 ifdef::cloud-service[]
 //RHOAI CS

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -33,7 +33,6 @@ endif::[]
 endif::[]
 
 Argo Workflows resources that are created by {productname-short} have the following labels in the OpenShift Console under *Administration > CustomResourceDefinitions*, in the `argoproj.io` group:
-+
 [source]
 ----
  labels:

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -31,6 +31,15 @@ ifdef::cloud-service[]
 To install or upgrade to {productname-short} with DSP 2.0, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 endif::[]
+
+Argo Workflows resources that are created by {productname-short} have the following labels in the OpenShift Console under *Administration > CustomResourceDefinitions*, in the `argoproj.io` group:
++
+[source]
+----
+ labels:
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.opendatahub.io/data-science-pipelines-operator: 'true'
+----
 ====
 
 [NOTE]
@@ -45,7 +54,7 @@ To install {productname-short} 2.10.0, ensure that there is no installation of A
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
 endif::[]
 
 ifndef::upstream[]
@@ -55,7 +64,7 @@ To install {productname-short} with DSP 2.0, ensure that there is no installatio
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short}.
 
-To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
 endif::[]
 
 //RHOAI self-managed & disconnected
@@ -64,7 +73,7 @@ To install {productname-short} 2.9, ensure that there is no installation of Argo
 
 If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.9 or later.
 
-To enable DSP, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
+To enable DSP, remove the separate installation of Argo Workflows from your cluster and restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
 endif::[]
 endif::[]
 
@@ -78,8 +87,7 @@ After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 
 
 To upgrade to {productname-short} 2.10.0 with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
-If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
-endif::[]
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `opendatahub-operator-controller-manager-XXXXXX` pod in the `opendatahub` namespace.
 
 ifndef::upstream[]
 ifdef::cloud-service[]
@@ -91,7 +99,7 @@ After you upgrade to {productname-short} with DSP 2.0, pipelines created with DS
 
 To upgrade {productname-short}, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_cloud_service/index[Upgrading {productname-short } AI Cloud Service].
 
-If you upgrade to {productname-short} with DSP 2.0 enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
+If you upgrade to {productname-short} with DSP 2.0 enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
 endif::[]
 
 //RHOAI self-managed & disconnected
@@ -103,7 +111,7 @@ After you upgrade to {productname-short} 2.9 or later, pipelines created with DS
 
 To upgrade to {productname-short} 2.9, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed/index[Upgrading {productname-short} Self-Managed], or for disconnected environments, link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed_in_a_disconnected_environment/index[Upgrading {productname-long} in a disconnected environment].
 
-If you upgrade to {productname-short} 2.9 or later with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
+If you upgrade to {productname-short} 2.9 or later with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `rhods-operator` pod in the `redhat-ods-operator` namespace. 
 endif::[]
 endif::[]
 

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -26,12 +26,12 @@ To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no sep
 endif::[]
 ifndef::upstream[]
 ifdef::self-managed[]
-If there is an existing installation of Argo workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.9 with DSP will fail.
-To install or upgrade to {productname-short} 2.9 with DSP, ensure that no separate installation of Argo workflows exists on your cluster.
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.9 with DSP will fail.
+To install or upgrade to {productname-short} 2.9 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 ifdef::cloud-service[]
-If there is an existing installation of Argo workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} with DSP 2.0 will fail.
-To install or upgrade to {productname-short} with DSP 2.0, ensure that no separate installation of Argo workflows exists on your cluster.
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} with DSP 2.0 will fail.
+To install or upgrade to {productname-short} with DSP 2.0, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 endif::[]
 ====

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -14,6 +14,7 @@ endif::[]
 ifdef::cloud-service[]
 Data science pipelines in {productname-short} are now based on link:https://www.kubeflow.org/docs/components/pipelines/v2/[KubeFlow Pipelines (KFP) version 2.0]. DSP 2.0 is enabled and deployed by default in {productname-short}.
 endif::[]
+endif::[]
 
 [IMPORTANT]
 ====
@@ -111,7 +112,12 @@ ifndef::upstream[]
 
 {productname-short} does not automatically migrate existing DSP 1.0 instances to 2.0. To use existing pipelines with DSP 2.0, you must manually migrate them.
 
+ifdef::self-managed[]
 . On {productname-short} 2.9, create a new data science project.
+endif::[]
+ifdef::cloud-service[]
+. On {productname-short} with DSP 2.0, create a new data science project.
+endif::[]
 . Configure a new pipeline server. 
 . Update and recompile your DSP 1.0 pipelines as described in link:https://www.kubeflow.org/docs/components/pipelines/v2/migration/[Migrate from KFP SDK v1: v1 to v2 migration instructions and breaking changes].
 . Import your updated pipelines to your new DSP 2.0-based data science project.
@@ -150,5 +156,3 @@ Before removing the OpenShift Pipelines Operator, ensure that migration of your 
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#deleting-a-pipeline-server_ds-pipelines[Deleting a pipeline server]
 
 endif::[]
-
-

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -20,55 +20,89 @@ endif::[]
 Data Science Pipelines (DSP) 2.0 contains an installation of Argo Workflows. {productname-short} does not support direct customer usage of this installation of Argo Workflows.
 
 ifdef::upstream[]
-If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.10.0 with DSP will fail.
-
 To install or upgrade to {productname-short} 2.10.0 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 ifndef::upstream[]
 ifdef::self-managed[]
-If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} 2.9 with DSP will fail.
 To install or upgrade to {productname-short} 2.9 with DSP, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 ifdef::cloud-service[]
-If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, installations of and upgrades to {productname-short} with DSP 2.0 will fail.
 To install or upgrade to {productname-short} with DSP 2.0, ensure that no separate installation of Argo Workflows exists on your cluster.
 endif::[]
 endif::[]
+====
+
+[NOTE]
+====
+The `PipelineConf` class is deprecated, and there is no KFP 2.0 equivalent.
 ====
 
 == Installing {productname-short} with DSP 2.0
 
 ifdef::upstream[]
 To install {productname-short} 2.10.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the installation steps described in link:{odhdocshome}/installing-open-data-hub/[Installing {productname-short}].
+
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.10.0 with DSP.
+
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
 endif::[]
 
 ifndef::upstream[]
 ifdef::cloud-service[]
 //RHOAI CS
 To install {productname-short} with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the installation steps described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_openshift_ai_cloud_service/index[Installing and uninstalling OpenShift AI Cloud Service].
+
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short}.
+
+To enable data science pipelines, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
 endif::[]
 
 //RHOAI self-managed & disconnected
 ifdef::self-managed[]
 To install {productname-short} 2.9, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the installation steps described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_openshift_ai_self-managed/index[Installing and uninstalling OpenShift AI Self-Managed], or for disconnected environments, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_openshift_ai_self-managed_in_a_disconnected_environment[Installing and uninstalling {productname-long} in a disconnected environment].
+
+If there is an existing installation of Argo Workflows that is not installed by DSP on your cluster, DSP will be disabled after you install {productname-short} 2.9 or later.
+
+To enable DSP, remove the separate installation of Argo Workflows from your cluster and restart the `operator` pod.
 endif::[]
 endif::[]
 
 == Upgrading to DSP 2.0
 
 ifdef::upstream[]
+[IMPORTANT]
+====
+After you upgrade to {productname-short} 2.10.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on an earlier version of {productname-short} until you are ready to migrate to the new pipelines solution. 
+====
+
 To upgrade to {productname-short} 2.10.0 with DSP 2.0, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
+
+If you upgrade to {productname-short} 2.10.0 with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
 endif::[]
 
 ifndef::upstream[]
 ifdef::cloud-service[]
 //RHOAI CS
+[IMPORTANT]
+====
+After you upgrade to {productname-short} with DSP 2.0, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users do not upgrade to {productname-short} with DSP 2.0 until you are ready to migrate to the new pipelines solution. 
+====
+
 To upgrade {productname-short}, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_cloud_service/index[Upgrading {productname-short } AI Cloud Service].
+
+If you upgrade to {productname-short} with DSP 2.0 enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
 endif::[]
 
 //RHOAI self-managed & disconnected
 ifdef::self-managed[]
+[IMPORTANT]
+====
+After you upgrade to {productname-short} 2.9 or later, pipelines created with DSP 1.0 will continue to run, but will be inaccessible from the {productname-short} dashboard. We recommend that current DSP users stay on {productname-short} 2.8 until you are ready to migrate to the new pipelines solution. 
+====
+
 To upgrade to {productname-short} 2.9, ensure that there is no installation of Argo Workflows that is not installed by DSP on your cluster, and follow the upgrade steps described in link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed/index[Upgrading {productname-short} Self-Managed], or for disconnected environments, link:{rhoaidocshome}{default-format-url}/upgrading_openshift_ai_self-managed_in_a_disconnected_environment/index[Upgrading {productname-long} in a disconnected environment].
+
+If you upgrade to {productname-short} 2.9 or later with DSP enabled and an existing Argo Workflows installation that is not installed by DSP on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable DSP or remove the separate installation of Argo Workflows, and then restart the `operator` pod.
 endif::[]
 endif::[]
 
@@ -116,4 +150,5 @@ Before removing the OpenShift Pipelines Operator, ensure that migration of your 
 * link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/working-with-data-science-pipelines_ds-pipelines#deleting-a-pipeline-server_ds-pipelines[Deleting a pipeline server]
 
 endif::[]
+
 


### PR DESCRIPTION
- Updates the Argo Workflows installation and upgrade warnings to include specific info on the upgrade and install scenarios/resolution steps
- Adds warning about DSP 1.0 pipelines being inaccessible from the dashboard with DSP 2.0


- Adds prereq on MySQL DB version to _Configuring a pipeline server_
- Adds a note/warning to _Configuring a pipeline server_ about external MySQL DBs being migrated to DSP 2.0 format and becoming incompatible with earlier product versions.
- Updates note on storage directories in _Configuring a pipeline server_

- Adds a note to _Enabling DSP 2.0_ about the `PipelineConf` class being deprecated with no KFP 2.0 equivalent
- Adds info on how to identify Argo resources that were created by the product.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
