### PR TITLE
RHOAI-14217 standardizing RHOAI admin references

### DIFF
--- a/modules/about-workbench-images.adoc
+++ b/modules/about-workbench-images.adoc
@@ -4,7 +4,7 @@
 = About workbench images
 
 [role="_abstract"]
-A workbench image (sometimes referred to as a notebook image) is optimized with the tools and libraries that you need for model development. You can use the provided workbench images or an {productname-short} admin user can create custom workbench images adapted to your needs.
+A workbench image (sometimes referred to as a notebook image) is optimized with the tools and libraries that you need for model development. You can use the provided workbench images or an {productname-short} administrator can create custom workbench images adapted to your needs.
 
 To provide a consistent, stable platform for your model development, many provided workbench images contain the same version of Python. Most workbench images available on {productname-short} are pre-built and ready for you to use immediately after {productname-short} is installed or upgraded. 
 
@@ -19,8 +19,7 @@ If the preinstalled packages that are provided in these images are not sufficien
 * Install additional libraries after launching a default image. This option is good if you want to add libraries on an ad hoc basis as you develop models. However, it can be challenging to manage the dependencies of installed libraries and your changes are not saved when the workbench restarts.
 
 ifdef::upstream[]
-* Create a custom image that includes the additional libraries or packages. For more information, see
-link:{odhdocshome}/managing-odh/#creating-custom-workbench-images[Creating custom workbench images]
+* Create a custom image that includes the additional libraries or packages. For more information, see link:{odhdocshome}/managing-resources/#creating-custom-workbench-images_custom-images[Creating custom workbench images].
 endif::[]
 
 ifndef::upstream[]
@@ -92,7 +91,7 @@ For more information, see link:https://posit.co/products/open-source/rstudio-ser
 endif::[]
 
 ifndef::upstream[]
-| CUDA - RStudio Server (Technology preview)
+| CUDA - RStudio Server (Technology Preview)
 a| Use the CUDA - RStudio Server notebook image to access the RStudio IDE and NVIDIA CUDA Toolkit. RStudio is an integrated development environment for R, a programming language for statistical computing and graphics. With the NVIDIA CUDA toolkit, you can optimize your work using GPU-accelerated libraries and optimization tools.
 For more information, see link:https://posit.co/products/open-source/rstudio-server/[the RStudio Server site]. 
 

--- a/modules/adding-a-custom-model-serving-runtime-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-custom-model-serving-runtime-for-the-multi-model-serving-platform.adoc
@@ -12,7 +12,7 @@ NOTE: {org-name} does not provide support for custom runtimes. You are responsib
 [role='_abstract']
 
 .Prerequisites
-* You have logged in to {productname-short} as an administrator.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 ifdef::upstream[]
 * You are familiar with how to link:{odhdocshome}/serving-models/#adding-a-model-server-for-the-multi-model-serving-platform_model-serving[add a model server to your project]. When you have added a custom model-serving runtime, you must configure a new model server to use the runtime.
 endif::[]

--- a/modules/adding-a-custom-model-serving-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-custom-model-serving-runtime-for-the-single-model-serving-platform.adoc
@@ -17,7 +17,7 @@ NOTE: {org-name} does not provide support for custom runtimes. You are responsib
 [role='_abstract']
 
 .Prerequisites
-* You have logged in to {productname-short} as an administrator.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * You have built your custom runtime and added the image to a container image repository such as link:https://quay.io[Quay^].
 
 .Procedure

--- a/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
@@ -10,7 +10,7 @@ You can use the {productname-long} dashboard to add and enable the *NVIDIA Trito
 [role='_abstract']
 
 .Prerequisites
-* You have logged in to {productname-short} as an administrator.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 ifdef::upstream[]
 * You are familiar with how to link:{odhdocshome}/serving-models/#adding-a-model-server-for-the-multi-model-serving-platform_model-serving[add a model server to your project]. After you have added a tested and verified model-serving runtime, you must configure a new model server to use the runtime.
 endif::[]

--- a/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
@@ -11,7 +11,7 @@ You can use the {productname-long} dashboard to add and enable the *NVIDIA Trito
 [role='_abstract']
 
 .Prerequisites
-* You have logged in to {productname-short} as an administrator.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* > *Serving runtimes*.

--- a/modules/adding-an-application-to-the-dashboard.adoc
+++ b/modules/adding-an-application-to-the-dashboard.adoc
@@ -10,10 +10,10 @@ If you have installed an application in your {openshift-platform} cluster, you c
 * You have cluster administrator privileges for your {openshift-platform} cluster.
 
 ifndef::upstream[]
-* The dashboard configuration enablement option is set to `true` (the default). Note that an admin user can disable this ability as described in link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
+* The dashboard configuration enablement option is set to `true` (the default). Note that a cluster administrator can disable this ability as described in link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
 endif::[]
 ifdef::upstream[]
-* The dashboard configuration enablement option is set to `true` (the default). Note that an admin user can disable this ability as described in link:{odhdocshome}/managing-odh/#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
+* The dashboard configuration enablement option is set to `true` (the default). Note that a cluster administrator can disable this ability as described in link:{odhdocshome}/managing-odh/#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
 endif::[]
 
 .Procedure

