### PR TITLE
ENG-19598: Removes reference to ray:2.35.0-py39-rocm62 file

### DIFF
--- a/modules/creating-a-custom-training-image.adoc
+++ b/modules/creating-a-custom-training-image.adoc
@@ -32,12 +32,6 @@ The following table shows some example base training images:
 
 | Ray
 | ROCm
-| 3.9
-| `ray:2.35.0-py39-rocm62`
-| Ray 2.35.0, Python 3.9, ROCm 6.2
-
-| Ray
-| ROCm
 | 3.11
 | `ray:2.35.0-py311-rocm62`
 | Ray 2.35.0, Python 3.11, ROCm 6.2


### PR DESCRIPTION
ENG-19598: Removes reference to ray:2.35.0-py39-rocm62 file