### PR TITLE
updates to remove vernum ref in cloud doc instances

### DIFF
--- a/modules/adding-a-ca-bundle-after-upgrading.adoc
+++ b/modules/adding-a-ca-bundle-after-upgrading.adoc
@@ -6,7 +6,12 @@
 
 [role='_abstract']
 ifndef::upstream[]
+ifdef::self-managed[]
 {productname-long} {vernum} provides support for using self-signed certificates. If you have upgraded from {productname-short} 2.7 or earlier versions, you can add self-signed certificates to the {productname-short} deployments and Data Science Projects in your cluster. 
+endif::[]
+ifdef::cloud-service[]
+{productname-long} provides support for using self-signed certificates. If you have upgraded from {productname-short} 2.7 or earlier versions, you can add self-signed certificates to the {productname-short} deployments and Data Science Projects in your cluster. 
+endif::[]
 endif::[]
 
 ifdef::upstream[]

--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -6,10 +6,18 @@
 [role='_abstract']
 When you have enabled the multi-model serving platform, you must configure a model server to deploy models. If you require extra computing power for use with large datasets, you can assign accelerators to your model server.
 
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports only NVIDIA GPU accelerators for model serving.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports only NVIDIA GPU accelerators for model serving.
+====
+endif::[]
 
 .Prerequisites
 * You have logged in to {productname-long}.

--- a/modules/configuring-quota-management-for-distributed-workloads.adoc
+++ b/modules/configuring-quota-management-for-distributed-workloads.adoc
@@ -38,6 +38,7 @@ endif::[]
 * You have sufficient resources. In addition to the base {productname-short} resources, you need 1.6 vCPU and 2 GiB memory to deploy the distributed workloads infrastructure.
 
 ifndef::upstream[]
+ifdef::self-managed[]
 * The resources are physically available in the cluster.
 +
 [NOTE]
@@ -46,6 +47,17 @@ In {productname-short} {vernum}, {org-name} supports only a single cluster queue
 For more information about Kueue resources, see link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/overview-of-distributed-workloads_distributed-workloads#overview-of-kueue-resources_distributed-workloads[Overview of Kueue resources].
 ====
 endif::[]
+ifdef::cloud-service[]
+* The resources are physically available in the cluster.
++
+[NOTE]
+====
+In {productname-short}, {org-name} supports only a single cluster queue per cluster (that is, homogenous clusters), and only empty resource flavors.
+For more information about Kueue resources, see link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/overview-of-distributed-workloads_distributed-workloads#overview-of-kueue-resources_distributed-workloads[Overview of Kueue resources].
+====
+endif::[]
+endif::[]
+
 ifdef::upstream[]
 * The resources are physically available in the cluster.
 +
@@ -59,10 +71,18 @@ ifndef::upstream[]
 * If you want to use graphics processing units (GPUs), you have enabled GPU support in {productname-short}.
 See link:{rhoaidocshome}{default-format-url}/managing_resources/managing-cluster-resources_cluster-mgmt#enabling-nvidia-gpus_cluster-mgmt[Enabling NVIDIA GPUs].
 +
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports only NVIDIA GPU accelerators for distributed workloads.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports only NVIDIA GPU accelerators for distributed workloads.
+====
+endif::[]
 endif::[]
 ifdef::upstream[]
 * If you want to use graphics processing units (GPUs), you have enabled GPU support.

--- a/modules/configuring-the-distributed-workloads-components.adoc
+++ b/modules/configuring-the-distributed-workloads-components.adoc
@@ -29,12 +29,22 @@ endif::[]
 
 * You have access to a Ray cluster image. For information about how to create a Ray cluster, see the link:https://docs.ray.io/en/latest/cluster/getting-started.html[Ray Clusters documentation].
 +
+ifdef::self-managed[]
 [NOTE]
 ====
 Mutual Transport Layer Security (mTLS) is enabled by default in the CodeFlare component in {productname-short}.
 {productname-short} {vernum} does not support the `submissionMode=K8sJobMode` setting in the Ray job specification, so the KubeRay Operator cannot create a submitter Kubernetes Job to submit the Ray job.
 Instead, users must configure the Ray job specification to set `submissionMode=HTTPMode` only, so that the KubeRay Operator sends a request to the RayCluster to create a Ray job.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+Mutual Transport Layer Security (mTLS) is enabled by default in the CodeFlare component in {productname-short}.
