### PR TITLE
Add note about generating metrics for the vLLM runtime

### DIFF
--- a/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
@@ -34,7 +34,11 @@ ifdef::upstream,self-managed[]
 ----
 sum(increase(vllm:request_success_total{namespace='${namespace}',model_name='${model_name}'}[${rate_interval}]))
 ----
-
++
+[NOTE]
+--
+To generate certain vLLM runtime metrics, you must first send an inference request. Idle servers do not generate runtime metrics.
+--
 .. The following query displays the number of successful inference requests over a period of time for a model deployed with the standalone TGIS runtime:
 +
 [source,subs="+quotes"]
@@ -55,7 +59,6 @@ sum(increase(predict_rpc_count_total{namespace='${namespace}',code='OK',model_id
 ----
 sum(increase(ovms_requests_success{namespace='${namespace}',name='${model_name}'}[${rate_interval}]))
 ----
-
 
 endif::[]
 ifdef::cloud-service[]

--- a/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
@@ -37,7 +37,7 @@ sum(increase(vllm:request_success_total{namespace='${namespace}',model_name='${m
 +
 [NOTE]
 --
-To generate certain vLLM runtime metrics, you must first send an inference request. Idle servers do not generate runtime metrics.
+Certain vLLM metrics are available only after an inference request is processed by a deployed model. To generate and view these metrics, you must first make an inference request to the model.
 --
 .. The following query displays the number of successful inference requests over a period of time for a model deployed with the standalone TGIS runtime:
 +


### PR DESCRIPTION
## Description
Added a note explaining that metrics are only generated if an inference request is made.

Closes 9634

## How Has This Been Tested?
Built a local preview in Gatsby and confirmed changes appear 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
