### PR TITLE
RHOAIENG-16242: Updating YAML to include newly tested models

### DIFF
--- a/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
@@ -63,7 +63,7 @@ spec:
           tritonserver "--model-repository=/models/_triton_models" "--model-control-mode=explicit" "--strict-model-config=false" "--strict-readiness=false" "--allow-http=true" "--allow-grpc=true"  '
       command:
         - /bin/sh
-      image: nvcr.io/nvidia/tritonserver:23.05-py3
+      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
       name: triton
       resources:
         limits:
@@ -80,9 +80,6 @@ spec:
     - v2
   supportedModelFormats:
     - autoSelect: true
-      name: keras
-      version: "2"
-    - autoSelect: true
       name: onnx
       version: "1"
     - autoSelect: true
@@ -94,6 +91,15 @@ spec:
     - autoSelect: true
       name: tensorflow
       version: "2"
+    - autoSelect: true
+      name: tensorrt
+      version: "7"
+    - autoSelect: false
+      name: xgboost
+      version: "1"
+    - autoSelect: true
+      name: python
+      version: "1"
 ----
 . In the `metadata.name` field, make sure that the value of the runtime you are adding does not match a runtime that you have already added).
 

--- a/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-multi-model-serving-platform.adoc
@@ -63,7 +63,7 @@ spec:
           tritonserver "--model-repository=/models/_triton_models" "--model-control-mode=explicit" "--strict-model-config=false" "--strict-readiness=false" "--allow-http=true" "--allow-grpc=true"  '
       command:
         - /bin/sh
-      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
+      image: nvcr.io/nvidia/tritonserver@sha256:xxxxx
       name: triton
       resources:
         limits:

--- a/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
@@ -48,7 +48,7 @@ spec:
         - --http-port=8080
         - --allow-grpc=true
         - --allow-http=true
-      image: nvcr.io/nvidia/tritonserver:23.05-py3
+      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
       name: kserve-container
       resources:
         limits:
@@ -65,6 +65,9 @@ spec:
     - grpc-v2
   supportedModelFormats:
     - autoSelect: true
+      name: tensorrt
+      version: "8"
+    - autoSelect: true
       name: tensorflow
       version: "1"
     - autoSelect: true
@@ -76,8 +79,14 @@ spec:
     - name: pytorch
       version: "1"
     - autoSelect: true
-      name: keras
+      name: triton
       version: "2"
+    - autoSelect: true
+      name: xgboost
+      version: "1"
+    - autoSelect: true
+      name: python
+      version: "1"
 ----
 
 .. If you selected the *gRPC* API protocol, enter or paste the following YAML code directly in the embedded editor.
@@ -102,7 +111,7 @@ spec:
         - --http-port=8080
         - --allow-grpc=true
         - --allow-http=true
-      image: nvcr.io/nvidia/tritonserver:23.05-py3
+      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
       name: kserve-container
       ports:
         - containerPort: 9000
@@ -123,8 +132,8 @@ spec:
     - grpc-v2
   supportedModelFormats:
     - autoSelect: true
-      name: keras
-      version: "2"
+      name: tensorrt
+      version: "8"
     - autoSelect: true
       name: tensorflow
       version: "1"
@@ -135,6 +144,15 @@ spec:
       name: onnx
       version: "1"
     - name: pytorch
+      version: "1"
+    - autoSelect: true
+      name: triton
+      version: "2"
+    - autoSelect: true
+      name: xgboost
+      version: "1"
+    - autoSelect: true
+      name: python
       version: "1"
 volumes:
   - emptyDir: null

--- a/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
@@ -48,7 +48,7 @@ spec:
         - --http-port=8080
         - --allow-grpc=true
         - --allow-http=true
-      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
+      image: nvcr.io/nvidia/tritonserver@sha256:xxxxx
       name: kserve-container
       resources:
         limits:
@@ -111,7 +111,7 @@ spec:
         - --http-port=8080
         - --allow-grpc=true
         - --allow-http=true
-      image: nvcr.io/nvidia/tritonserver@sha256:1bde45b946f50f3e23a562cc5401d5ae7af8cb4a2daf037a55548241fadbd6f0
+      image: nvcr.io/nvidia/tritonserver@sha256:xxxxx
       name: kserve-container
       ports:
         - containerPort: 9000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating the YAML configuration for triton runtime to include newly tested models

## How Has This Been Tested?
Local build

## Preview [KServe-REST]
<img width="705" alt="Screenshot 2024-12-04 at 12 04 30 PM" src="https://github.com/user-attachments/assets/311a5a60-92e2-43a4-a739-c2c6c9ebb2bb">


## Preview [KServe-GRPC]
<img width="654" alt="Screenshot 2024-12-04 at 12 04 44 PM" src="https://github.com/user-attachments/assets/d6145729-c218-47ca-9e90-0ac9c5f7a315">


## Preview [Modelmesh]
<img width="725" alt="Screenshot 2024-12-04 at 12 08 50 PM" src="https://github.com/user-attachments/assets/0f6cc049-19be-4a4a-9ecd-2017bea4986b">

