### PR TITLE
RHOAIENG-13027: Adding note for chat_template requirement

### DIFF
--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -87,14 +87,20 @@ vLLM ServingRuntime for KServe::
 * `:443/detokenize`
 +
 [NOTE]
---
-The vLLM runtime is compatible with the OpenAI REST API. For a list of models that the vLLM runtime supports, see link:https://docs.vllm.ai/en/latest/models/supported_models.html[Supported models].
---
+====
+* The vLLM runtime is compatible with the OpenAI REST API. For a list of models that the vLLM runtime supports, see link:https://docs.vllm.ai/en/latest/models/supported_models.html[Supported models].
+* To use the embeddings inference endpoint in vLLM, you must use an embeddings model that the vLLM supports. You cannot use the embeddings endpoint with generative models. For more information, see link:https://github.com/vllm-project/vllm/pull/3734[Supported embeddings models in vLLM].
+* As of vLLM v0.5.5, you must provide a chat template while querying a model using the `/v1/chat/completions` endpoint. If your model does not include a predefined chat template, you can use the `chat-template` command-line parameter to specify a chat template in your custom vLLM runtime, as shown in the example. Replace `<CHAT_TEMPLATE>` with the path to your template.
 +
-[NOTE]
---
-To use the embeddings inference endpoint in vLLM, you must use an embeddings model that the vLLM supports. You cannot use the embeddings endpoint with generative models. For more information, see link:https://github.com/vllm-project/vllm/pull/3734[Supported embeddings models in vLLM].
---
+[source]
+----
+containers:
+  - args:
+      - --chat-template=<CHAT_TEMPLATE>
+----
++
+You can also use the chat templates included with the vLLM image under `/apps/data/template`.
+====
 +
 
 As indicated by the paths shown, the single-model serving platform uses the HTTPS port of your OpenShift router (usually port 443) to serve external API requests.
@@ -159,15 +165,6 @@ curl -v https://<inference_endpoint_url>:443/v1/chat/completions -H \
 "content": "<content>" \
 }] -H 'Authorization: Bearer <token>'
 ----
-[NOTE]
---
-As of vLLM v0.5.5, you must provide a chat template while querying a model using the `/v1/chat/completions` endpoint. If your model does not include a built-in chat template, you can provide one by using the `chat-template` parameter within your custom vLLM runtime and also use the example templates provided in the vLLM image under `/apps/data/template`:
-+
-[source]
-----
---chat-template=/apps/data/template/template_chatml.jinja
-----
---
 --
 endif::[]
 ifdef::self-managed,cloud-service[]
@@ -210,15 +207,6 @@ curl -ks <inference_endpoint_url>/v2/models/<model_name>/infer -d '{ "model_name
 ----
 curl -v https://<inference_endpoint_url>:443/v1/chat/completions -H "Content-Type: application/json" -d '{ "messages": [{ "role": "<role>", "content": "<content>" }] -H 'Authorization: Bearer <token>'
 ----
-[NOTE]
---
-As of vLLM v0.5.5, you must provide a chat template while querying a model using the `/v1/chat/completions` endpoint. If your model does not include a built-in chat template, you can provide one by using the `chat-template` parameter within your custom vLLM runtime and also use the example templates provided in the vLLM image under `/apps/data/template`:
-+
-[source]
-----
---chat-template=/apps/data/template/template_chatml.jinja
-----
---
 --
 endif::[]
 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -99,7 +99,7 @@ containers:
       - --chat-template=<CHAT_TEMPLATE>
 ----
 +
-You can also use the chat templates included with the vLLM image under `/apps/data/template`.
+You can use the chat templates that are available as `.jinja` files link:https://github.com/opendatahub-io/vllm/tree/main/examples[here] or with the vLLM image under `/apps/data/template`. For more information about chat templates, see link:https://huggingface.co/docs/transformers/main/chat_templating[Chat templates].
 ====
 +
 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -201,6 +201,15 @@ curl -ks <inference_endpoint_url>/v2/models/<model_name>/infer -d '{ "model_name
 ----
 curl -v https://<inference_endpoint_url>:443/v1/chat/completions -H "Content-Type: application/json" -d '{ "messages": [{ "role": "<role>", "content": "<content>" }] -H 'Authorization: Bearer <token>'
 ----
+[NOTE]
+--
+As of vLLM v0.5.5, you must provide a chat template while querying a model using the `/v1/chat/completions` endpoint. If your model does not include a built-in chat template, you can provide one by using the `chat-template` parameter within your custom vLLM runtime and also use the example templates provided in the vLLM image under `/apps/data/template`:
++
+[source]
+----
+--chat-template=/apps/data/template/template_chatml.jinja
+----
+--
 --
 endif::[]
 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -99,7 +99,7 @@ containers:
       - --chat-template=<CHAT_TEMPLATE>
 ----
 +
-You can use the chat templates that are available as `.jinja` files link:https://github.com/opendatahub-io/vllm/tree/main/examples[here] or with the vLLM image under `/apps/data/template`. For more information about chat templates, see link:https://huggingface.co/docs/transformers/main/chat_templating[Chat templates].
+You can use the chat templates that are available as `.jinja` files link:https://github.com/opendatahub-io/vllm/tree/main/examples[here] or with the vLLM image under `/apps/data/template`. For more information, see link:https://huggingface.co/docs/transformers/main/chat_templating[Chat templates].
 ====
 +
 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -159,6 +159,15 @@ curl -v https://<inference_endpoint_url>:443/v1/chat/completions -H \
 "content": "<content>" \
 }] -H 'Authorization: Bearer <token>'
 ----
+[NOTE]
+--
+As of vLLM v0.5.5, you must provide a chat template while querying a model using the `/v1/chat/completions` endpoint. If your model does not include a built-in chat template, you can provide one by using the `chat-template` parameter within your custom vLLM runtime and also use the example templates provided in the vLLM image under `/apps/data/template`:
++
+[source]
+----
+--chat-template=/apps/data/template/template_chatml.jinja
+----
+--
 --
 endif::[]
 ifdef::self-managed,cloud-service[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding note for chat_template requirement (RHOAIENG-12233)

```
As of vLLM v0.5.5, you must provide a chat template while querying a model using the /v1/chat/completions endpoint. If your model does not include a predefined chat template, you can use the chat-template command-line parameter to specify a chat template in your custom vLLM runtime, as shown in the example. Replace <CHAT_TEMPLATE> with the path to your template.

containers:
  - args:
      - --chat-template=<CHAT_TEMPLATE>
You can use the chat templates that are available as `.jinja` files link:https://github.com/opendatahub-io/vllm/tree/main/examples[here] or with the vLLM image under `/apps/data/template`. For more information about chat templates, see link:https://huggingface.co/docs/transformers/main/chat_templating[Chat templates].
```

## How Has This Been Tested?
Local build

Upstream preview:

<img width="585" alt="Screenshot 2024-09-18 at 11 14 32 AM" src="https://github.com/user-attachments/assets/7f1e7894-50f1-43cb-a53b-a70db38b10a9">

Downstream preview:
<img width="745" alt="Screenshot 2024-09-18 at 11 16 29 AM" src="https://github.com/user-attachments/assets/2b3d156d-62d9-440d-9ad3-46edf081460d">


