### PR TITLE
DS-10353 - added documentation on additional way of enabling or disab…

### DIFF
--- a/modules/viewing-scheduled-pipeline-runs.adoc
+++ b/modules/viewing-scheduled-pipeline-runs.adoc
@@ -24,7 +24,7 @@ endif::[]
 . From the list of pipeline experiments, click the experiment that contains the pipeline runs that you want to view.
 . On the *Runs* page, click the *Schedules* tab.
 +
-After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*. Alternatively, you can change its execution availability from the details page for the scheduled run by clicking the *Actions* drop-down menu and selecting *Enable* or *Disable*.
+After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*. Alternatively, you can change its execution availability from the details page for the scheduled run by clicking the *Actions* drop-down menu and then selecting *Enable* or *Disable*.
  
 
 .Verification

--- a/modules/viewing-scheduled-pipeline-runs.adoc
+++ b/modules/viewing-scheduled-pipeline-runs.adoc
@@ -24,7 +24,8 @@ endif::[]
 . From the list of pipeline experiments, click the experiment that contains the pipeline runs that you want to view.
 . On the *Runs* page, click the *Schedules* tab.
 +
-After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*.
+After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*. Alternatively, you can change its execution availability from the details page for the scheduled run by clicking the *Actions* drop-down menu and selecting *Enable* or *Disable*.
+ 
 
 .Verification
 * A list of scheduled runs appears on the *Schedules* tab on the *Runs* page for the pipeline experiment.

--- a/modules/viewing-scheduled-pipeline-runs.adoc
+++ b/modules/viewing-scheduled-pipeline-runs.adoc
@@ -24,7 +24,7 @@ endif::[]
 . From the list of pipeline experiments, click the experiment that contains the pipeline runs that you want to view.
 . On the *Runs* page, click the *Schedules* tab.
 +
-After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*. Alternatively, you can change its execution availability from the details page for the scheduled run by clicking the *Actions* drop-down menu and then selecting *Enable* or *Disable*.
+After a run is scheduled, the *Status* column indicates whether the run is ready or unavailable for execution. To change its execution availability, set the *Status* switch to *On* or *Off*. Alternatively, you can change its execution availability from the details page for the scheduled run by clicking the *Actions* drop-down menu, and then selecting *Enable* or *Disable*.
  
 
 .Verification


### PR DESCRIPTION
…ling the execution availability of a scheduled pipeline run

<!--- Provide a general summary of your changes in the Title above -->

## Description
You can now change the execution availability of a scheduled pipeline run from the details page for the scheduled run. You do this by clicking on the Action menu and then selecting **Enable** or **Disable** from the menu. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
