### PR TITLE
Added 'data science project' para to prerequisites x5 docs

### DIFF
--- a/modules/configuring-quota-management-for-distributed-workloads.adoc
+++ b/modules/configuring-quota-management-for-distributed-workloads.adoc
@@ -29,7 +29,7 @@ ifdef::upstream[]
 endif::[]
 
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. 
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. 
 For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
 ifdef::upstream[]

--- a/modules/configuring-quota-management-for-distributed-workloads.adoc
+++ b/modules/configuring-quota-management-for-distributed-workloads.adoc
@@ -23,9 +23,14 @@ endif::[]
 
 ifndef::upstream[]
 * You have enabled the required distributed workloads components as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-the-distributed-workloads-components_distributed-workloads[Configuring the distributed workloads components].
+
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
+
 ifdef::upstream[]
 * You have enabled the required distributed workloads components as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-the-distributed-workloads-components_distributed-workloads[Configuring the distributed workloads components].
+
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 * You have sufficient resources. In addition to the base {productname-short} resources, you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.

--- a/modules/configuring-quota-management-for-distributed-workloads.adoc
+++ b/modules/configuring-quota-management-for-distributed-workloads.adoc
@@ -23,18 +23,21 @@ endif::[]
 
 ifndef::upstream[]
 * You have enabled the required distributed workloads components as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-the-distributed-workloads-components_distributed-workloads[Configuring the distributed workloads components].
-
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
-
 ifdef::upstream[]
 * You have enabled the required distributed workloads components as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-the-distributed-workloads-components_distributed-workloads[Configuring the distributed workloads components].
+endif::[]
 
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. 
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. 
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 * You have sufficient resources. In addition to the base {productname-short} resources, you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
-
 * The resources are physically available in the cluster.
 +
 [NOTE]

--- a/modules/configuring-the-distributed-workloads-components.adoc
+++ b/modules/configuring-the-distributed-workloads-components.adoc
@@ -28,7 +28,7 @@ ifdef::upstream[]
 endif::[]
 
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
 For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
 ifdef::upstream[]