+{productname-short}, does not support the `submissionMode=K8sJobMode` setting in the Ray job specification, so the KubeRay Operator cannot create a submitter Kubernetes Job to submit the Ray job.
+Instead, users must configure the Ray job specification to set `submissionMode=HTTPMode` only, so that the KubeRay Operator sends a request to the RayCluster to create a Ray job.
+====
+endif::[]
 * You have access to the data sets and models that the distributed workload uses.
 * You have access to the Python dependencies for the distributed workload.
 
@@ -49,12 +59,22 @@ ifndef::upstream[]
 * If you want to use graphics processing units (GPUs), you have enabled GPU support in {productname-short}.
 See link:{rhoaidocshome}{default-format-url}/managing_resources/managing-cluster-resources_cluster-mgmt#enabling-nvidia-gpus_cluster-mgmt[Enabling NVIDIA GPUs].
 +
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, for distributed workloads, {org-name} supports only NVIDIA GPU accelerators.
 {org-name} supports the use of accelerators within the same cluster only. 
 {org-name} does not support remote direct memory access (RDMA) between accelerators, or the use of accelerators across a network, for example, by using technology such as NVIDIA GPUDirect or NVLink.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, for distributed workloads, {org-name} supports only NVIDIA GPU accelerators.
+{org-name} supports the use of accelerators within the same cluster only. 
+{org-name} does not support remote direct memory access (RDMA) between accelerators, or the use of accelerators across a network, for example, by using technology such as NVIDIA GPUDirect or NVLink.
+====
+endif::[]
 endif::[]
 ifdef::upstream[]
 * If you want to use graphics processing units (GPUs), you have enabled GPU support.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -36,10 +36,18 @@ ifdef::upstream[]
 * To use the vLLM runtime or use graphics processing units (GPUs) with your model server, you have enabled GPU support. This includes installing the Node Feature Discovery and NVIDIA GPU Operators. For more information, see https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/index.html[NVIDIA GPU Operator on {org-name} OpenShift Container Platform^] in the NVIDIA documentation.
 endif::[]
 
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports only NVIDIA GPU accelerators for model serving.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports only NVIDIA GPU accelerators for model serving.
+====
+endif::[]
 
 *  To deploy {rhelai-productname-short} models:
 ** You have enabled the vLLM runtime.

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -83,11 +83,18 @@ ifdef::upstream[]
 ====
 After you upgrade to {productname-short} 2.9 or later, pipelines created with data science pipelines 1.0 continue to run, but are inaccessible from the {productname-short} dashboard. If you are a current data science pipelines user, do not upgrade to {productname-short} with data science pipelines 2.0 until you are ready to migrate to the new pipelines solution.
 ====
-
+ifdef::self-managed[]
 To upgrade to {productname-short} {vernum} with data science pipelines 2.0, ensure that there is no installation of Argo Workflows that is not installed by data science pipelines on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
 If you upgrade to {productname-short} {vernum} with data science pipelines enabled and an Argo Workflows installation that is not installed by data science pipelines exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable data science pipelines or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 endif::[]
+ifdef::cloud-service[]
+To upgrade to {productname-short} with data science pipelines 2.0, ensure that there is no installation of Argo Workflows that is not installed by data science pipelines on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
+
+If you upgrade to {productname-short} with data science pipelines enabled and an Argo Workflows installation that is not installed by data science pipelines exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable data science pipelines or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
+endif::[]
+endif::[]
+
 ifndef::upstream[]
 ifdef::cloud-service[]
 //RHOAI CS

--- a/modules/enabling-data-science-pipelines-2.adoc
+++ b/modules/enabling-data-science-pipelines-2.adoc
@@ -89,7 +89,7 @@ To upgrade to {productname-short} {vernum} with data science pipelines 2.0, ensu
 If you upgrade to {productname-short} {vernum} with data science pipelines enabled and an Argo Workflows installation that is not installed by data science pipelines exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable data science pipelines or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 endif::[]
 ifdef::cloud-service[]
