### PR TITLE
odh-7730 add two modules to managing resources guide

### DIFF
--- a/assemblies/managing-applications-that-show-in-the-dashboard.adoc
+++ b/assemblies/managing-applications-that-show-in-the-dashboard.adoc
@@ -14,11 +14,12 @@ include::../_artifacts/document-attributes-global.adoc[]
 endif::preview[]
 
 
-
 include::modules/adding-an-application-to-the-dashboard.adoc[leveloffset=+1]
 include::modules/preventing-users-from-adding-applications-to-the-dashboard.adoc[leveloffset=+1]
+include::modules/disabling-applications-connected.adoc[leveloffset=+1]
 include::modules/showing-hiding-information-about-enabled-applications.adoc[leveloffset=+1]
 include::modules/hiding-the-default-jupyter-application.adoc[leveloffset=+1]
+include::modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc[leveloffset=+1]
 
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION

I am reorganizing sections of the documentation.

Need to move these two modules to the Managing resources guide because they are relevant to admin users:

Disabling applications that are connected to OpenShift AI
Troubleshooting common problems in Jupyter

