### PR TITLE
Fixing links to updated OCP resources

### DIFF
--- a/modules/configuring-monitoring-for-the-multi-model-serving-platform.adoc
+++ b/modules/configuring-monitoring-for-the-multi-model-serving-platform.adoc
@@ -11,8 +11,8 @@ After you have configured monitoring, you can view metrics for the ModelMesh com
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
 * You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.openshift.com/container-platform/{ocp-latest-version}/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli[Installing the OpenShift CLI].
-* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[creating a config map] for monitoring a user-defined workflow. You will perform similar steps in this procedure.
-* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[enabling monitoring] for user-defined projects in OpenShift. You will perform similar steps in this procedure.
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[creating a config map] for monitoring a user-defined workflow. You will perform similar steps in this procedure.
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html[enabling monitoring] for user-defined projects in OpenShift. You will perform similar steps in this procedure.
 * You have link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned] the `monitoring-rules-view` role to users that will monitor metrics.
 
 .Procedure

--- a/modules/configuring-monitoring-for-the-single-model-serving-platform.adoc
+++ b/modules/configuring-monitoring-for-the-single-model-serving-platform.adoc
@@ -20,9 +20,9 @@ endif::[]
 * You have cluster administrator privileges for your {openshift-platform} cluster.
 * You have created OpenShift Service Mesh and Knative Serving instances and installed KServe.
 * You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.openshift.com/container-platform/{ocp-latest-version}/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli[Installing the OpenShift CLI].
-* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[creating a config map] for monitoring a user-defined workflow. You will perform similar steps in this procedure.
-* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[enabling monitoring] for user-defined projects in OpenShift. You will perform similar steps in this procedure.
-* You have link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned] the `monitoring-rules-view` role to users that will monitor metrics.
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[creating a config map] for monitoring a user-defined workflow. You will perform similar steps in this procedure.
+* You are familiar with link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html[enabling monitoring] for user-defined projects in OpenShift. You will perform similar steps in this procedure.
+* You have link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned] the `monitoring-rules-view` role to users that will monitor metrics.
 
 .Procedure
 . In a terminal window, if you are not already logged in to your OpenShift cluster as a cluster administrator, log in to the OpenShift CLI as shown in the following example:

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -10,7 +10,7 @@ You can use the OpenShift web console to install specific components of Open Dat
 * You have installed version 2 of the Open Data Hub Operator.
 * You can log in as a user with `cluster-admin` privileges.
 ifdef::upstream[]
-* If you want to use the `trustyai` component, you must enable user workload monitoring as described in link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects].
+* If you want to use the `trustyai` component, you must enable user workload monitoring as described in link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects].
 endif::[]
 * If you want to use the `kserve` or `modelmesh` components, you must have already installed the following Operator or Operators for the component. For information about installing an Operator, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
 

--- a/modules/viewing-metrics-for-the-multi-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-multi-model-serving-platform.adoc
@@ -9,7 +9,7 @@ After a cluster administrator has configured monitoring for the multi-model serv
 .Prerequisites
 ifdef::self-managed[]
 * A cluster administrator has configured monitoring for the multi-model serving platform.
-* You have been link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned^] the `monitoring-rules-view` role.
+* You have been link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned^] the `monitoring-rules-view` role.
 * You are familiar with how to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitor project metrics^] in the {openshift-platform} web console.
 endif::[]
 ifdef::cloud-service[]

--- a/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
@@ -9,7 +9,7 @@ When a cluster administrator has configured monitoring for the single-model serv
 .Prerequisites
 ifdef::self-managed[]
 * A cluster administrator has configured monitoring for the single-model serving platform.
-* You have been link:https://docs.openshift.com/container-platform/{ocp-latest-version}/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned^] the `monitoring-rules-view` role.
+* You have been link:https://docs.openshift.com/container-platform/{ocp-latest-version}/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[assigned^] the `monitoring-rules-view` role.
 * You are familiar with how to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitor project metrics^] in the {openshift-platform} web console.
 endif::[]
 ifdef::cloud-service[]


### PR DESCRIPTION
Fixes links to the updated https://docs.openshift.com/container-platform/4.16/observability/monitoring/ section of the OCP docs, which previously was just /monitoring/.

- Updates some links to align with downstream changes
- Updates some links that I noticed also needed the same changes

Tested by previewing changes and confirming updated links work successfully.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
