### PR TITLE
2161 link fixes: Correcting ID of oci image serving module

### DIFF
--- a/modules/deploying-model-stored-in-oci-image.adoc
+++ b/modules/deploying-model-stored-in-oci-image.adoc
@@ -1,6 +1,6 @@
 :_module-type: PROCEDURE
 
-[id="deploying-model-stored-in-oci-container_{context}"]
+[id="deploying-model-stored-in-oci-image_{context}"]
 = Deploying a model stored in an OCI image
 
 [role='_abstract']


### PR DESCRIPTION
The ID of modules/deploying-model-stored-in-oci-image.adoc doesn't match its title or filename. Updating to correct.

Checked for other instances of 'deploying-model-stored-in-oci-container' upstream and down, looks like just this one.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
