### PR TITLE
DS-3881 - removed note from Running a Pipeline in JupyterLab module s…

### DIFF
--- a/modules/running-a-pipeline-in-jupyterlab.adoc
+++ b/modules/running-a-pipeline-in-jupyterlab.adoc
@@ -26,11 +26,6 @@ endif::[]
 . In the Pipeline Editor user interface, click *Run Pipeline* (image:images/jupyterlab-run-pipeline-button.png[The Runtimes icon]).
 +
 The *Run Pipeline* dialog appears. The *Pipeline Name* field is automatically populated with the pipeline file name.
-+
-[IMPORTANT]
-====
-You must enter a unique pipeline name. The pipeline name that you enter must not match the name of any previously executed pipelines. 
-====
 . Define the settings for your pipeline run.
 .. From the *Runtime Configuration* list, select the relevant runtime configuration to run your pipeline.
 .. Optional: Configure your pipeline parameters, if applicable. If your pipeline contains nodes that reference pipeline parameters, you can change the default parameter values. If a parameter is required and has no default value, you must enter a value.


### PR DESCRIPTION
…tating that pipeline names should be unique - this is no longer mandatory

<!--- Provide a general summary of your changes in the Title above -->

## Description
When a pipeline is run from JupyterLab, a new version of the pipeline is then created. Therefore, there is no need to change the pipeline name each time. A note has been removed which stated that the pipeline name must be unique each time it is run.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
