### PR TITLE
Remove prerequisite about logging in as a cluster admin

### DIFF
--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -7,13 +7,6 @@
 To run a distributed data science workload from a data science pipeline, you must first update the pipeline to include a link to your Ray cluster image.
 
 .Prerequisites
-ifdef::upstream,self-managed[]
-* You have logged in to {openshift-platform} with the `cluster-admin` role.
-endif::[]
-ifdef::cloud-service[]
-* You have logged in to OpenShift with the `cluster-admin` role.
-endif::[]
-
 ifndef::upstream[]
 * You have access to a data science cluster that is configured to run distributed workloads as described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/configuring-distributed-workloads_distributed-workloads[Configuring distributed workloads].
 endif::[]


### PR DESCRIPTION
Removes the prerequisite that says you need to log in to RHOAI as a cluster-admin to perform the described task, as you do not.