### PR TITLE
Start/stop workbench UI update

### DIFF
--- a/modules/starting-a-workbench.adoc
+++ b/modules/starting-a-workbench.adoc
@@ -25,7 +25,6 @@ The *Data Science Projects* page opens.
 A project details page opens.
 . Click the *Workbenches* tab.
 . In the *Status* column for the workbench that you want to start, click *Start*.
-
 +
 The *Status* column changes from *Stopped* to *Starting* when the workbench server is starting, and then to *Running* when the workbench has successfully started.
 * Optional: Click the *Open* link to open the IDE in a new window.

--- a/modules/starting-a-workbench.adoc
+++ b/modules/starting-a-workbench.adoc
@@ -24,7 +24,8 @@ The *Data Science Projects* page opens.
 +
 A project details page opens.
 . Click the *Workbenches* tab.
-. Click the action menu (*&#8942;*) beside the workbench that you want to start, and click *Start*.
+. In the *Status* column for the workbench that you want to start, click *Start*.
+
 +
 The *Status* column changes from *Stopped* to *Starting* when the workbench server is starting, and then to *Running* when the workbench has successfully started.
 * Optional: Click the *Open* link to open the IDE in a new window.


### PR DESCRIPTION
- Updated workbench start/stop references to the button/link (instead of in the Actions menu)
- Verified that there are no references to an **Add storage** button on the Workbenches tab