### PR TITLE
DS-4434 - changed jupyter administration interface name

### DIFF
--- a/assemblies/managing-notebook-servers.adoc
+++ b/assemblies/managing-notebook-servers.adoc
@@ -3,7 +3,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="managing-notebook-servers"]
-= Managing Jupyter notebook servers
+= Managing notebook servers
 :upstream:
 //:preview:
 
@@ -13,7 +13,7 @@ endif::preview[]
 
 
 
-include::modules/accessing-the-jupyter-administration-interface.adoc[leveloffset=+1]
+include::modules/accessing-the-notebook-administration-interface.adoc[leveloffset=+1]
 
 include::modules/starting-notebook-servers-owned-by-other-users.adoc[leveloffset=+1]
 

--- a/modules/accessing-the-notebook-administration-interface.adoc
+++ b/modules/accessing-the-notebook-administration-interface.adoc
@@ -1,10 +1,10 @@
 :_module-type: PROCEDURE
 
-[id='accessing-the-jupyter-administration-interface_{context}']
-= Accessing the Jupyter administration interface
+[id='accessing-the-notebook-administration-interface_{context}']
+= Accessing the notebook administration interface
 
 [role='_abstract']
-You can use the Jupyter administration interface to control notebook servers in your {productname-long} environment.
+You can use the notebook administration interface to control notebook servers in your {productname-long} environment.
 
 .Prerequisite
 ifdef::upstream[]
@@ -16,14 +16,14 @@ ifndef::upstream[]
 endif::[]
 
 .Procedure
-** To access the Jupyter administration interface from {productname-short}, perform the following actions:
+** To access the notebook administration interface from {productname-short}, perform the following actions:
 ... In {productname-short}, in the *Applications* section of the left menu, click *Enabled*.
 ... Locate the Jupyter tile and click *Launch application*.
 ... On the page that opens when you launch Jupyter, click the *Administration* tab.
 +
 The *Administration* page opens.
 
-** To access the Jupyter administration interface from JupyterLab, perform the following actions:
+** To access the notebook administration interface from JupyterLab, perform the following actions:
 ... Click *File* -> *Hub Control Panel*.
 ... On the page that opens in {productname-short}, click the *Administration* tab. 
 +
@@ -31,4 +31,4 @@ The *Administration* page opens.
 
 .Verification
 
-* You can see the Jupyter administration interface.
+* You can see the notebook administration interface.

--- a/modules/starting-notebook-servers-owned-by-other-users.adoc
+++ b/modules/starting-notebook-servers-owned-by-other-users.adoc
@@ -4,7 +4,7 @@
 = Starting notebook servers owned by other users
 
 [role='_abstract']
-Administrators can start a notebook server for another existing user from the Jupyter administration interface.
+Administrators can start a notebook server for another existing user from the notebook administration interface.
 
 .Prerequisites
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently you can spawn multiple IDEs using the Jupyter Spawner page (accessed from the Jupyter tab on the Enabled page). Because you now spawn vs-code and rstudio from the spawner page, the administration interface covers more than just Jupyter notebooks. Therefore it is necessary to change the name of the interface in the docs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
