### PR TITLE
ENG-5155: Removes Tech Preview references for distributed workloads

### DIFF
--- a/assemblies/working-with-distributed-workloads.adoc
+++ b/assemblies/working-with-distributed-workloads.adoc
@@ -11,23 +11,6 @@ ifdef::context[:parent-context: {context}]
 To train complex machine-learning models or process data more quickly, data scientists can use the distributed workloads feature to run their jobs on multiple OpenShift worker nodes in parallel.
 This approach significantly reduces the task completion time, and enables the use of larger datasets and more complex models.
 
-ifndef::upstream[]
-[IMPORTANT]
-====
-ifdef::self-managed[]
-The distributed workloads feature is currently available in {productname-long} {vernum} as a Technology Preview feature.
-endif::[]
-ifdef::cloud-service[]
-The distributed workloads feature is currently available in {productname-long} as a Technology Preview feature.
-endif::[]
-Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
-Red{nbsp}Hat does not recommend using them in production.
-These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::[]
-
 
 include::modules/overview-of-distributed-workloads.adoc[leveloffset=+1]
 


### PR DESCRIPTION
ENG-5155: Removes Tech Preview references for distributed workloads

Setting as Draft because this PR will not be necessary if PR 273 is merged (removes the affected file).