--- a/modules/configuring-the-distributed-workloads-components.adoc
+++ b/modules/configuring-the-distributed-workloads-components.adoc
@@ -20,18 +20,20 @@ endif::[]
 ifdef::cloud-service[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install[Installing and deploying {productname-short}], you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
 endif::[]
-
 ifdef::self-managed[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install[Installing and deploying {productname-short}] (for disconnected environments, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/deploying-openshift-ai-in-a-disconnected-environment_install[Deploying {productname-short} in a disconnected environment]), you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
 endif::[]
-
-ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
-endif::[]
 ifdef::upstream[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{odhdocshome}/installing-open-data-hub/#installing-the-odh-operator-v2_installv2[Installing the {productname-short} Operator version 2], you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
+endif::[]
 
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 * You have access to a Ray cluster image. For information about how to create a Ray cluster, see the link:https://docs.ray.io/en/latest/cluster/getting-started.html[Ray Clusters documentation].

--- a/modules/configuring-the-distributed-workloads-components.adoc
+++ b/modules/configuring-the-distributed-workloads-components.adoc
@@ -20,11 +20,18 @@ endif::[]
 ifdef::cloud-service[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install[Installing and deploying {productname-short}], you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
 endif::[]
+
 ifdef::self-managed[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install[Installing and deploying {productname-short}] (for disconnected environments, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/deploying-openshift-ai-in-a-disconnected-environment_install[Deploying {productname-short} in a disconnected environment]), you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
 endif::[]
+
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
 ifdef::upstream[]
 * You have sufficient resources. In addition to the minimum {productname-short} resources described in link:{odhdocshome}/installing-open-data-hub/#installing-the-odh-operator-v2_installv2[Installing the {productname-short} Operator version 2], you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
+
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 * You have access to a Ray cluster image. For information about how to create a Ray cluster, see the link:https://docs.ray.io/en/latest/cluster/getting-started.html[Ray Clusters documentation].

--- a/modules/running-distributed-data-science-workloads-disconnected-env.adoc
+++ b/modules/running-distributed-data-science-workloads-disconnected-env.adoc
@@ -17,12 +17,13 @@ To run a distributed data science workload in a disconnected environment, you mu
 ** The Python dependencies for the workload, either in a Ray image or in your own Python Package Index (PyPI) server that is available from the disconnected cluster
 * You have logged in to {productname-long}.
 
-ifdef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
-endif::[]
-
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 .Procedure

--- a/modules/running-distributed-data-science-workloads-disconnected-env.adoc
+++ b/modules/running-distributed-data-science-workloads-disconnected-env.adoc
@@ -18,7 +18,7 @@ To run a distributed data science workload in a disconnected environment, you mu
 * You have logged in to {productname-long}.
 
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
 For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
 ifdef::upstream[]

--- a/modules/running-distributed-data-science-workloads-disconnected-env.adoc
+++ b/modules/running-distributed-data-science-workloads-disconnected-env.adoc
@@ -16,7 +16,14 @@ To run a distributed data science workload in a disconnected environment, you mu
 ** The data sets and models to be used by the workload
 ** The Python dependencies for the workload, either in a Ray image or in your own Python Package Index (PyPI) server that is available from the disconnected cluster
 * You have logged in to {productname-long}.
-* You have created a data science project.
+
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
+endif::[]
+
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
 
 .Procedure
 . Configure the disconnected data science cluster to run distributed workloads as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].

--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -56,7 +56,7 @@ If you do not create a default local queue, you must specify a local queue in ea
 endif::[]
 
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
 For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
 ifdef::upstream[]

--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -55,9 +55,16 @@ If you do not create a default local queue, you must specify a local queue in ea
 ====
 endif::[]
 
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
+endif::[]
+
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+
 * You have access to S3-compatible object storage.
 * You have logged in to {productname-long}.
-* You have created a data science project.
 
 .Procedure
 ifndef::upstream[]

--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -55,12 +55,13 @@ If you do not create a default local queue, you must specify a local queue in ea
 ====
 endif::[]
 
-ifdef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
-endif::[]
-
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
 * You have access to S3-compatible object storage.

--- a/modules/running-distributed-data-science-workloads-from-notebooks.adoc
+++ b/modules/running-distributed-data-science-workloads-from-notebooks.adoc
@@ -10,6 +10,15 @@ To run a distributed data science workload from a notebook, you must first provi
 ifndef::upstream[]
 * You have access to a data science cluster that is configured to run distributed workloads as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].
 endif::[]
+
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
+endif::[]
+
+ifndef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+
 ifdef::upstream[]
 * You have access to a data science cluster that is configured to run distributed workloads as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].
 endif::[]
@@ -17,6 +26,7 @@ endif::[]
 ifndef::upstream[]
 * You have created the required Kueue resources as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-quota-management-for-distributed-workloads_distributed-workloads[Configuring quota management for distributed workloads].
 endif::[]
+
 ifdef::upstream[]
 * You have created the required Kueue resources as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-quota-management-for-distributed-workloads_distributed-workloads[Configuring quota management for distributed workloads].
 endif::[]
@@ -46,19 +56,6 @@ ifdef::upstream[]
 ====
 If you do not create a default local queue, you must specify a local queue in each notebook.
 ====
-endif::[]
-
-ifndef::upstream[]
-* You have created a data science project that contains a workbench that is running one of the default notebook images, for example, the *Standard Data Science* notebook.
-See the table in link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/creating-a-workbench-select-ide_nb-server
-#about-workbench-images_nb-server[About workbench images] for a complete list of default notebook images.
-endif::[]
-ifdef::upstream[]
-* You have created a data science project that contains a workbench that is running one of the default notebook images, for example, the *Standard Data Science* notebook.
-See the table in link:{odhdocshome}/working_on_data_science_projects/creating-a-workbench-select-ide_nb-server
-#about-workbench-images_nb-server[About workbench images] for a complete list of default notebook images.
-
-
 endif::[]
 
 * You have launched your notebook server and logged in to your notebook editor.

--- a/modules/running-distributed-data-science-workloads-from-notebooks.adoc
+++ b/modules/running-distributed-data-science-workloads-from-notebooks.adoc
@@ -15,7 +15,7 @@ ifdef::upstream[]
 endif::[]
 
 ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
 For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
 endif::[]
 ifdef::upstream[]

--- a/modules/running-distributed-data-science-workloads-from-notebooks.adoc
+++ b/modules/running-distributed-data-science-workloads-from-notebooks.adoc
@@ -10,23 +10,22 @@ To run a distributed data science workload from a notebook, you must first provi
 ifndef::upstream[]
 * You have access to a data science cluster that is configured to run distributed workloads as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].
 endif::[]
-
-ifdef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see  link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{odhdocshome}//working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
-endif::[]
-
-ifndef::upstream[]
-* You have created a data science project that contains a workbench, and the workbench is running one of the default notebook images that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook.  For information on how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project]. For a complete list of the default notebook images and the preinstalled packages that they contain, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
-endif::[]
-
 ifdef::upstream[]
 * You have access to a data science cluster that is configured to run distributed workloads as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].
 endif::[]
 
 ifndef::upstream[]
-* You have created the required Kueue resources as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-quota-management-for-distributed-workloads_distributed-workloads[Configuring quota management for distributed workloads].
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example,the *Standard Data Science* notebook. For information about how to create a project, see link:{rhoaidocshome}/working_on_data_science_projects/working-on-data-science-projects_nb-server#creating-a-data-science-project_nb-server[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{rhoaidocshome}/working_on_data_science_projects/creating-and-importing-notebooks_notebooks#notebook-images-for-data-scientists_notebooks[Notebook images for data scientists].
+endif::[]
+ifdef::upstream[]
+* You have created a data science project that contains a workbench, and the workbench is running a default notebook image that contains the CodeFlare SDK, for example, the *Standard Data Science* notebook. For information about how to create a project, see link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Creating a data science project].
+For a complete list of the default notebook images and their preinstalled packages, see the table in link:{odhdocshome}/working-on-data-science-projects/#_using_data_science_projects[Notebook images for data scientists].
 endif::[]
 
+ifndef::upstream[]
+* You have created the required Kueue resources as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads#configuring-quota-management-for-distributed-workloads_distributed-workloads[Configuring quota management for distributed workloads].
+endif::[]
 ifdef::upstream[]
 * You have created the required Kueue resources as described in link:{odhdocshome}/working-with-distributed-workloads/#configuring-quota-management-for-distributed-workloads_distributed-workloads[Configuring quota management for distributed workloads].
 endif::[]


### PR DESCRIPTION
Added or changed text in 5 docs, which states that the end-user needs to have a data science project created in the prerequisites section of the instructions.