### PR TITLE
Adding note highlighting endpoints not supported by ModelMesh

### DIFF
--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -220,8 +220,8 @@ endif::[]
 ====
 ModelMesh does not support the following endpoints:
 
-* `/v2/health/live`
-* `/v2/health/ready`
+* `v2/health/live`
+* `v2/health/ready`
 * `v2/models/<model_name>[/versions/]/ready`
 ====
 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -218,7 +218,7 @@ endif::[]
 
 [NOTE]
 ====
-ModelMesh does not support the following endpoints:
+ModelMesh does not support the following REST endpoints:
 
 * `v2/health/live`
 * `v2/health/ready`

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -216,6 +216,15 @@ endif::[]
 * `v2`
 --
 
+[NOTE]
+====
+ModelMesh does not support the following endpoints:
+
+* `/v2/health/live`
+* `/v2/health/ready`
+* `/v2/models/<modelname>/ready`
+====
+
 .Example command
 ifndef::upstream[]
 [source]

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -222,7 +222,7 @@ ModelMesh does not support the following endpoints:
 
 * `/v2/health/live`
 * `/v2/health/ready`
-* `/v2/models/<modelname>/ready`
+* `v2/models/<model_name>[/versions/]/ready`
 ====
 
 .Example command


### PR DESCRIPTION
Adds a note to modules/ref-inference-endpoints.adoc, highlighting the REST endpoints that ModelMesh doesn't support.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
