### PR TITLE
Remove specific prefixes

### DIFF
--- a/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
+++ b/modules/viewing-metrics-for-the-single-model-serving-platform.adoc
@@ -27,7 +27,7 @@ endif::[]
 . Switch to the *Developer* perspective.
 . In the left menu, click *Observe*.
 ifdef::upstream,self-managed[]
-. As described in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitoring project metrics^], use the web console to run queries for `caikit_*`, `tgi_*`, `ovms_*` and `vllm:*` model-serving runtime metrics. You can also run queries for `istio_*` metrics that are related to OpenShift Service Mesh. Some examples are shown.
+. As described in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html/building_applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective[monitoring project metrics^], use the web console to run queries for model-serving runtime metrics. You can also run queries for metrics that are related to OpenShift Service Mesh. Some examples are shown.
 .. The following query displays the number of successful inference requests over a period of time for a model deployed with the vLLM runtime:
 +
 [source,subs="+quotes"]


### PR DESCRIPTION
## Description
Not all commands to view metrics require prefixes. Removed text that implied all metrics commands required prefixes.

## How Has This Been Tested?
Made changes, built locally, and verified that changes appeared as expected

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
