### PR TITLE
[DRAFT]  - ENG-16992 custom namespace docs draft

### DIFF
--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -8,14 +8,17 @@ ifdef::context[:parent-context: {context}]
 = Installing Open Data Hub version 2
 
 [role='_abstract']
-You can install Open Data Hub version 2 on your OpenShift Container Platform from the OpenShift web console. 
-For information about upgrading the Open Hub Operator, see link:{odhdocshome}/upgrading-open-data-hub[Upgrading Open Data Hub].
+You can install {productname-short} version 2 on your {openshift-platform} from the OpenShift web console. 
+For information about upgrading the {productname-short} Operator, see link:{odhdocshome}/upgrading-open-data-hub[Upgrading Open Data Hub].
  
-Installing Open Data Hub involves the following tasks:
+Installing {productname-short} involves the following tasks:
 
-. Installing the Open Data Hub Operator.
-. Installing Open Data Hub components.
-. Accessing the Open Data Hub dashboard.
+. Optional: Configuring custom namespaces.
+. Installing the {productname-short} Operator.
+. Installing {productname-short} components.
+. Accessing the {productname-short} dashboard.
+
+include::modules/configuring-custom-namespaces.adoc[leveloffset=+1]
 
 include::modules/installing-the-odh-operator-v2.adoc[leveloffset=+1]
 

--- a/assemblies/installing-odh-v2.adoc
+++ b/assemblies/installing-odh-v2.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 = Installing Open Data Hub version 2
 
 [role='_abstract']
-You can install {productname-short} version 2 on your {openshift-platform} from the OpenShift web console. 
+You can install {productname-short} version 2 on {openshift-platform} from the OpenShift web console. 
 For information about upgrading the {productname-short} Operator, see link:{odhdocshome}/upgrading-open-data-hub[Upgrading Open Data Hub].
  
 Installing {productname-short} involves the following tasks:

--- a/modules/configuring-custom-namespaces.adoc
+++ b/modules/configuring-custom-namespaces.adoc
@@ -1,0 +1,33 @@
+:_module-type: PROCEDURE
+
+[id="configuring-custom-namespaces"]
+= Configuring custom namespaces
+
+[role='_abstract']
+By default, {productname-short} uses predefined namespaces, but you can define a custom namespace for the operator and `DSCI.applicationNamespace` as needed. Namespaces created by {productname-short} typically include `openshift` or `redhat` in their name. These system namespaces should not be renamed, as they are required for {productname-short} to function properly.
+
+.Prerequisites
+* You have access to a {productname-short} cluster with cluster administrator privileges.
+* You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI^].
+
+.Procedure
+. In a terminal window, if you are not already logged in to your OpenShift cluster as a cluster administrator, log in to the OpenShift CLI as shown in the following example:
++
+[source,subs="+quotes"]
+----
+oc login __<openshift_cluster_url>__ -u __<admin_username>__ -p __<password>__
+----
+. Enter the following command to create the custom namespace. 
++
+[source]
+----
+oc create namespace <custom_namespace>
+----
+. If you are creating a namespace for a `DSCI.applicationNamespace`, enter the following command to add the correct label:
++
+[source]
+----
+oc label namespace <application_namespace> opendatahub.io/application-namespace=true
+----
+
+//.Additional information

--- a/modules/configuring-custom-namespaces.adoc
+++ b/modules/configuring-custom-namespaces.adoc
@@ -4,7 +4,7 @@
 = Configuring custom namespaces
 
 [role='_abstract']
-By default, {productname-short} uses predefined namespaces, but you can define a custom namespace for the operator and `DSCI.applicationNamespace` as needed. Namespaces created by {productname-short} typically include `openshift` or `redhat` in their name. These system namespaces should not be renamed, as they are required for {productname-short} to function properly.
+By default, {productname-short} uses predefined namespaces, but you can define a custom namespace for the operator and `DSCI.applicationNamespace` as needed. Namespaces created by {productname-short} typically include `openshift` or `redhat` in their name. These system namespaces should not be renamed because they are required for {productname-short} to function properly.
 
 .Prerequisites
 * You have access to a {productname-short} cluster with cluster administrator privileges.
@@ -17,7 +17,7 @@ By default, {productname-short} uses predefined namespaces, but you can define a
 ----
 oc login __<openshift_cluster_url>__ -u __<admin_username>__ -p __<password>__
 ----
-. Enter the following command to create the custom namespace. 
+. Enter the following command to create the custom namespace:
 +
 [source]
 ----

--- a/modules/installing-the-odh-operator-v2.adoc
+++ b/modules/installing-the-odh-operator-v2.adoc
@@ -7,6 +7,7 @@
 * You are using OpenShift Container Platform {ocp-minimum-version} or later.
 * Your OpenShift cluster has a minimum of 16 CPUs and 32GB of memory across all OpenShift worker nodes.
 * You have cluster administrator privileges for your OpenShift Container Platform cluster.
+* If you are using custom namespaces, you have created and labelled them as required. 
 * If you are installing {productname-short} 2.10.0 or later with data science pipelines, ensure your cluster does not have a separate installation of Argo Workflows that was not installed by {productname-short}.
 +
 [IMPORTANT]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Documentation on creating custom namespace before installing RHOAI.
Namespaces created by RHOAI tend to have “openshift”, “redhat”, etc, in their name. These namespaces should not be renamed because they are system namespaces and need the default name for RHOAI to function properly. 

However, customers want to install operators in custom-named namespaces. Renaming the namespace is particularly needed in Watsonx.ai. 

This feature would allow the customer to define a custom name when installing the operator namespace and DSCI.applicationNamespace, which are the two main use cases in customer requests for this feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
