### PR TITLE
image reference updated

### DIFF
--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -123,7 +123,7 @@ def ray_fn():
            min_memory=1,
            max_memory=1,
            num_gpus=0,
-           image="quay.io/project-codeflare/ray:latest-py39-cu118", <6>
+           image="quay.io/rhoai/ray:2.23.0-py39-cu121", <6>
            local_queue="local_queue_name", <7>
        )
    )


### PR DESCRIPTION
For 2.11 the CodeFlare SDK will be supporting version 2.23.0 of Ray which will require a doc change to update the old image, from:  `quay.io/project-codeflare/ray:latest-py39-cu118` 
to the new one: `quay.io/rhoai/ray:2.23.0-py39-cu121`

Location in docs:
https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html-single/working_with_distributed_workloads/index#running-distributed-data-science-workloads-from-ds-pipelines_distributed-workloads