### PR TITLE
RHOAIENG-18466_rev1: Addressing SME/QE feedback

### DIFF
--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -40,7 +40,7 @@ A project details page opens.
 The *Deploy model* dialog opens.
 . Configure properties for deploying your model as follows:
 .. In the *Model deployment name* field, enter a unique name for the deployment.
-.. From the *NVIDIA NIM* list, select the NVIDIA NIM model that you want to deploy.
+.. From the *NVIDIA NIM* list, select the NVIDIA NIM model that you want to deploy. For more information, see link:https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html[Supported Models]
 .. In the *NVIDIA NIM storage size* field, specify the size of the cluster storage instance that will be created to store the NVIDIA NIM model.
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
@@ -48,11 +48,6 @@ The *Deploy model* dialog opens.
 +
 The *Number of accelerators* field appears.
 .. In the *Number of accelerators* field, specify the number of accelerators to use. The default value is 1.
-. Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
-. To require token authorization for inference requests to the deployed model, perform the following actions:
-.. Select *Require token authorization*.
-.. In the *Service account name* field, enter the service account name that the token will be generated for.
-.. To add an additional service account, click *Add a service account* and enter another service account name.
 . Click *Deploy*.
 
 .Verification

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -40,7 +40,7 @@ A project details page opens.
 The *Deploy model* dialog opens.
 . Configure properties for deploying your model as follows:
 .. In the *Model deployment name* field, enter a unique name for the deployment.
-.. From the *NVIDIA NIM* list, select the NVIDIA NIM model that you want to deploy. For more information, see link:https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html[Supported Models]
+.. From the *NVIDIA NIM* list, select the NVIDIA NIM model that you want to deploy. For more information, see link:https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html[Supported Models^]
 .. In the *NVIDIA NIM storage size* field, specify the size of the cluster storage instance that will be created to store the NVIDIA NIM model.
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
@@ -57,3 +57,4 @@ The *Number of accelerators* field appears.
 .Additional resources
 
 * link:https://docs.nvidia.com/nim/large-language-models/latest/api-reference.html[NVIDIA NIM API reference^]
+* link:https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html[Supported Models^]

--- a/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
+++ b/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
@@ -16,10 +16,10 @@ endif::[]
 .Prerequisites
 * You have logged in to {productname-long} as an administrator.
 ifdef::upstream[]
-* You have enabled the single-model serving platform as described in link:{odhdocshome}/serving-models/#deploying-models-using-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
+* You have enabled the single-model serving platform. You do not need to enable a preinstalled runtime. For more information about enabling the single-model serving platform, see link:{odhdocshome}/serving-models/#deploying-models-using-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
 endif::[]
 ifndef::upstream[]
-* You have enabled the single-model serving platform as described in link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#enabling-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
+* You have enabled the single-model serving platform. You do not need to enable a preinstalled runtime. For more information about enabling the single-model serving platform, see link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#enabling-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
 endif::[]
 * The following {productname-short} dashboard configuration is enabled.
 +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Addressing SME/QE feedback:

- Removed model route options (applicable only to 2.17(
- Added that users need to enable single-model serving, but do not need to enable a preinstalled runtime.
- Added link to NVIDIA supported models

## Downstream Preview
[NVIDIA_NIM.pdf](https://github.com/user-attachments/files/18594025/NVIDIA_NIM.pdf)

## Upstream Preview
<img width="477" alt="Screenshot 2025-01-29 at 4 02 49 PM" src="https://github.com/user-attachments/assets/fa20d9b2-ad73-42e2-a7e7-cfcf08862b01" />
<img width="480" alt="Screenshot 2025-01-29 at 4 03 01 PM" src="https://github.com/user-attachments/assets/ca5ef403-2af9-463a-addf-bc31067a844c" />


## How Has This Been Tested?
Local build


