### PR TITLE
ENG-20217 - Initial commit of the draft of the generic accelerator en…

### DIFF
--- a/modules/enabling-accelerators.adoc
+++ b/modules/enabling-accelerators.adoc
@@ -1,0 +1,68 @@
+:_module-type: PROCEDURE
+//:disconnected:
+//:upstream:
+//:self-managed:
+
+[id='enabling-accelerators_{context}']
+= Enabling Accelerators
+
+[role='_abstract']
+Before you can use an accelerator in {productname-short}, you must install the relevant software components. The installation process varies based on the accelerator type.
+
+.Prerequisites
+* You have logged in to your {openshift-platform} cluster.
+* You have the `cluster-admin` role in your {openshift-platform} cluster.
+* You have installed an accelerator and confirmed that it is detected in your environment.
+
+.Procedure
+. Follow the appropriate documentation to enable your accelerator:
+ifndef::upstream[]
+* **NVIDIA GPUs**: See link:{rhoaidocshome}{default-format-url}/working_with_accelerators/enabling-nvidia-gpus_accelerators[Enabling NVIDIA GPUs].
+* **Intel Gaudi AI accelerators**: See link:{rhoaidocshome}{default-format-url}/working_with_accelerators/intel-gaudi-ai-accelerator-integration_accelerators[Enabling Intel Gaudi AI accelerators].
+* **AMD GPUs**: See link:{rhoaidocshome}{default-format-url}/working_with_accelerators/amd-gpu-integration_accelerators[Enabling AMD GPUs].
+endif::[]
+ifdef::upstream[]
+* **NVIDIA GPUs**: See link:{odhdocshome}/working-with-accelerators/#enabling-nvidia-gpus_accelerators[Enabling NVIDIA GPUs].
+* **Intel Gaudi AI accelerators**: See link:{odhdocshome}/working-with-accelerators/#intel-gaudi-ai-accelerator-integration_accelerators[Intel Gaudi AI Accelerator integration].
+* **AMD GPUs**: See link:{odhdocshome}/working-with-accelerators/#amd-gpu-integration_accelerators[AMD GPU Integration].
+endif::[]
+. After installing your accelerator, create an accelerator profile as described in:
+ifndef::upstream[]
+link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+endif::[]
+ifdef::upstream[]
+link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+endif::[]
+
+.Verification
+* From the *Administrator* perspective, go to the *Operators* -> *Installed Operators* page. Confirm that the following Operators appear:
+
+** The Operator for your accelerator 
+** Node Feature Discovery (NFD)
+** Kernel Module Management (KMM)
+
+* The accelerator is correctly detected a few minutes after full installation of the Node Feature Discovery (NFD) and the relevant accelerator Operator. The {openshift-platform} command line interface (CLI) displays the appropriate output for the GPU worker node. For example, here is output confirming that an NVIDIA GPU is detected: 
++
+[source]
+----
+# Expected output when the accelerator is detected correctly
+oc describe node <node name>
+...
+Capacity:
+  cpu:                4
+  ephemeral-storage:  313981932Ki
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             16076568Ki
+  nvidia.com/gpu:     1
+  pods:               250
+Allocatable:
+  cpu:                3920m
+  ephemeral-storage:  288292006229
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             12828440Ki
+  nvidia.com/gpu:     1
+  pods:               250 
+----
+

--- a/working-with-accelerators.adoc
+++ b/working-with-accelerators.adoc
@@ -20,7 +20,7 @@ Use accelerators, such as NVIDIA GPUs, AMD GPUs, and Intel Gaudi AI accelerators
 
 //Overview of accelerators
 include::modules/overview-of-accelerators.adoc[leveloffset=+1]
-
+include::modules/enabling-accelerators.adoc[leveloffset=+1]
 //Specific partner content
 //NVIDIA GPUs
 //include::modules/nvidia-gpu-integration.adoc[leveloffset=+1]


### PR DESCRIPTION
…ablement module

<!--- Provide a general summary of your changes in the Title above -->

## Description
At the moment, the RHOAI installation guide documentation only contains information on "Enabling NVIDIA GPUs". It does not cover enabling Intel Gaudi or AMD GPU accelerators. We already have this documentation in other areas of the RHOAI docs, but we need to add this to the installation guide. The easiest way to do this would be to create a generic module containing the relevant links to the enablement documentation for Intel and AMD, whilst retaining the NVIDIA content.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