-To upgrade to {productname-short} with data science pipelines 2.0, ensure that there is no installation of Argo Workflows that is not installed by data science pipelines on your cluster, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
+To upgrade to {productname-short} with data science pipelines 2.0, ensure that data science pipelines on your cluster have not installed Argo Workflows, and follow the upgrade steps described in link:{odhdocshome}/upgrading-open-data-hub/[Upgrading {productname-short}].
 
 If you upgrade to {productname-short} with data science pipelines enabled and an Argo Workflows installation that is not installed by data science pipelines exists on your cluster, {productname-short} components will not be upgraded. To complete the component upgrade, disable data science pipelines or remove the separate installation of Argo Workflows. The component upgrade will complete automatically.
 endif::[]

--- a/modules/enabling-nvidia-gpus.adoc
+++ b/modules/enabling-nvidia-gpus.adoc
@@ -86,11 +86,20 @@ endif::[]
 
 //the following note applies to downstream only: self-managed (connected and disconnected) and cloud service
 ifndef::upstream[]
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports the use of accelerators within the same cluster only. 
 {org-name} does not support remote direct memory access (RDMA) between accelerators, or the use of accelerators across a network, for example, by using technology such as NVIDIA GPUDirect or NVLink.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports the use of accelerators within the same cluster only. 
+{org-name} does not support remote direct memory access (RDMA) between accelerators, or the use of accelerators across a network, for example, by using technology such as NVIDIA GPUDirect or NVLink.
+====
+endif::[]
 endif::[]
 
 //the following step applies to downstream only: self-managed (connected and disconnected) and cloud service

--- a/modules/overview-of-kueue-resources.adoc
+++ b/modules/overview-of-kueue-resources.adoc
@@ -58,11 +58,18 @@ spec:
 ////
 
 ifndef::upstream[]
-
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports only empty resource flavors.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports only empty resource flavors.
+====
+endif::[]
 endif::[]
 
 
@@ -78,11 +85,18 @@ The Kueue `ClusterQueue` object manages a pool of cluster resources such as pods
 A cluster queue can reference multiple resource flavors.
 
 ifndef::upstream[]
-
+ifdef::self-managed[]
 [NOTE]
 ====
 In {productname-short} {vernum}, {org-name} supports only a single cluster queue per cluster.
 ====
+endif::[]
+ifdef::cloud-service[]
+[NOTE]
+====
+In {productname-short}, {org-name} supports only a single cluster queue per cluster.
+====
+endif::[]
 endif::[]
 
 Cluster administrators can configure a cluster queue to define the resource flavors that the queue manages, and assign a quota for each resource in each resource flavor.

--- a/modules/understanding-certificates.adoc
+++ b/modules/understanding-certificates.adoc
@@ -54,7 +54,9 @@ In the Operator's DSCI object, you can set the `spec.trustedCABundle.managementS
 
 * `Managed`: The {productname-long} Operator manages the `odh-trusted-ca-bundle` ConfigMap and adds it to all non-reserved existing and new namespaces (the ConfigMap is not added to any reserved or system namespaces, such as `default`, `openshift-\*` or `kube-*`). The ConfigMap is automatically updated to reflect any changes made to the `customCABundle` field. This is the default value after installing {productname-long}.
 
+ifdef::self-managed[]
 * `Removed`: The {productname-long} Operator removes the `odh-trusted-ca-bundle` ConfigMap (if present) and disables the creation of the ConfigMap in new namespaces. If you change this field from `Managed` to `Removed`, the `odh-trusted-ca-bundle` ConfigMap is also deleted from namespaces. This is the default value after upgrading {productname-long} from 2.7 or earlier versions to {vernum}.
+endif::[]
 
 * `Unmanaged`: The {productname-long} Operator does not manage the `odh-trusted-ca-bundle` ConfigMap, allowing for an administrator to manage it instead. Changing the `managementState` from `Managed` to `Unmanaged` does not remove the `odh-trusted-ca-bundle` ConfigMap, but the ConfigMap is not updated if you make changes to the `customCABundle` field.
 


### PR DESCRIPTION
Updated single-sourced downstream content in upstream repo to remove vernum refs in cloud docs.