### PR TITLE
RHOAIENG-4198: Initial commit for kserve perf metrics

### DIFF
--- a/assemblies/serving-large-models.adoc
+++ b/assemblies/serving-large-models.adoc
@@ -24,6 +24,12 @@ endif::[]
 
 include::modules/viewing-metrics-for-the-single-model-serving-platform.adoc[leveloffset=+1]
 
+== Monitoring model performance
+
+In the single-model serving platform, you can view performance metrics for a specific model that is deployed on the platform.
+
+include::modules/viewing-performance-metrics-for-deployed-model.adoc[leveloffset=+2]
+
 == Performance tuning on the single-model serving platform
 Certain performance issues might require you to tune the parameters of your inference service or model-serving runtime.
 

--- a/assemblies/serving-small-and-medium-sized-models.adoc
+++ b/assemblies/serving-small-and-medium-sized-models.adoc
@@ -30,6 +30,9 @@ endif::[]
 include::modules/viewing-metrics-for-the-multi-model-serving-platform.adoc[leveloffset=+1]
 
 == Monitoring model performance
+
+In the multi-model serving platform, you can view performance metrics for all models deployed on a model server and for a specific model that is deployed on the model server.
+
 include::modules/viewing-performance-metrics-for-model-server.adoc[leveloffset=+2]
 include::modules/viewing-http-request-metrics-for-a-deployed-model.adoc[leveloffset=+2]
 

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -10,7 +10,7 @@ You can view a graph that illustrates the HTTP requests that have failed or succ
 .Prerequisites
 * You have installed {productname-long}.
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
-* The following dashboard configuration options are set to their default values as shown:
+* The following dashboard configuration options are set to the default values as shown:
 +
 [source]
 ----

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -10,7 +10,19 @@ You can view a graph that illustrates the HTTP requests that have failed or succ
 .Prerequisites
 * You have installed {productname-long}.
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to hide the *Endpoint Performance* tab on the *Model Serving* page. For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* The following dashboard configuration options are set to their default values as shown:
++
+[source]
+----
+disablePerformanceMetrics:false
+disableKServeMetrics:false
+----
+ifdef::upstream[]
+For more information, see link:{odhdocshome}/managing_resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+ifndef::upstream[]
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[] 
 * You have logged in to {productname-short}.
 ifndef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
@@ -35,8 +47,3 @@ endif::[]
 .Verification
 
 The *Endpoint performance* tab shows a graph of the HTTP metrics for the model.
-
-//See also
-//Viewing performance metrics for all models on a model server
-
-

--- a/modules/viewing-performance-metrics-for-deployed-model.adoc
+++ b/modules/viewing-performance-metrics-for-deployed-model.adoc
@@ -1,0 +1,72 @@
+:_module-type: PROCEDURE
+
+[id="viewing-performance-metrics-for-model-server_{context}"]
+= Viewing performance metrics for a deployed model
+
+[role='_abstract']
+
+You can monitor the following metrics for a specific model that is deployed on the single-model serving platform:
+
+* *Number of requests* - The number of HTTP requests that have failed or succeeded for a specific model.
+* *Average response time (ms)* - The average time it takes a specific model to respond to requests.
+* *CPU utilization (%)* - The percentage of the CPU's capacity that is currently being used by a specific model.
+* *Memory utilization (%)* - The percentage of the system's memory that is currently being used by a specific model.
+
+You can specify a time range and a refresh interval for these metrics to help you determine, for example, when the peak usage hours are and how the model is performing at a specified time.
+
+.Prerequisites
+* You have installed {productname-long}.
+
+* On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
+
+* You have logged in to {productname-short}.
+ifndef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
+endif::[]
+ifdef::upstream[]
+* If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
+endif::[]
+* The following dashboard configuration options are set to their default values as shown:
++
+[source]
+----
+disablePerformanceMetrics:false
+disableKServeMetrics:false
+----
+ifdef::upstream[]
+For more information, see link:{odhdocshome}/managing_resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+ifndef::upstream[]
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+* You have deployed a model on the single-model serving platform by using a preinstalled runtime.
++
+[NOTE]
+====
+Metrics are only supported for models deployed by using a preinstalled model-serving runtime or a custom runtime that is duplicated from a preinstalled runtime.
+====
+
+.Procedure
+
+. From the {productname-short} dashboard navigation menu, click *Data Science Projects*.
++
+The *Data Science Projects* page opens.
+. Click the name of the project that contains the data science models that you want to monitor.
+
+. In the project details page, click the *Models* tab.
+
+. Select the model that you are interested in.
+
+. On the *Endpoint performance* tab, set the following options:
+
+** *Time range* - Specifies how long to track the metrics. You can select one of these values: 1 hour, 24 hours, 7 days, and 30 days.
+
+** *Refresh interval* - Specifies how frequently the graphs on the metrics page are refreshed (to show the latest data). You can select one of these values: 15 seconds, 30 seconds, 1 minute, 5 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, and 1 day.
+
+. Scroll down to view data graphs for number of requests, average response time, CPU utilization, and memory utilization.
+
+.Verification
+
+The *Endpoint performance* tab shows graphs of metrics for the model.
+//.See also
+//Viewing HTTP request metrics for a deployed model