--- a/modules/adding-notebook-pod-tolerations.adoc
+++ b/modules/adding-notebook-pod-tolerations.adoc
@@ -9,8 +9,7 @@ If you want to dedicate certain machine pools to only running notebook pods, you
 This capability is useful if you want to make sure that notebook servers are placed on nodes that can handle their needs. By preventing other workloads from running on these specific nodes, you can ensure that the necessary resources are available to users who need to work with large notebook sizes.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 * You are familiar with {openshift-platform} taints and tolerations, as described in link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations].
 
 .Procedure

--- a/modules/cleaning-up-after-deleting-users.adoc
+++ b/modules/cleaning-up-after-deleting-users.adoc
@@ -25,11 +25,9 @@ ifdef::self-managed[]
 * You have backed up the user's storage data.
 endif::[]
 
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using groups, you have OpenShift `cluster-admin` privileges.
+* You have logged in to the {openshift-platform} web console as a user with the `cluster-admin` role.
 
-* You have logged in to the {openshift-platform} web console.
-
-* You have logged in to {productname-short}.
+//* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . Delete the user's persistent volume claim (PVC).
@@ -59,10 +57,5 @@ The *Delete ConfigMap* dialog appears.
 // TODO: When RHOAIENG-1137 is corrected, change to:
 //* The user is not visible in the Jupyter administration interface.
 * The user cannot access Jupyter any more, and sees an "Access permission needed" message if they try. 
-ifdef::upstream,self-managed[]
 * The user's single-user profile, persistent volume claim (PVC), and ConfigMap are not visible in {openshift-platform}.
-endif::[]
-ifdef::cloud-service[]
-* The user's single-user profile, persistent volume claim (PVC), and ConfigMap are not visible in OpenShift.
-endif::[]
 

--- a/modules/comparing-runs.adoc
+++ b/modules/comparing-runs.adoc
@@ -40,7 +40,7 @@ The *Compare runs* page opens and displays available parameter, scalar metric, c
 The *Manage runs* dialog opens.
 +
 .. From the *Search* filter drop-down list, select *Run*, *Experiment*, *Pipeline version*, *Created after*, or *Status* to filter the run list by each value.
-.. Deselect the checkbox next to each run that you want to remove from your comparison.
+.. Clear the checkbox next to each run that you want to remove from your comparison.
 .. Select the checkbox next to each run that you want to add to your comparison.
 . Click *Update*.
 

--- a/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
@@ -7,14 +7,7 @@
 To help you indicate the most suitable accelerators to your data scientists, you can configure a recommended tag to appear on the dashboard. 
 
 .Prerequisites
-ifdef::upstream,self-managed[]
-* You have logged in to {openshift-platform}.
-* You have the `cluster-admin` role in {openshift-platform}.
-endif::[]
-ifdef::cloud-service[]
-* You have logged in to OpenShift.
-* You have the `cluster-admin` role in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * You have existing notebook images in your deployment.
 
 .Procedure

