### PR TITLE
Check Managing resources book for RHOAI admin

### DIFF
--- a/modules/accessing-notebook-servers-owned-by-other-users.adoc
+++ b/modules/accessing-notebook-servers-owned-by-other-users.adoc
@@ -4,11 +4,11 @@
 = Accessing notebook servers owned by other users
 
 [role='_abstract']
-Administrators can access notebook servers that are owned by other users to correct configuration errors or to help them troubleshoot problems with their environment.
+{productname-short} administrators can access notebook servers that are owned by other users to correct configuration errors or to help them troubleshoot problems with their environment.
 
 .Prerequisites
 
-* You have OpenShift `cluster-admin` privileges.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 
 ifdef::upstream[]
 * You have launched the Jupyter application, as described in link:{odhdocshome}/working-with-connected-applications/#starting-a-jupyter-notebook-server_connected-apps[Starting a Jupyter notebook server].

--- a/modules/accessing-the-jupyter-administration-interface.adoc
+++ b/modules/accessing-the-jupyter-administration-interface.adoc
@@ -8,7 +8,7 @@ You can use the Jupyter administration interface to control notebook servers in 
 
 .Prerequisite
 
-* You have OpenShift `cluster-admin` privileges.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 
 .Procedure
 ** To access the Jupyter administration interface from {productname-short}, perform the following actions:


### PR DESCRIPTION
Reviewed prereqs of modules in the Managing resources book for RHOAI admin instead of cluster admin