--- a/modules/viewing-performance-metrics-for-deployed-model.adoc
+++ b/modules/viewing-performance-metrics-for-deployed-model.adoc
@@ -1,16 +1,16 @@
 :_module-type: PROCEDURE
 
-[id="viewing-performance-metrics-for-model-server_{context}"]
+[id="viewing-performance-metrics-for-deployed-model_{context}"]
 = Viewing performance metrics for a deployed model
 
 [role='_abstract']
 
 You can monitor the following metrics for a specific model that is deployed on the single-model serving platform:
 
-* *Number of requests* - The number of HTTP requests that have failed or succeeded for a specific model.
+* *Number of requests* - The number of requests that have failed or succeeded for a specific model.
 * *Average response time (ms)* - The average time it takes a specific model to respond to requests.
-* *CPU utilization (%)* - The percentage of the CPU's capacity that is currently being used by a specific model.
-* *Memory utilization (%)* - The percentage of the system's memory that is currently being used by a specific model.
+* *CPU utilization (%)* - The percentage of the CPU limit per model replica that is currently utilized by a specific model.
+* *Memory utilization (%)* - The percentage of the memory limit per model replica that is utilized by a specific model.
 
 You can specify a time range and a refresh interval for these metrics to help you determine, for example, when the peak usage hours are and how the model is performing at a specified time.
 
@@ -26,7 +26,7 @@ endif::[]
 ifdef::upstream[]
 * If you are using specialized {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
 endif::[]
-* The following dashboard configuration options are set to their default values as shown:
+* The following dashboard configuration options are set to the default values as shown:
 +
 [source]
 ----

--- a/modules/viewing-performance-metrics-for-model-server.adoc
+++ b/modules/viewing-performance-metrics-for-model-server.adoc
@@ -5,11 +5,9 @@
 
 [role='_abstract']
 
-In {productname-short}, you can monitor the following metrics for all the models that are deployed on a model server:
+You can monitor the following metrics for all the models that are deployed on a model server:
 
-* *HTTP requests* - The number of HTTP requests that have failed or succeeded for all models on the server.
-+
-Note: You can also view the number of HTTP requests that have failed or succeeded for a specific model, as described in xref:viewing-http-request-metrics-for-a-deployed-model_model-serving[Viewing HTTP request metrics for a deployed model].
+* *HTTP requests per 5 minutes* - The number of HTTP requests that have failed or succeeded for all models on the server.
 * *Average response time (ms)* - For all models on the server, the average time it takes the model server to respond to requests.
 * *CPU utilization (%)* - The percentage of the CPU's capacity that is currently being used by all models on the server.
 * *Memory utilization (%)* - The percentage of the system's memory that is currently being used by all models on the server.
@@ -47,11 +45,11 @@ The *Data Science Projects* page opens.
 
 ** *Refresh interval* - Specifies how frequently the graphs on the metrics page are refreshed (to show the latest data). You can select one of these values: 15 seconds, 30 seconds, 1 minute, 5 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, and 1 day.
 
-. Scroll down to view data graphs for HTTP requests, average response time, CPU utilization, and memory utilization.
+. Scroll down to view data graphs for HTTP requests per 5 minutes, average response time, CPU utilization, and memory utilization.
 
 .Verification
 
-On the metrics page for the model server, the graphs provide performance metric data.
+On the metrics page for the model server, the graphs provide data on performance metrics.
 
 //.See also
 //Viewing HTTP request metrics for a deployed model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initial commit for KServe performance metrics feature.

- Adding a procedure for viewing kserve metrics on the single-model serving platform

## How Has This Been Tested?
Local build
## Previews:
### _Monitoring Model Performance (Multi-model serving platform)_
<img width="747" alt="Screenshot 2024-08-07 at 2 04 19 PM" src="https://github.com/user-attachments/assets/c501ae54-cf62-48ee-ba01-3c40a5bf025e">
<img width="713" alt="Screenshot 2024-08-07 at 2 04 37 PM" src="https://github.com/user-attachments/assets/548e4ff9-faf7-44a3-9fb6-08e6c4e9bc76">
<img width="661" alt="Screenshot 2024-08-07 at 2 05 00 PM" src="https://github.com/user-attachments/assets/8f7b1c17-5be1-4553-9e25-4878d68ee54d">

### _Monitoring Model Performance (Single-model serving platform)_
<img width="692" alt="Screenshot 2024-08-07 at 2 05 15 PM" src="https://github.com/user-attachments/assets/fe417307-5e3b-4987-8b63-01f4d504a85c">
<img width="694" alt="Screenshot 2024-08-07 at 2 05 27 PM" src="https://github.com/user-attachments/assets/e97cc853-128f-4e2d-a298-f05e7c1406d3">



