### PR TITLE
Uploading Model Training Data module and references 

### DIFF
--- a/assemblies/setting-up-trustyai-for-your-project.adoc
+++ b/assemblies/setting-up-trustyai-for-your-project.adoc
@@ -17,7 +17,7 @@ After setting up, a data scientist can create and view bias and data drift metri
 
 include::modules/authenticating-trustyai-service.adoc[leveloffset=+1]
 
-include::modules/upload-model-training-data-to-trustyai.adoc[leveloffset=+1]
+include::modules/uploading-training-data-to-trustyai.adoc[leveloffset=+1]
 
 include::modules/sending-training-data-to-trustyai.adoc[leveloffset=+1]
 

--- a/assemblies/setting-up-trustyai-for-your-project.adoc
+++ b/assemblies/setting-up-trustyai-for-your-project.adoc
@@ -10,12 +10,14 @@ ifdef::context[:parent-context: {context}]
 To set up model monitoring with TrustyAI for a data science project, a data scientist does the following tasks:
 
 * Authenticate the TrustyAI service
-* Send training data to TrustyAI for bias or data drift monitoring
+* Upload and send training data to TrustyAI for bias or data drift monitoring
 * Label your data fields (optional)
 
 After setting up, a data scientist can create and view bias and data drift metrics for deployed models. 
 
 include::modules/authenticating-trustyai-service.adoc[leveloffset=+1]
+
+include::modules/upload-model-training-data-to-trustyai.adoc[leveloffset=+1]
 
 include::modules/sending-training-data-to-trustyai.adoc[leveloffset=+1]
 

--- a/modules/sending-training-data-to-trustyai.adoc
+++ b/modules/sending-training-data-to-trustyai.adoc
@@ -17,6 +17,8 @@ ifdef::upstream[]
 * You authenticated the TrustyAI service as described in link:{odhdocshome}/monitoring-data-science-models/#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service].
 endif::[]
 
+* You have uploaded model training data to TrustyAI.
+
 * Your deployed model is registered with TrustyAI. 
 +
 Verify that the TrustyAI service has registered your deployed model, as follows:

--- a/modules/uploading-training-data-to-trustyai.adoc
+++ b/modules/uploading-training-data-to-trustyai.adoc
@@ -8,7 +8,7 @@ Upload training data to use with TrustyAI for bias monitoring or data drift dete
 
 .Prerequisites
 
-* Your OpenShift cluster administrator added you as a user to the {openshift-platform} cluster and has installed the TrustyAI service for the data science project that contains the deployed models.
+* Your cluster administrator added you as a user to the {openshift-platform} cluster and has installed the TrustyAI service for the data science project that contains the deployed models.
 
 * You have training data to upload.
 
@@ -37,22 +37,22 @@ curl -sk $TRUSTY_ROUTE/data/upload  \
   -d @data/training_data.json
 ----
 
-. The message `1000 datapoints successfully added to gaussian-credit-model data` appears if the upload was successful.
+. The following message appears if the upload was successful: `1000 datapoints successfully added to gaussian-credit-model data`.
 
 .Verification
 
-. Verify that TrustyAI has received the data via the `/info` endpoint by inputting this query:
+* Verify that TrustyAI has received the data via the `/info` endpoint by inputting this query:
 +
 ----
 curl -H 'Authorization: Bearer ${TOKEN}' \
     $TRUSTY_ROUTE/info | jq ".[0].data"
 ----
 
-. The output returns a json file containing information for the model:
+The output returns a json file containing the following information for the model:
 
-.. The names, data types, and positions of fields in the input and output.
+* The names, data types, and positions of fields in the input and output.
 
-.. The observed values that these fields take (usually `null`, because there are too many unique feature values to enumerate).
+* The observed values that these fields take. This value is usually `null` because there are too many unique feature values to enumerate.
 
-.. The total number of input-output pairs observed (it should be `1000`).
+* The total number of input-output pairs observed. It should be `1000`.
 

--- a/modules/uploading-training-data-to-trustyai.adoc
+++ b/modules/uploading-training-data-to-trustyai.adoc
@@ -10,10 +10,11 @@ Upload training data to use with TrustyAI for bias monitoring or data drift dete
 
 * Your cluster administrator added you as a user to the {openshift-platform} cluster and has installed the TrustyAI service for the data science project that contains the deployed models.
 
