### PR TITLE
ENG-19276: Removing listed order Operator install req for model reg

### DIFF
--- a/modules/configuring-the-model-registry-component.adoc
+++ b/modules/configuring-the-model-registry-component.adoc
@@ -19,7 +19,7 @@ endif::[]
 ifdef::upstream[]
 [IMPORTANT]
 ====
-You must install the required Operators in the listed order. You should install the Open Data Hub Operator only after the other listed Operators are installed and in a running state.
+You should install the {productname-long} Operator only after the other listed Operators are installed and in a running state.
 
 For more information about installing Operators in OpenShift, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
 
@@ -30,7 +30,7 @@ endif::[]
 ifndef::upstream[]
 [IMPORTANT]
 ====
-You must install the required Operators in the listed order. You should install the {productname-long} Operator only after the other listed Operators are installed and in a running state.
+You should install the {productname-long} Operator only after the other listed Operators are installed and in a running state.
 
 For more information about installing Operators in OpenShift, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
 


### PR DESCRIPTION
Removes a line from 2 notes in the modules/configuring-the-model-registry-component.adoc module, removing the requirement for prerequisite Operators to be installed in a specific order.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