--- a/modules/configuring-a-recommended-accelerator-for-serving-runtimes.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-serving-runtimes.adoc
@@ -7,13 +7,7 @@
 To help you indicate the most suitable accelerators to your data scientists, you can configure a recommended accelerator tag for your serving runtimes. 
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you use {productname-short} groups, you are part of the admin group (for example, `{oai-admin-group}` ) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you use {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* > *Serving runtimes*.

--- a/modules/configuring-storage-class-settings.adoc
+++ b/modules/configuring-storage-class-settings.adoc
@@ -7,8 +7,7 @@
 As an {productname-short} administrator, you can manage {openshift-platform} cluster storage class settings for usage within {productname-short}, including the display name, description, and whether users can use the storage class when creating or editing cluster storage. These settings do not impact the storage class within {openshift-platform}.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-* You have {productname-short} administrator permissions.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Storage classes*.

--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -11,10 +11,7 @@ To configure how resources are claimed within your {productname-short} cluster, 
 //Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::cloud-service[]
-* You are part of the administrator group for {productname-short} in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 NOTE: Changing the PVC setting restarts the Jupyter pod and makes Jupyter unavailable for up to 30 seconds. As a workaround, it is recommended that you perform this action outside of your organization's typical working day.
 

--- a/modules/configuring-the-default-storage-class-for-your-cluster.adoc
+++ b/modules/configuring-the-default-storage-class-for-your-cluster.adoc
@@ -7,8 +7,7 @@
 As an {productname-short} administrator, you can configure the default storage class for {productname-short} to be different from the default storage class in {openshift-platform}.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-* You have {productname-short} administrator permissions.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Storage classes*.

--- a/modules/creating-a-model-registry.adoc
+++ b/modules/creating-a-model-registry.adoc
@@ -7,14 +7,12 @@
 You can create a model registry to store, share, version, deploy, and track your models.
 
 .Prerequisites
-* You have logged in to {productname-long}.
+You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {odh-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
-* A cluster administrator has configured and enabled the model registry component in your {productname-short} deployment. For more information on configuring the model registry component, see link:{odhdocshome}/working-with-model-registries/#configuring-the-model-registry-component[Configuring the model registry component].
+* A cluster administrator has configured and enabled the model registry component in your {productname-short} deployment. For more information, see link:{odhdocshome}/working-with-model-registries/#configuring-the-model-registry-component[Configuring the model registry component].
 endif::[]
 ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-{openshift-platform-url}_install[Adding administrative users in {openshift-platform}].
-* A cluster administrator has configured and enabled the model registry component in your {productname-short} deployment. For more information on configuring the model registry component, see link:{rhoaidocshome}{default-format-url}/configuring_the_model_registry_component/configuring-the-model-registry-component_model-registry-config[Configuring the model registry component].
+* A cluster administrator has configured and enabled the model registry component in your {productname-short} deployment. For more information, see link:{rhoaidocshome}{default-format-url}/configuring_the_model_registry_component/configuring-the-model-registry-component_model-registry-config[Configuring the model registry component].
 endif::[]
 * The model registry component is enabled for your {productname-short} deployment.
 * You have access to an external MySQL database which uses at least MySQL version 5.x. However, {org-name} recommends that you use MySQL version 8.x.

--- a/modules/creating-an-accelerator-profile.adoc
+++ b/modules/creating-an-accelerator-profile.adoc
@@ -7,13 +7,7 @@
 To configure accelerators for your data scientists to use in {productname-short}, you must create an associated accelerator profile. 
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::cloud-service[]
-* You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
-endif::[]
-ifdef::self-managed[]
-* You are assigned the `cluster-admin` role in {openshift-platform}.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Accelerator profiles*.

--- a/modules/customizing-component-resources.adoc
+++ b/modules/customizing-component-resources.adoc
@@ -8,7 +8,6 @@ You can customize component deployment resources by updating the `.spec.template
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
 
 .Procedure
 . Log in to the {openshift-platform} console as a cluster administrator.

--- a/modules/deleting-a-model-registry.adoc
+++ b/modules/deleting-a-model-registry.adoc
@@ -12,13 +12,7 @@ When you delete a model registry, databases connected to the model registry will
 ====
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {odh-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
-endif::[]
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-and-deploying-openshift-ai_install#adding-administrative-users-in-{openshift-platform-url}_install[Adding administrative users in {openshift-platform}].
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * An available model registry exists in your deployment.
 
 .Procedure

--- a/modules/deleting-an-accelerator-profile.adoc
+++ b/modules/deleting-an-accelerator-profile.adoc
@@ -7,13 +7,7 @@
 To discard accelerator profiles that you no longer require, you can delete them so that they do not appear on the dashboard.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::cloud-service[]
-* You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
-endif::[]
-ifdef::self-managed[]
-* You are assigned the `cluster-admin` role in {openshift-platform}.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 * The accelerator profile that you want to delete exists in your deployment. 
 
 .Procedure

--- a/modules/disabling-component-resource-customization.adoc
+++ b/modules/disabling-component-resource-customization.adoc
@@ -20,7 +20,6 @@ endif::[]
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
 
 .Procedure
 . Log in to the {openshift-platform} console as a cluster administrator.

--- a/modules/enabling-applications-connected.adoc
+++ b/modules/enabling-applications-connected.adoc
@@ -32,7 +32,7 @@ Some independent software vendor (ISV) applications must be installed in specifi
 To help you get started quickly, you can access the application's learning resources and documentation on the **Resources** page, or on the **Enabled** page by clicking the relevant link on the tile for the application.
 
 .Prerequisites
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifdef::upstream,self-managed[]
 * Your administrator has installed or configured the application on your {openshift-platform} cluster.
 endif::[]

--- a/modules/enabling-custom-images.adoc
+++ b/modules/enabling-custom-images.adoc
@@ -3,16 +3,16 @@
 [id='enabling-custom-images_{context}']
 = Enabling custom images in {productname-short}
 
-All {productname-short} admin users can import custom workbench images, by default, by selecting the *Settings* -> *Notebook images* navigation option in the {productname-short} dashboard.
+All {productname-short} administrators can import custom workbench images, by default, by selecting the *Settings* -> *Notebook images* navigation option in the {productname-short} dashboard.
 
 If the *Settings* -> *Notebook images* option is not available, check the following settings, depending on which navigation element does not appear in the dashboard:
 
 * The *Settings* menu does not appear in the {productname-short} navigation bar
 +
-The visibility of the {productname-short} dashboard's Settings menu is determined by your user permissions. By default, the **Settings* menu is available to {productname-short} administration users (users that are members of the `rhoai-admins` group). Users with the OpenShift `cluster-admin` role, are automatically added to the `rhoai-admins` group and are granted administrator access in {productname-short}. 
+The visibility of the {productname-short} dashboard's Settings menu is determined by your user permissions. By default, the *Settings* menu is available to {productname-short} administration users (users that are members of the `rhoai-admins` group). Users with the OpenShift `cluster-admin` role are automatically added to the `rhoai-admins` group and are granted administrator access in {productname-short}. 
 + 
 ifdef::upstream[]
-For more information about user permissions, see link:{odhdocshome}/managing-odh/#managing-users-and-groups[Managing users and groups].
+For more information about user permissions, see link:{odhdocshome}/managing-odh/#managing-groups-and-users[Managing users and groups].
 endif::[]
 ifndef::upstream[]
 For more information about user permissions, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-users-and-groups[Managing users and groups].

--- a/modules/enabling-custom-images.adoc
+++ b/modules/enabling-custom-images.adoc
@@ -9,7 +9,7 @@ If the *Settings* -> *Notebook images* option is not available, check the follow
 
 * The *Settings* menu does not appear in the {productname-short} navigation bar
 +
-The visibility of the {productname-short} dashboard's Settings menu is determined by your user permissions. By default, the *Settings* menu is available to {productname-short} administration users (users that are members of the `rhoai-admins` group). Users with the OpenShift `cluster-admin` role are automatically added to the `rhoai-admins` group and are granted administrator access in {productname-short}. 
+The visibility of the {productname-short} dashboard *Settings* menu is determined by your user permissions. By default, the *Settings* menu is available to {productname-short} administration users (users that are members of the `rhoai-admins` group). Users with the OpenShift `cluster-admin` role are automatically added to the `rhoai-admins` group and are granted administrator access in {productname-short}. 
 + 
 ifdef::upstream[]
 For more information about user permissions, see link:{odhdocshome}/managing-odh/#managing-groups-and-users[Managing users and groups].

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -7,13 +7,7 @@
 To use the multi-model serving platform, you must first enable the platform.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the multi-model serving platform, which uses the ModelMesh component. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
 .Procedure

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -7,13 +7,7 @@
 When you have installed KServe, you can use the {productname-long} dashboard to enable the single-model serving platform. You can also use the dashboard to enable model-serving runtimes for the platform.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in OpenShift.
-endif::[] 
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * You have installed KServe.
 * Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the single-model serving platform, which uses the KServe component. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 

--- a/modules/hiding-information-about-applications.adoc
+++ b/modules/hiding-information-about-applications.adoc
@@ -7,14 +7,13 @@
 You can view a list of available applications in the *Exploring applications* page of the {productname-short} dashboard. You can disable the following extra information that is provided about the applications by default:
 
 * Any independent software vendor (ISV) application is indicated with a label on the tile indicating “{org-name} managed”, “Partner managed”, or “Self-managed”. 
-As an admin user, you can hide the labels, for example, if you are running a self-managed environment and you want to show all available applications regardless of the support level. 
+As a cluster administrator, you can hide the labels, for example, if you are running a self-managed environment and you want to show all available applications regardless of the support level. 
 
 * When a user clicks on an application, an information panel appears and provides more information about the application, including links to quick starts or detailed documentation. You can disable the appearance of application information panels.
 
 .Prerequisite
 
 * You have cluster administrator privileges for your {openshift-platform} cluster.
-
 
 .Procedure
 

--- a/modules/importing-a-custom-workbench-image.adoc
+++ b/modules/importing-a-custom-workbench-image.adoc
@@ -18,8 +18,7 @@ ifndef::upstream[]
 endif::[]
 
 .Prerequisites
-* You have logged in to {productname-long}.
-* You have {productname-short} administrator permissions.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 * Your custom image exists in an image registry that is accessible to {productname-short}.
 
 ifdef::upstream[]

--- a/modules/installing-trustyai-service-using-dashboard.adoc
+++ b/modules/installing-trustyai-service-using-dashboard.adoc
@@ -20,19 +20,16 @@ Model monitoring with TrustyAI is only available on the ModelMesh-based _multi-m
 * If you are using TrustyAI with a database instead of PVC, a cluster administrator has configured TrustyAI to use the database, as described in link:{odhdocshome}/monitoring-data-science-models/#configuring-trustyai-with-a-database_monitor[Configuring TrustyAI with a database].
 
 ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
-
 * The data scientist has created a data science project, as described in link:{rhoaidocshome}{default-format-url}/working_on_data_science_projects/using-data-science-projects_projects#creating-a-data-science-project_projects[Creating a data science project], that contains the models that the data scientist wants to monitor.
 endif::[]
 
 ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {odh-admin-group}). If you are not using specialized groups, you are part of the {openshift-platform} administrator group.
-
 * The data scientist has created a data science project, as described in link:{odhdocshome}/working-on-data-science-projects/#creating-a-data-science-project_projects[Creating a data science project], that contains the models that the data scientist wants to monitor.
 endif::[]
 
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
+
 .Procedure
-. Log in to {productname-short}.
 . From the {productname-short} dashboard, click *Data Science Projects*.
 +
 The *Data Science Projects* page opens.

--- a/modules/managing-model-registry-permissions.adoc
+++ b/modules/managing-model-registry-permissions.adoc
@@ -9,8 +9,7 @@ You can manage access to a model registry for individual users and user groups i
 {productname-short} creates the `<model-registry-name>-users` group automatically for use with model registries. You can add users to this group in OpenShift, or ask the cluster admin to do so.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-* You have {productname-short} administrator privileges.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * An available model registry exists in your deployment.
 ifdef::upstream[]
 * The users and groups that you want to provide access to already exist in {openshift-platform}. For more information, see

--- a/modules/optimizing-the-vllm-runtime.adoc
+++ b/modules/optimizing-the-vllm-runtime.adoc
@@ -13,13 +13,7 @@ To configure the *vLLM ServingRuntime for KServe* runtime for speculative decodi
 
 .Prerequisites
 
-* You have logged in to {productname-long}.
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, `odh-admin-group`) in OpenShift.
-endif::[]
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, `oai-admin-group`) in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 ifdef::upstream[]
 * If you used the pre-installed *vLLM ServingRuntime for KServe* runtime, you duplicated the runtime to create a custom version. For more information about duplicating the pre-installed vLLM runtime, see {odhdocshome}/serving-models/#adding-a-custom-model-serving-runtime-for-the-single-model-serving-platform_serving-large-models[Adding a custom model-serving runtime for the single-model serving platform].
 endif::[]

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -4,9 +4,9 @@
 = Preventing users from adding applications to the dashboard
 
 [role='_abstract']
-By default, admin users are allowed to add applications to the {productname-short} dashboard *Application → Enabled* page.
+By default, {productname-short} administrators are allowed to add applications to the {productname-short} dashboard *Application → Enabled* page.
 
-You can disable the ability for admin users to add applications to the dashboard.
+As a cluster administrator, you can disable the ability for {productname-short} administrators to add applications to the dashboard.
 
 ifndef::upstream[]
 *Note:* The Jupyter tile is enabled by default. To disable it, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#hiding-the-default-jupyter-application_dashboard[Hiding the default Jupyter application].
@@ -35,4 +35,4 @@ endif::[]
 
 .Verification
 
-Open the {productname-short} dashboard *Application → Enabled* page. 
+* Open the {productname-short} dashboard *Application → Enabled* page. 

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -4,7 +4,7 @@
 = Preventing users from adding applications to the dashboard
 
 [role='_abstract']
-By default, {productname-short} administrators are allowed to add applications to the {productname-short} dashboard *Application → Enabled* page.
+By default, {productname-short} administrators can add applications to the {productname-short} dashboard *Application → Enabled* page.
 
 As a cluster administrator, you can disable the ability for {productname-short} administrators to add applications to the dashboard.
 

--- a/modules/reenabling-component-resource-customization.adoc
+++ b/modules/reenabling-component-resource-customization.adoc
@@ -15,7 +15,6 @@ To remove the annotation from a deployment, use the following steps to delete th
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
 
 .Procedure
 

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -68,9 +68,9 @@ disableUserManagement` | `false` | Shows the *Settings → User management* opti
 enablement` | `true` | Enables {productname-short} administrators to add applications to the {productname-short} dashboard *Applications → Enabled* page. To disable this ability, set the value to `false`.
 | `notebookController:
 enabled` | `true` | Controls the Notebook Controller options, such as whether it is enabled in the dashboard and which parts are visible.
-| `notebookSizes` | | Allows you to customize names and resources for notebooks. The Kubernetes-style sizes are shown in the drop-down menu that appears when spawning notebooks with the Notebook Controller. Note: These sizes must follow conventions. For example, requests must be smaller than limits.
+| `notebookSizes` | | Allows you to customize names and resources for notebooks. The Kubernetes-style sizes are shown in the drop-down menu that appears when launching a workbench with the Notebook Controller. Note: These sizes must follow conventions. For example, requests must be smaller than limits.
 | `ModelServerSizes` | | Allows you to customize names and resources for model servers.
-| `groupsConfig` | | Controls access to dashboard features, such as the spawner for allowed users and the cluster settings UI for {productname-short} administrators.
+| `groupsConfig` | | Controls access to dashboard features, such as the *Notebook server control panel* for allowed users and the cluster settings user interface for {productname-short} administrators.
 | `templateOrder` | | Specifies the order of custom Serving Runtime templates. When the user creates a new template, it is added to this list.
 |===
 

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -65,12 +65,12 @@ disableTrustyBiasMetrics` | `false` | Shows the *Model Bias* tab on the *Model S
 | `dashboardConfig:
 disableUserManagement` | `false` | Shows the *Settings → User management* option in the dashboard navigation menu. To hide this menu option, set the value to `true`.
 | `dashboardConfig:
-enablement` | `true` | Enables admin users to add applications to the {productname-short} dashboard *Applications → Enabled* page. To disable this ability, set the value to `false`.
+enablement` | `true` | Enables {productname-short} administrators to add applications to the {productname-short} dashboard *Applications → Enabled* page. To disable this ability, set the value to `false`.
 | `notebookController:
 enabled` | `true` | Controls the Notebook Controller options, such as whether it is enabled in the dashboard and which parts are visible.
 | `notebookSizes` | | Allows you to customize names and resources for notebooks. The Kubernetes-style sizes are shown in the drop-down menu that appears when spawning notebooks with the Notebook Controller. Note: These sizes must follow conventions. For example, requests must be smaller than limits.
 | `ModelServerSizes` | | Allows you to customize names and resources for model servers.
-| `groupsConfig` | | Controls access to dashboard features, such as the spawner for allowed users and the cluster settings UI for admin users.
+| `groupsConfig` | | Controls access to dashboard features, such as the spawner for allowed users and the cluster settings UI for {productname-short} administrators.
 | `templateOrder` | | Specifies the order of custom Serving Runtime templates. When the user creates a new template, it is added to this list.
 |===
 

--- a/modules/removing-access-to-a-data-science-project.adoc
+++ b/modules/removing-access-to-a-data-science-project.adoc
@@ -8,15 +8,9 @@ If you no longer want to work collaboratively on your data science project, you 
 
 .Prerequisites
 * You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
-endif::[]
+* You have {productname-short} administrator privileges or you are the project owner.
 * You have created a data science project.
 * You have previously shared access to your project with other users or groups.
-* You have administrator permissions or you are the project owner.
 
 .Procedure
 . From the {productname-short} dashboard, click *Data Science Projects*.

--- a/modules/requirements-for-upgrading-odh.adoc
+++ b/modules/requirements-for-upgrading-odh.adoc
@@ -35,7 +35,7 @@ For KServe (single-model serving platform), you must meet these requirements:
 
 * In {productname-long} version 1, the KServe component is a Limited Availability feature. If you enabled the `kserve` component and created models in version 1, then after you upgrade to version {vernum}, you must update some {productname-short} resources as follows:
 
-. Log in as an admin user to the {openshift-platform} cluster where {productname-short} {vernum} is installed:
+. Log in to the {openshift-platform} console as a cluster administrator:
 +
 ----
 $ oc login

--- a/modules/resolving-cuda-oom-errors.adoc
+++ b/modules/resolving-cuda-oom-errors.adoc
@@ -9,13 +9,7 @@ In certain cases, depending on the model and hardware accelerator used, the TGIS
 
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {odh-admin-group}) in {openshift-platform}.
-endif::[]
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the admin group (for example, {oai-admin-group}) in {openshift-platform}.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* > *Serving runtimes*.

--- a/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/restoring-the-default-pvc-size-for-your-cluster.adoc
@@ -11,13 +11,7 @@ To change the size of resources utilized within your {productname-short} cluster
 //Users cannot access the Jupyter server launcher or create a new notebook server until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::upstream,self-managed[]
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
-endif::[]
-ifdef::cloud-service[]
-* You are part of the administrator group for {productname-short} in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Cluster settings*.

--- a/modules/revoking-user-access-to-jupyter.adoc
+++ b/modules/revoking-user-access-to-jupyter.adoc
@@ -4,9 +4,9 @@
 = Revoking user access to Jupyter
 
 [role='_abstract']
-You can revoke a user's access to Jupyter by removing the user from the specialized user groups that define access to {productname-short}. When you remove a user from the specialized user groups, the user is prevented from accessing the {productname-short} dashboard and from using associated services that consume resources in your cluster.
+You can revoke a user's access to Jupyter by removing the user from the {productname-short} user groups that define access to {productname-short}. When you remove a user from the user groups, the user is prevented from accessing the {productname-short} dashboard and from using associated services that consume resources in your cluster.
 
-IMPORTANT: Follow these steps only if you have implemented specialized user groups to restrict access to {productname-short}. To completely remove a user from {productname-short}, you must remove them from the allowed group in your OpenShift identity provider.
+IMPORTANT: Follow these steps only if you have implemented {productname-short} user groups to restrict access to {productname-short}. To completely remove a user from {productname-short}, you must remove them from the allowed group in your OpenShift identity provider.
 
 .Prerequisites
 * You have stopped any notebook servers owned by the user you want to delete.
@@ -16,15 +16,10 @@ endif::[]
 ifdef::self-managed[]
 * You are assigned the `cluster-admin` role in {openshift-platform}.
 endif::[]
-* You are using specialized user groups for {productname-short}, and the user is part of the specialized user group, administrator group, or both.
+* You are using {productname-short} user groups, and the user is part of the user group, administrator group, or both.
 
 .Procedure
-ifdef::upstream,self-managed[]
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.
-endif::[]
-ifdef::cloud-service[]
-. In the OpenShift web console, click *User Management* -> *Groups*.
-endif::[]
 . Click the name of the group that you want to remove the user from.
 ** For administrative users, click the name of your administrator group, for example, {oai-admin-group}.
 ** For non-administrator users, click the name of your user group, for example, {oai-user-group}.

--- a/modules/selecting-admin-and-user-groups.adoc
+++ b/modules/selecting-admin-and-user-groups.adoc
@@ -11,24 +11,20 @@ After a `cluster admin` user defines additional administrator and user groups in
 
 .Prerequisites
 
-* You have administrator privileges in {productname-short} and can view the *Settings* navigation option in the {productname-short} dashboard.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 ifdef::upstream[]
-* You have logged in to {productname-long} as described in link:{odhdocshome}/getting-started-with-open-data-hub/#logging-in_get-started[Logging in to {productname-short}].
-
 * The groups that you want to select as administrator and user groups for {productname-short} already exist in {openshift-platform}. For more information, see
 link:{odhdocshome}/managing-odh/#managing-users-and-groups[Managing users and groups].
 endif::[]
 
 ifndef::upstream[]
-* You have logged in to {productname-long} as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/logging-in_get-started[Logging in to {productname-short}].
-
 * The groups that you want to select as administrator and user groups for {productname-short} already exist in {openshift-platform}. For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/index#managing-users-and-groups[Managing users and groups].
 endif::[]
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *User management*.
-. Select your {productname-short} admin groups: Under *Data science administrator groups*, click the text box and select an OpenShift group. Repeat this process to define multiple admin groups.
+. Select your {productname-short} administrator groups: Under *Data science administrator groups*, click the text box and select an OpenShift group. Repeat this process to define multiple administrator groups.
 . Select your {productname-short} user groups: Under *Data science user groups*, click the text box and select an OpenShift group. Repeat this process to define multiple user groups.
 +
 IMPORTANT: The `system:authenticated` setting allows all users authenticated in OpenShift to access {productname-short}.

--- a/modules/starting-notebook-servers-owned-by-other-users.adoc
+++ b/modules/starting-notebook-servers-owned-by-other-users.adoc
@@ -4,18 +4,16 @@
 = Starting notebook servers owned by other users
 
 [role='_abstract']
-Administrators can start a notebook server for another existing user from the Jupyter administration interface.
+{productname-short} administrators can start a notebook server for another existing user from the Jupyter administration interface.
 
 .Prerequisites
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 ifdef::upstream[]
-* You are part of the {openshift-platform} administrator group which requires  the `cluster-admin` role on {openshift-platform}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/authentication_and_authorization/using-rbac#creating-cluster-admin_using-rbac[Creating a cluster admin].
-
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 
 ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using groups, you have OpenShift `cluster-admin` privileges.
 * You have launched the Jupyter application, as described in link:{rhoaidocshome}{default-format-url}/working_with_connected_applications/using_the_jupyter_application/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].
 endif::[]
 

--- a/modules/stopping-idle-notebooks.adoc
+++ b/modules/stopping-idle-notebooks.adoc
@@ -11,13 +11,7 @@ If you have configured your cluster settings to disconnect all users from a clus
 ====
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::upstream,self-managed[]
-* You are part of the administrator group for {productname-short} in {openshift-platform}.
-endif::[]
-ifdef::cloud-service[]
-* You are part of the administrator group for {productname-short} in OpenShift.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Cluster settings*.

--- a/modules/stopping-notebook-servers-owned-by-other-users.adoc
+++ b/modules/stopping-notebook-servers-owned-by-other-users.adoc
@@ -4,11 +4,11 @@
 = Stopping notebook servers owned by other users
 
 [role='_abstract']
-Administrators can stop notebook servers that are owned by other users to reduce resource consumption on the cluster, or as part of removing a user and their resources from the cluster.
+{productname-short} administrators can stop notebook servers that are owned by other users to reduce resource consumption on the cluster, or as part of removing a user and their resources from the cluster.
 
 .Prerequisites
 
-* If you are using {productname-short} groups, you are part of the administrator group (for example, {oai-admin-group}). If you are not using groups, you have OpenShift `cluster-admin` privileges.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].

--- a/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-administrators.adoc
@@ -13,18 +13,13 @@ endif::[]
 == A user receives a *404: Page not found* error when logging in to Jupyter
 
 .Problem
-If you have configured specialized user groups for {productname-short}, the user name might not be added to the default user group for {productname-short}.
+If you have configured {productname-short} user groups, the user name might not be added to the default user group for {productname-short}.
 
 .Diagnosis
 Check whether the user is part of the default user group.
 
 . Find the names of groups allowed access to Jupyter.
-ifdef::upstream,self-managed[]
 .. Log in to the {openshift-platform} web console.
-endif::[]
-ifdef::cloud-service[]
-.. Log in to the OpenShift web console.
-endif::[]
 .. Click *User Management* -> *Groups*.
 .. Click the name of your user group, for example, {oai-user-group}.
 +

--- a/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
+++ b/modules/troubleshooting-common-problems-in-jupyter-for-users.adoc
@@ -14,21 +14,16 @@ endif::[]
 I see a *403: Forbidden* error when I log in to Jupyter::
 +
 .Problem
-If your administrator has configured specialized user groups for {productname-short}, your username might not be added to the default user group or the default administrator group for {productname-short}.
+If your cluster administrator has configured {productname-short} user groups, your username might not be added to the default user group or the default administrator group for {productname-short}.
 +
 .Resolution
- Contact your administrator so that they can add you to the correct group/s.
+ Contact your cluster administrator so that they can add you to the correct group/s.
 
 
 My notebook server does not start::
 +
 .Problem
-ifdef::cloud-service[]
-The OpenShift cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
-endif::[]
-ifdef::upstream,self-managed[]
 The {openshift-platform} cluster that hosts your notebook server might not have access to enough resources, or the Jupyter pod may have failed.
-endif::[]
 +
 .Resolution
 Check the logs in the *Events* section in OpenShift for error messages associated with the problem. For example:
@@ -40,7 +35,7 @@ Server requested
 that the pod didn't tolerate.
 ----
 +
-Contact your administrator with details of any relevant error messages so that they can perform further checks.
+Contact your cluster administrator with details of any relevant error messages so that they can perform further checks.
 
 I see a *database or disk is full* error or a *no space left on device* error when I run my notebook cells::
 +
@@ -48,5 +43,5 @@ I see a *database or disk is full* error or a *no space left on device* error wh
 You might have run out of storage space on your notebook server.
 +
 .Resolution
-Contact your administrator so that they can perform further checks.
+Contact your cluster administrator so that they can perform further checks.
 

--- a/modules/updating-access-to-a-data-science-project.adoc
+++ b/modules/updating-access-to-a-data-science-project.adoc
@@ -8,15 +8,9 @@ To change the level of collaboration on your data science project, you can updat
 
 .Prerequisites
 * You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
-endif::[]
+* You have {productname-short} administrator privileges or you are the project owner.
 * You have created a data science project.
 * You have previously shared access to your project with other users or groups.
-* You have administrator permissions or you are the project owner.
 
 .Procedure
 . From the {productname-short} dashboard, click *Data Science Projects*.

--- a/modules/updating-an-accelerator-profile.adoc
+++ b/modules/updating-an-accelerator-profile.adoc
@@ -7,13 +7,7 @@
 You can update the existing accelerator profiles in your deployment. You might want to change important identifying information, such as the display name, the identifier, or the description. 
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::cloud-service[]
-* You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
-endif::[]
-ifdef::self-managed[]
-* You are assigned the `cluster-admin` role in {openshift-platform}.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * The accelerator profile exists in your deployment.
 
 .Procedure

--- a/modules/viewing-accelerator-profiles.adoc
+++ b/modules/viewing-accelerator-profiles.adoc
@@ -5,13 +5,7 @@
 If you have defined accelerator profiles for {productname-short}, you can view, enable, and disable them from the *Accelerator profiles* page.
 
 .Prerequisites
-* You have logged in to {productname-long}.
-ifdef::cloud-service[]
-* You are part of the `cluster-admins` or `dedicated-admins` user group in your OpenShift cluster. The `dedicated-admins` user group applies only to OpenShift Dedicated.
-endif::[]
-ifdef::self-managed[]
-* You are assigned the `cluster-admin` role in {openshift-platform}.
-endif::[]
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * Your deployment contains existing accelerator profiles. 
 
 .Procedure

--- a/modules/viewing-active-pipeline-runs.adoc
+++ b/modules/viewing-active-pipeline-runs.adoc
@@ -8,6 +8,12 @@ You can view a list of pipeline runs that were previously executed in a pipeline
 
 .Prerequisites
 * You have logged in to {productname-long}.
+ifndef::upstream[]
+* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
+endif::[]
+ifdef::upstream[]
+* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
+endif::[]
 * You have previously created a data science project that is available and has a pipeline server.
 * You have imported a pipeline to an active pipeline server.
 * You have previously executed a pipeline run that is available.

--- a/modules/viewing-active-pipeline-runs.adoc
+++ b/modules/viewing-active-pipeline-runs.adoc
@@ -8,12 +8,6 @@ You can view a list of pipeline runs that were previously executed in a pipeline
 
 .Prerequisites
 * You have logged in to {productname-long}.
-ifndef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group} ) in OpenShift.
-endif::[]
-ifdef::upstream[]
-* If you are using {productname-short} groups, you are part of the user group or admin group (for example, {odh-user-group} or {odh-admin-group}) in OpenShift.
-endif::[]
 * You have previously created a data science project that is available and has a pipeline server.
 * You have imported a pipeline to an active pipeline server.
 * You have previously executed a pipeline run that is available.

--- a/modules/viewing-connected-applications.adoc
+++ b/modules/viewing-connected-applications.adoc
@@ -9,7 +9,7 @@ You can view the available open source and third-party connected applications fr
 
 .Prerequisites
 
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 
 .Procedure
 

--- a/modules/viewing-data-science-users.adoc
+++ b/modules/viewing-data-science-users.adoc
@@ -2,7 +2,7 @@
 
 [id='viewing-data-science-users_{context}']
 = Viewing {productname-short} users
-If you have defined specialized user groups for {productname-short}, you can view the users that belong to these groups.
+If you have defined {productname-short} user groups, you can view the users that belong to these groups.
 
 .Prerequisites
 * The {productname-long} user group, administrator group, or both exist.
@@ -15,15 +15,8 @@ ifdef::upstream,self-managed[]
 * You have configured a supported identity provider for {openshift-platform}.
 endif::[]
 
-
 .Procedure
-
-ifdef::upstream,self-managed[]
 . In the {openshift-platform} web console, click *User Management* -> *Groups*.
-endif::[]
-ifdef::cloud-service[]
-. In the OpenShift web console, click *User Management* -> *Groups*.
-endif::[]
 . Click the name of the group containing the users that you want to view.
 ifndef::upstream[]
 ** For administrative users, click the name of your administrator group. for example, {oai-admin-group}.

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -23,7 +23,7 @@ endif::[]
 ifndef::upstream[]
 For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifndef::upstream[]
 * If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]

--- a/modules/viewing-performance-metrics-for-deployed-model.adoc
+++ b/modules/viewing-performance-metrics-for-deployed-model.adoc
@@ -21,7 +21,7 @@ ifdef::upstream,self-managed[]
 * A cluster admin has enabled user workload monitoring (UWM) for user-defined projects on your OpenShift cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/monitoring/enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects] and link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#configuring-monitoring-for-the-single-model-serving-platform_serving-large-models[Configuring monitoring for the single-model serving platform].
 endif::[]
 
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifndef::upstream[]
 * If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]

--- a/modules/viewing-performance-metrics-for-model-server.adoc
+++ b/modules/viewing-performance-metrics-for-model-server.adoc
@@ -19,7 +19,7 @@ You can specify a time range and a refresh interval for these metrics to help yo
 
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
 
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifndef::upstream[]
 * If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]

--- a/modules/viewing-project-metrics-for-distributed-workloads.adoc
+++ b/modules/viewing-project-metrics-for-distributed-workloads.adoc
@@ -17,7 +17,7 @@ You can use these metrics to monitor the resources used by the distributed workl
 
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
 
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifndef::upstream[]
 * If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]

--- a/modules/viewing-the-status-of-distributed-workloads.adoc
+++ b/modules/viewing-the-status-of-distributed-workloads.adoc
@@ -11,7 +11,7 @@ You can track the progress of the distributed workloads, and identify corrective
 .Prerequisites
 * You have installed {productname-long}.
 * On the OpenShift cluster where {productname-short} is installed, user workload monitoring is enabled.
-* You have logged in to {productname-short}.
+* You have logged in to {productname-long}.
 ifndef::upstream[]
 * If you are using {productname-short} groups, you are part of the user group or admin group (for example, {oai-user-group} or {oai-admin-group}) in OpenShift.
 endif::[]


### PR DESCRIPTION
- Changed "administrator permissions" to "administrator privileges" 
- Changed "admin user" to "{productname-short} administrator" or "cluster administrator"
- Changed all RHOAI admin prereq bullet to:
    - You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
- Removed a few stray references to "specialized" - see https://github.com/opendatahub-io/opendatahub-documentation/pull/470