### PR TITLE
RHOAIENG-5433: Removing references to TGIS gRPC API for vLLM

### DIFF
--- a/modules/accessing-inference-endpoint-for-model-deployed-on-single-model-serving-platform.adoc
+++ b/modules/accessing-inference-endpoint-for-model-deployed-on-single-model-serving-platform.adoc
@@ -58,7 +58,7 @@ NOTE: To query the endpoint for the TGIS standalone runtime, you must also downl
 * `:443/v1/completions`
 * `:443/v1/embeddings`
 +
-NOTE: The vLLM runtime is compatible with the OpenAI REST API and TGIS gRPC API. If you have deployed a model by using the TGIS Standalone runtime, you have the option to migrate to the vLLM runtime, if desired. To use the TGIS gRPC API to query the endpoints for a model deployed using the vLLM runtime, refer to the paths that are used for the TGIS Standalone runtime. For a list of models supported by the vLLM runtime, see link:https://docs.vllm.ai/en/latest/models/supported_models.html[Supported models].
+NOTE: The vLLM runtime is compatible with the OpenAI REST API. For a list of models supported by the vLLM runtime, see link:https://docs.vllm.ai/en/latest/models/supported_models.html[Supported models].
 +
 NOTE: To use the embeddings inference endpoint in vLLM, you must use an embeddings model that is supported by vLLM. You cannot use the embeddings endpoint with generative models. For more information, see link:https://github.com/vllm-project/vllm/pull/3734[Supported embeddings models in vLLM].
 +


### PR DESCRIPTION
## Description
Removing references to TGIS gRPC API for vLLM

## How Has This Been Tested?
Local Build

