### PR TITLE
Adjust wording of installing Kserve

### DIFF
--- a/modules/about-the-single-model-serving-platform.adoc
+++ b/modules/about-the-single-model-serving-platform.adoc
@@ -20,9 +20,9 @@ endif::[]
 
 To install the single-model serving platform, you have the following options:
 
-Automated installation:: If you have not already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you can configure the {productname-long} Operator to install KServe and its dependencies.
+Automated installation:: If you have not already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you can configure the {productname-long} Operator to install KServe and configure its dependencies.
 
-Manual installation:: If you have already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you _cannot_ configure the {productname-long} Operator to install KServe and its dependencies. In this situation, you must install KServe manually.
+Manual installation:: If you have already created a `ServiceMeshControlPlane` or `KNativeServing` resource on your OpenShift cluster, you _cannot_ configure the {productname-long} Operator to install KServe and configure its dependencies. In this situation, you must install KServe manually.
 
 When you have installed KServe, you can use the {productname-short} dashboard to deploy models using pre-installed or custom model-serving runtimes. 
 


### PR DESCRIPTION
## Description
Clean up the wording to reflect that we are "configuring" not "installing" the dependencies.

## How Has This Been Tested?
Ran a local Gatsby build and verified that the changes appeared as expected 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