-* You have training data to upload.
+* You have model training data to upload.
 
 ifndef::upstream[]
-* You authenticated the TrustyAI service as described in link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/setting-up-trustyai-for-your-project_monitor#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service]. 
+* You authenticated the TrustyAI service as described in link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/
+setting-up-trustyai-for-your-project_monitor#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service]. 
 endif::[]
 ifdef::upstream[]
 * You authenticated the TrustyAI service as described in link:{odhdocshome}/monitoring-data-science-models/#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service].
@@ -37,7 +38,8 @@ curl -sk $TRUSTY_ROUTE/data/upload  \
   -d @data/training_data.json
 ----
 
-. The following message appears if the upload was successful: `1000 datapoints successfully added to gaussian-credit-model data`.
++
+The following message appears if the upload was successful: `1000 datapoints successfully added to gaussian-credit-model data`.
 
 .Verification
 
@@ -48,11 +50,12 @@ curl -H 'Authorization: Bearer ${TOKEN}' \
     $TRUSTY_ROUTE/info | jq ".[0].data"
 ----
 
++
 The output returns a json file containing the following information for the model:
 
-* The names, data types, and positions of fields in the input and output.
+** The names, data types, and positions of fields in the input and output.
 
-* The observed values that these fields take. This value is usually `null` because there are too many unique feature values to enumerate.
+** The observed values that these fields take. This value is usually `null` because there are too many unique feature values to enumerate.
 
-* The total number of input-output pairs observed. It should be `1000`.
+** The total number of input-output pairs observed. It should be `1000`.
 

--- a/modules/uploading-training-data-to-trustyai.adoc
+++ b/modules/uploading-training-data-to-trustyai.adoc
@@ -1,0 +1,58 @@
+:_module-type: PROCEDURE
+
+[id="uploading-training-data-to-trustyai_{context}"]
+= Uploading training data to TrustyAI
+
+[role='_abstract']
+Upload training data to use with TrustyAI for bias monitoring or data drift detection.
+
+.Prerequisites
+
+* Your OpenShift cluster administrator added you as a user to the {openshift-platform} cluster and has installed the TrustyAI service for the data science project that contains the deployed models.
+
+* You have training data to upload.
+
+ifndef::upstream[]
+* You authenticated the TrustyAI service as described in link:{rhoaidocshome}{default-format-url}/monitoring_data_science_models/setting-up-trustyai-for-your-project_monitor#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service]. 
+endif::[]
+ifdef::upstream[]
+* You authenticated the TrustyAI service as described in link:{odhdocshome}/monitoring-data-science-models/#authenticating-trustyai-service_monitor[Authenticating the TrustyAI service].
+endif::[]
+
+
+.Procedure
+
+. Set the `TRUSTY_ROUTE` variable to the external route for the TrustyAI service in your project:
++
+----
+TRUSTY_ROUTE=https://$(oc get route/trustyai-service --template={{.spec.host}})
+----
+
+. Send the training data to the `/data/upload` endpoint:
++
+----
+curl -sk $TRUSTY_ROUTE/data/upload  \
+  --header 'Authorization: Bearer ${TOKEN}' \
+  --header 'Content-Type: application/json' \
+  -d @data/training_data.json
+----
+
+. The message `1000 datapoints successfully added to gaussian-credit-model data` appears if the upload was successful.
+
+.Verification
+
+. Verify that TrustyAI has received the data via the `/info` endpoint by inputting this query:
++
+----
+curl -H 'Authorization: Bearer ${TOKEN}' \
+    $TRUSTY_ROUTE/info | jq ".[0].data"
+----
+
+. The output returns a json file containing information for the model:
+
+.. The names, data types, and positions of fields in the input and output.
+
+.. The observed values that these fields take (usually `null`, because there are too many unique feature values to enumerate).
+
+.. The total number of input-output pairs observed (it should be `1000`).
+


### PR DESCRIPTION
Uploading Model Training Data module and references; 

Content (in modified format) from https://trustyai-explainability.github.io/trustyai-site/main/data-drift-monitoring.html#_upload_model_training_data_to_trustyai 

