### PR TITLE
11031: Updating component resource customization table for MR TP.

### DIFF
--- a/modules/overview-of-component-resource-customization.adoc
+++ b/modules/overview-of-component-resource-customization.adoc
@@ -25,7 +25,9 @@ endif::[]
 | KServe 
 a| * kserve-controller-manager 
 * odh-model-controller
+ifdef::upstream[]
 | TrustyAI | trustyai-service-operator-controller-manager
+endif::[]
 | Ray | kuberay-operator 
 | Kueue | kueue-controller-manager
 | Workbenches

--- a/modules/overview-of-component-resource-customization.adoc
+++ b/modules/overview-of-component-resource-customization.adoc
@@ -10,7 +10,12 @@ ifdef::upstream[]
 The following table shows the deployment names for each component in the `opendatahub` namespace:
 endif::[]
 ifndef::upstream[]
-The following table shows the deployment names for each component in the `redhat-ods-applications` namespace:
+The following table shows the deployment names for each component in the `redhat-ods-applications` namespace.
+
+[IMPORTANT]
+====
+Components denoted with `(Technology Preview)` in this table are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete. {org-name} does not recommend using Technology Preview features in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
 endif::[]
 
 |===

--- a/modules/overview-of-component-resource-customization.adoc
+++ b/modules/overview-of-component-resource-customization.adoc
@@ -38,6 +38,9 @@ a| * modelmesh-controller
 ifdef::upstream[]
 | Model registry | model-registry-operator-controller-manager
 endif::[]
+ifndef::upstream[]
+| Model registry (Technology Preview) | model-registry-operator-controller-manager
+endif::[]
 | Data science pipelines | data-science-pipelines-operator-controller-manager
 | Training Operator | kubeflow-training-operator
 |===


### PR DESCRIPTION
Updates the component deployment table in _Overview of component resource customization_ with new conditioning for model registry downstream.

+ Per discussion with component writers, updates to limit the TrustyAI component to upstream.


 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
