### PR TITLE
RHOAI-8083 platform references

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -64,7 +64,7 @@ endif::[]
 :org-name: Red{nbsp}Hat
 :rhodsdocshome: https://access.redhat.com/documentation/en-us/{url-productname-long}/{vernum}/
 :default-format-url: html
-:ocp-latest-version: 4.14
+:ocp-latest-version: 4.16
 :ocp-minimum-version: 4.12
 :osd-latest-version: 4
 :rosa-latest-version: 4

--- a/modules/accessing-notebook-servers-owned-by-other-users.adoc
+++ b/modules/accessing-notebook-servers-owned-by-other-users.adoc
@@ -14,14 +14,8 @@ ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 
-ifdef::self-managed[]
-* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
-
-* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
-endif::[]
-
-ifdef::cloud-service[]
-* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users].
+ifndef::upstream[]
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users in {openshift-platform}].
 
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]

--- a/modules/accessing-the-jupyter-administration-interface.adoc
+++ b/modules/accessing-the-jupyter-administration-interface.adoc
@@ -11,14 +11,9 @@ ifdef::upstream[]
 * You are part of the {openshift-platform} administrator group.
 endif::[]
 
-ifdef::self-managed[]
-* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+ifndef::upstream[]
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users in {openshift-platform}].
 endif::[]
-
-ifdef::cloud-service[]
-* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users].
-endif::[]
-
 
 .Procedure
 ** To access the Jupyter administration interface from {productname-short}, perform the following actions:

--- a/modules/cleaning-up-after-deleting-users.adoc
+++ b/modules/cleaning-up-after-deleting-users.adoc
@@ -19,21 +19,15 @@ endif::[]
 
 ifdef::cloud-service[]
 * You have backed up the user's storage data from Amazon EBS or Google Persistent Disk.
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users].
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users in {openshift-platform}].
 endif::[]
 
 ifdef::self-managed[]
 * You have backed up the user's storage data.
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users in {openshift-platform}].
 endif::[]
 
-ifdef::upstream,self-managed[]
 * You have logged in to the {openshift-platform} web console.
-endif::[]
-
-ifdef::cloud-service[]
-* You have logged in to the OpenShift web console.
-endif::[]
 
 * You have logged in to {productname-short}.
 

--- a/modules/cleaning-up-resources.adoc
+++ b/modules/cleaning-up-resources.adoc
@@ -4,11 +4,11 @@
 = Cleaning up resources
 
 [role='_abstract']
-Open Data Hub Operator versions 2.0 and 2.1 created some custom resource instances on your OpenShift Container Platform cluster for various components of {productname-short}. Before upgrading to versions 2.2 or later, you must manually clean up these resources in your cluster.
+Open Data Hub Operator versions 2.0 and 2.1 created some custom resource instances on your {openshift-platform} cluster for various components of {productname-short}. Before upgrading to versions 2.2 or later, you must manually clean up these resources in your cluster.
 
 .Prerequisites
 * You have installed version 2.0 or 2.1 of the Open Data Hub Operator and you want to upgrade to version 2.2 or later.
-* You have cluster administrator privileges for your OpenShift Container Platform cluster.
+* You have cluster administrator privileges for your {openshift-platform} cluster.
 
 .Procedure
 . Log in to the {openshift-platform} web console as a cluster administrator.

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -31,7 +31,7 @@ endif::[]
 
 
 .Procedure
-. Log in to your OpenShift Container Platform as a user with `cluster-admin` privileges. If you are performing a developer installation on link:http://try.openshift.com[try.openshift.com], you can log in as the `kubeadmin` user.
+. Log in to your {openshift-platform} as a user with `cluster-admin` privileges. If you are performing a developer installation on link:http://try.openshift.com[try.openshift.com], you can log in as the `kubeadmin` user.
 . Select *Operators* -> *Installed Operators*, and then click the *Open Data Hub Operator*.
 . On the *Operator details* page, click the *Data Science Cluster* tab, and then click *Create DataScienceCluster*.
 . On the *Create DataScienceCluster* page, configure the DataScienceCluster by using *Form* view or *YAML* view. For general information about the supported components, see link:https://opendatahub.io/docs/tiered-components[Tiered Components].

--- a/modules/starting-notebook-servers-owned-by-other-users.adoc
+++ b/modules/starting-notebook-servers-owned-by-other-users.adoc
@@ -10,17 +10,11 @@ Administrators can start a notebook server for another existing user from the Ju
 
 ifdef::upstream[]
 * You are part of the {openshift-platform} administrator group which requires  the `cluster-admin` role on {openshift-platform}. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/authentication_and_authorization/using-rbac#creating-cluster-admin_using-rbac[Creating a cluster admin]. 
-
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 
-ifdef::self-managed[]
-* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
-* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
-endif::[]
-
-ifdef::cloud-service[]
-* You are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users].
+ifndef::upstream[]
+* You are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users in {openshift-platform}].
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -9,25 +9,11 @@ Administrators can stop notebook servers that are owned by other users to reduce
 .Prerequisites
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {odh-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
-endif::[]
-
-ifdef::self-managed[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-for-{openshift-platform-url}_install[Adding administrative users for {openshift-platform}].
-endif::[]
-
-ifdef::cloud-service[]
-* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the OpenShift Dedicated or Red Hat OpenShift Service on AWS (ROSA) administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-openshift_install[Adding administrative users].
-endif::[]
-
-ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 
-ifdef::self-managed[]
-* You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
-endif::[]
-
-ifdef::cloud-service[]
+ifndef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-{openshift-platform-url}_install[Adding administrative users in {openshift-platform}].
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 


### PR DESCRIPTION
- Changed OpenShift Container Platform references in SM docs to {openshift-platform} where applicable
- Changed ROSA references in CS docs to ROSA Classic
- Other minor edits related to platform references