### PR TITLE
ENG-21266 initial draft of the hardware profile docs

### DIFF
--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -63,14 +63,12 @@ The *Add model server* dialog opens.
 If you are using a _custom_ model-serving runtime with your model server and want to use GPUs, you must ensure that your custom runtime supports GPUs and is appropriately configured to use them.
 ====
 . In the *Number of model replicas to deploy* field, specify a value.
-. From the *Model server size* list, select a value.
-. Optional: If you selected *Custom* in the preceding step, configure the following settings in the *Model server size* section to customize your model server:
-.. In the *CPUs requested* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
-.. In the *CPU limit* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
-.. In the *Memory requested* field, specify the requested memory for the model server in gibibytes (Gi).
-.. In the *Memory limit* field, specify the maximum memory limit for the model server in gibibytes (Gi).
-. Optional: From the *Accelerator* list, select an accelerator.
-.. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
+. From the *Hardware profile* list, select a hardware profile.
+. Optional: Click *Customize resource requests and limit* and update the following values:
+.. In the *CPUs requests* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+.. In the *CPU limits* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+.. In the *Memory requests* field, specify the requested memory for the model server in gibibytes (Gi).
+.. In the *Memory limits* field, specify the maximum memory limit for the model server in gibibytes (Gi).
 . Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
 . Optional: In the *Token authentication* section, select the *Require token authentication* checkbox to require token authentication for your model server. To finish configuring token authentication, perform the following actions:
 .. In the *Service account name* field, enter a service account name for which the token will be generated. The generated token is created and displayed in the *Token secret* field when the model server is configured.

--- a/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
+++ b/modules/configuring-a-recommended-accelerator-for-notebook-images.adoc
@@ -28,7 +28,7 @@ The *Update notebook image* dialog opens.
 +
 [NOTE]
 ====
-If you have already configured an accelerator identifier for a notebook image, you can specify a recommended accelerator for the notebook image by creating an associated accelerator profile. To do this, click *Create profile* on the row containing the notebook image and complete the relevant fields. If the notebook image does not contain an accelerator identifier, you must manually configure one before creating an associated accelerator profile.  
+If you have already configured an accelerator identifier for a notebook image, you can specify a recommended accelerator for the notebook image by creating an associated hardware profile. To do this, click *Create profile* on the row containing the notebook image and complete the relevant fields. If the notebook image does not contain an accelerator identifier, you must manually configure one before creating an associated hardware profile.  
 ====
 
 .Verification

--- a/modules/creating-a-hardware-profile.adoc
+++ b/modules/creating-a-hardware-profile.adoc
@@ -26,7 +26,7 @@ The *Create hardware profile* dialog appears.
 . Optional: Configure node resource request limits:
 .. Click *Add resource*. 
 +
-The *Add resource* dialog opens
+The *Add resource* dialog opens.
 .. In the *Resource label* field, enter a unique resource label. 
 .. In the *Resource identifier* field, enter a unique resource identifier. 
 .. From the *Resource type* field, select x from the list. 
@@ -39,7 +39,7 @@ The *Add resource* dialog opens
 . Optional: Add a node selector to schedule pods on nodes with matching labels.
 .. Click *Add node selector*. 
 +
-The *Add node selector* dialog opens
+The *Add node selector* dialog opens.
 .. In the *Key* field, enter a node selection key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Value* field, enter a node selection value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. Click *Add*.
@@ -57,7 +57,7 @@ The *Add toleration* dialog opens.
 * *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
 .. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
-.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
+.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition:
 ** *Forever* - Pods stays permanently bound to a node. 
 ** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.
 .. Click *Add*.
@@ -65,7 +65,7 @@ The *Add toleration* dialog opens.
 
 .Verification
 * The hardware profile appears on the *Hardware profiles* page.
-* The *Hardware profile* appears in the *Hardware profiles* list on the *Create workbench* page.
+* The hardware profile appears in the *Hardware profiles* list on the *Create workbench* page.
 * The hardware profile appears on the *Instances* tab on the details page for the `HardwareProfile` custom resource definition (CRD).
 
 [role='_additional-resources']

--- a/modules/creating-a-hardware-profile.adoc
+++ b/modules/creating-a-hardware-profile.adoc
@@ -13,10 +13,10 @@ To configure specific hardware configurations for your data scientists to use in
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Hardware profiles*.
 +
-The *Hardware profiles* page appears, displaying existing hardware profiles. To enable or disable an existing hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enable* column.
+The *Hardware profiles* page appears, displaying existing hardware profiles. To enable or disable an existing hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enabled* column.
 . Click *Create hardware profile*. 
 +
-The *Create hardware profile* dialog appears.
+The *Create hardware profile* page appears.
 . In the *Name* field, enter a name for the hardware profile.
 . Optional: To change the default name of your Kubernetes resource, click *Edit resource name* and enter a name in the *Resource name* field. The resource name cannot be edited after creation.
 . Optional: In the *Description* field, enter a description for the hardware profile.
@@ -29,7 +29,7 @@ The *Create hardware profile* dialog appears.
 The *Add resource* dialog opens.
 .. In the *Resource label* field, enter a unique resource label. 
 .. In the *Resource identifier* field, enter a unique resource identifier. 
-.. From the *Resource type* field, select x from the list. 
+.. From the *Resource type* field, select a resource type from the list. 
 .. In the *Default* field, enter the default resource request limit. This value must be equal to or between the minimum and maximum limits.
 .. In the *Minimum allowed* field, enter the minimum number of resources that users can request. 
 .. In the *Maximum allowed* field, enter the maximum number of resources that users can request:

--- a/modules/creating-a-hardware-profile.adoc
+++ b/modules/creating-a-hardware-profile.adoc
@@ -1,0 +1,75 @@
+:_module-type: PROCEDURE
+
+[id="creating-a-hardware-profile_{context}"]
+= Creating a hardware profile
+
+[role='_abstract']
+To configure specific hardware configurations for your data scientists to use in {productname-short}, you must create an associated hardware profile.
+
+.Prerequisites
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
+* The relevant hardware is installed and you have confirmed that it is detected in your environment.
+
+.Procedure
+. From the {productname-short} dashboard, click *Settings* -> *Hardware profiles*.
++
+The *Hardware profiles* page appears, displaying existing hardware profiles. To enable or disable an existing hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enable* column.
+. Click *Create hardware profile*. 
++
+The *Create hardware profile* dialog appears.
+. In the *Name* field, enter a name for the hardware profile.
+. Optional: To change the default name of your Kubernetes resource, click *Edit resource name* and enter a name in the *Resource name* field. The resource name cannot be edited after creation.
+. Optional: In the *Description* field, enter a description for the hardware profile.
+. In the *Visiblity* section, set the hardware profile visibility level:
+.. To access the hardware profile in all areas of {productname-short}, leave the *Visible everywhere* radio button selected.
+.. Click the *Limited visibility* radio button to limit the areas of {productname-short} where your data scientists can use the hardware profile.
+. Optional: Configure node resource request limits:
+.. Click *Add resource*. 
++
+The *Add resource* dialog opens
+.. In the *Resource label* field, enter a unique resource label. 
+.. In the *Resource identifier* field, enter a unique resource identifier. 
+.. From the *Resource type* field, select x from the list. 
+.. In the *Default* field, enter the default resource request limit. This value must be equal to or between the minimum and maximum limits.
+.. In the *Minimum allowed* field, enter the minimum number of resources that users can request. 
+.. In the *Maximum allowed* field, enter the maximum number of resources that users can request:
+... To set a specific maximum request limit, click the *Set maximum limit* radio button and enter a value.
+... To set no maximum request limit, click the *No maximum limit* radio button.
+.. Click *Add*.
+. Optional: Add a node selector to schedule pods on nodes with matching labels.
+.. Click *Add node selector*. 
++
+The *Add node selector* dialog opens
+.. In the *Key* field, enter a node selection key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a node selection value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. Click *Add*.
+. Optional: Add a toleration to schedule pods with matching taints.
+.. Click *Add toleration*. 
++
+The *Add toleration* dialog opens.
+.. From the *Operator* list, select one of the following options:
+* *Equal* - The *key/value/effect* parameters must match. This is the default.
+* *Exists* - The *key/effect* parameters must match. You must leave a blank value parameter, which matches any.
+.. From the *Effect* list, select one of the following options:
+* *None* 
+* *NoSchedule* - New pods that do not match the taint are not scheduled onto that node. Existing pods on the node remain.
+* *PreferNoSchedule* - New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to. Existing pods on the node remain.
+* *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
+.. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition. 
+** *Forever* - Pods stays permanently bound to a node. 
+** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.
+.. Click *Add*.
+. Click *Create hardware profile*.
+
+.Verification
+* The hardware profile appears on the *Hardware profiles* page.
+* The *Hardware profile* appears in the *Hardware profiles* list on the *Create workbench* page.
+* The hardware profile appears on the *Instances* tab on the details page for the `HardwareProfile` custom resource definition (CRD).
+
+[role='_additional-resources']
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration v1 core]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/understanding-operators#crd-managing-resources-from-crds[Managing resources from custom resource definitions]

--- a/modules/creating-a-hardware-profile.adoc
+++ b/modules/creating-a-hardware-profile.adoc
@@ -40,8 +40,8 @@ The *Add resource* dialog opens.
 .. Click *Add node selector*. 
 +
 The *Add node selector* dialog opens.
-.. In the *Key* field, enter a node selection key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
-.. In the *Value* field, enter a node selection value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Key* field, enter a node selection key. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a node selection value. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. Click *Add*.
 . Optional: Add a toleration to schedule pods with matching taints.
 .. Click *Add toleration*. 
@@ -55,8 +55,8 @@ The *Add toleration* dialog opens.
 * *NoSchedule* - New pods that do not match the taint are not scheduled onto that node. Existing pods on the node remain.
 * *PreferNoSchedule* - New pods that do not match the taint might be scheduled onto that node, but the scheduler tries not to. Existing pods on the node remain.
 * *NoExecute* - New pods that do not match the taint cannot be scheduled onto that node. Existing pods on the node that do not have a matching toleration are removed.
-.. In the *Key* field, enter a toleration key. The key is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
-.. In the *Value* field, enter a toleration value. The value is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Key* field, enter a toleration key. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+.. In the *Value* field, enter a toleration value. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 .. In the *Toleration Seconds* section, select one of the following options to specify how long a pod stays bound to a node that has a node condition:
 ** *Forever* - Pods stays permanently bound to a node. 
 ** *Custom value* - Enter a value, in seconds, to define how long pods stay bound to a node that has a node condition.

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -62,7 +62,7 @@ If the workbench image has multiple versions available, select the workbench ima
 +
 NOTE: You can change the workbench image after you create the workbench.
 
-. In the *Deployment size* section, from the *Container size* list, select a container size for your server. The container size specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both.
+. In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
 
 . Optional: In the *Environment variables* section, select and specify values for any environment variables. 
 +

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -63,6 +63,11 @@ If the workbench image has multiple versions available, select the workbench ima
 NOTE: You can change the workbench image after you create the workbench.
 
 . In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
++
+[IMPORTANT]
+====
+By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options]. 
+====
 
 . Optional: In the *Environment variables* section, select and specify values for any environment variables. 
 +

--- a/modules/deleting-a-hardware-profile.adoc
+++ b/modules/deleting-a-hardware-profile.adoc
@@ -1,0 +1,30 @@
+:_module-type: PROCEDURE
+
+[id="deleting-a-hardware-profile_{context}"]
+= Deleting a hardware profile
+
+[role='_abstract']
+To discard hardware profiles that you no longer require, you can delete them so that they do not appear on the dashboard.
+
+.Prerequisites
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
+* The hardware profile that you want to delete exists in your deployment. 
+
+.Procedure
+. From the {productname-short} dashboard, click *Settings* -> *Hardware profiles*.
++
+The *Hardware profiles* page appears, displaying existing hardware profiles.
+. Click the action menu (*&#8942;*) beside the hardware profile that you want to delete and click *Delete*.
++
+The *Delete hardware profile* dialog opens.
+. Enter the name of the hardware profile in the text field to confirm that you intend to delete it.
+. Click *Delete*. 
+
+.Verification
+* The hardware profile no longer appears on the *Hardware profiles* page.
+
+[role='_additional-resources']
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration v1 core]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/understanding-operators#crd-managing-resources-from-crds[Managing resources from custom resource definitions]

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -44,10 +44,12 @@ The *Deploy model* dialog opens.
 .. In the *NVIDIA NIM storage size* field, specify the size of the cluster storage instance that will be created to store the NVIDIA NIM model.
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
-.. From the *Accelerator* list, select an accelerator.
-+
-The *Number of accelerators* field appears.
-.. In the *Number of accelerators* field, specify the number of accelerators to use. The default value is 1.
+. From the *Hardware profile* list, select a hardware profile.
+. Optional: Click *Customize resource requests and limit* and update the following values:
+.. In the *CPUs requests* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+.. In the *CPU limits* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+.. In the *Memory requests* field, specify the requested memory for the model server in gibibytes (Gi).
+.. In the *Memory limits* field, specify the maximum memory limit for the model server in gibibytes (Gi).
 . Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
 . To require token authentication for inference requests to the deployed model, perform the following actions:
 .. Select *Require token authentication*.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -53,16 +53,16 @@ ifdef::upstream[]
 * To use the *vLLM NVIDIA GPU ServingRuntime for KServe* runtime or use graphics processing units (GPUs) with your model server, you have enabled GPU support. This includes installing the Node Feature Discovery and NVIDIA GPU Operators. For more information, see link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/index.html[NVIDIA GPU Operator on {org-name} OpenShift Container Platform^] in the NVIDIA documentation.
 endif::[]
 ifndef::upstream[]
-* To use the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime, you have enabled support for hybrid processing units (HPUs) in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring an accelerator profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] in the AMD documentation and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+* To use the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime, you have enabled support for hybrid processing units (HPUs) in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring an hardware profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] in the AMD documentation and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 ifdef::upstream[]
-* To use the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime, you have enabled support for hybrid processing units (HPUs) in {productname-short}. This includes installing the Intel Gaudi Base Operator and configuring an accelerator profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+* To use the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime, you have enabled support for hybrid processing units (HPUs) in {productname-short}. This includes installing the Intel Gaudi Base Operator and configuring a hardware profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 ifndef::upstream[]
-* To use the *vLLM AMD GPU ServingRuntime for KServe* runtime, you have enabled support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring an accelerator profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+* To use the *vLLM AMD GPU ServingRuntime for KServe* runtime, you have enabled support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring a hardware profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 ifdef::upstream[]
-* To use the *vLLM AMD GPU ServingRuntime for KServe* runtime, you have enabled support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU Operator and configuring an accelerator profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+* To use the *vLLM AMD GPU ServingRuntime for KServe* runtime, you have enabled support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU Operator and configuring a hardware profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 ifdef::self-managed[]
 +
@@ -109,10 +109,9 @@ ifdef::upstream[]
 . From the **Deployment mode** list, select standard or advanced. For more information about deployment modes, see link:{odhdocshome}/serving-models/#about-kserve-deployment-modes_serving-large-models[About KServe deployment modes].
 endif::[]
 . In the *Number of model server replicas to deploy* field, specify a value.
-. From the *Model server size* list, select a value.
-. The following options are only available if you have enabled accelerator support on your cluster and created an accelerator profile:
-.. From the *Accelerator* list, select an accelerator.
-.. If you selected an accelerator in the preceding step, specify the number of accelerators to use in the *Number of accelerators* field.
+. The following options are only available if you have created a hardware profile:
+.. From the *Hardware profile* list, select a hardware profile.
+.. Optional To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values. The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. 
 . Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
 . To require token authentication for inference requests to the deployed model, perform the following actions:
 .. Select *Require token authentication*.

--- a/modules/enabling-accelerators.adoc
+++ b/modules/enabling-accelerators.adoc
@@ -26,12 +26,12 @@ ifdef::upstream[]
 * **Intel Gaudi AI accelerators**: See link:{odhdocshome}/working-with-accelerators/#intel-gaudi-ai-accelerator-integration_accelerators[Intel Gaudi AI Accelerator integration].
 * **AMD GPUs**: See link:{odhdocshome}/working-with-accelerators/#amd-gpu-integration_accelerators[AMD GPU Integration].
 endif::[]
-. After installing your accelerator, create an accelerator profile as described in:
+. After installing your accelerator, create a hardware profile as described in:
 ifndef::upstream[]
-link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 ifdef::upstream[]
-link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 
 .Verification

--- a/modules/enabling-amd-gpus.adoc
+++ b/modules/enabling-amd-gpus.adoc
@@ -31,12 +31,12 @@ Alternatively, you can install the AMD GPU Operator from the {org-name} Catalog.
 
 //downstream - all
 ifndef::upstream[]
-. After installing the AMD GPU Operator, create an accelerator profile, as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+. After installing the AMD GPU Operator, create a hardware profile, as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 
 //upstream only
 ifdef::upstream[]
-. After installing the AMD GPU Operator, create an accelerator profile, as described in link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+. After installing the AMD GPU Operator, create a hardware profile, as described in link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 
 .Verification

--- a/modules/enabling-intel-gaudi-ai-accelerators.adoc
+++ b/modules/enabling-intel-gaudi-ai-accelerators.adoc
@@ -72,11 +72,11 @@ ifdef::upstream[]
 endif::[]
 //downstream - all
 ifndef::upstream[]
-. After installing the Intel Gaudi AI Accelerator Operator, create an accelerator profile, as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+. After installing the Intel Gaudi AI Accelerator Operator, create a hardware profile, as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 //upstream only
 ifdef::upstream[]
-. After installing the Intel Gaudi AI Accelerator Operator, create an accelerator profile, as described in link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+. After installing the Intel Gaudi AI Accelerator Operator, create a hardware profile, as described in link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 
 .Verification

--- a/modules/enabling-nvidia-gpus.adoc
+++ b/modules/enabling-nvidia-gpus.adoc
@@ -139,10 +139,10 @@ endif::[]
 
 //the following step applies to downstream only: self-managed (connected and disconnected) and cloud service
 ifndef::upstream[]
-After installing the NVIDIA GPU Operator, create an accelerator profile as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles].
+After installing the NVIDIA GPU Operator, create a hardware profile as described in link:{rhoaidocshome}{default-format-url}/working_with_accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles].
 endif::[]
 //the following step applies to upstream only
 ifdef::upstream[]
-After installing the NVIDIA GPU Operator, create an accelerator profile as described in link:{odhdocshome}/working-with-accelerators/[Working with accelerators].
+After installing the NVIDIA GPU Operator, create a hardware profile as described in link:{odhdocshome}/working-with-accelerators/[Working with accelerators].
 endif::[]
 

--- a/modules/importing-a-custom-workbench-image.adoc
+++ b/modules/importing-a-custom-workbench-image.adoc
@@ -5,7 +5,7 @@
 
 [role='_abstract']
 ifdef::upstream[]
-You can import custom workbench images that cater to your {productname-short} project's specific requirements. From the *Notebook images* page, you can enable or disable a previously imported workbench image and create an accelerator profile as a recommended accelerator for existing notebook images.
+You can import custom workbench images that cater to your {productname-short} project's specific requirements. From the *Notebook images* page, you can enable or disable a previously imported workbench image and create a hardware profile as a recommended accelerator for existing notebook images.
 endif::[]
 ifndef::upstream[]
 In addition to workbench images provided and supported by {org-name} and independent software vendors (ISVs), you can import custom workbench images that cater to your project's specific requirements.
@@ -39,7 +39,7 @@ endif::[]
 +
 The *Notebook images* page appears. Previously imported images are displayed. To enable or disable a previously imported image, on the row containing the relevant image, click the toggle in the *Enable* column. 
 
-. Optional: If you want to associate an accelerator and you have not already created an accelerator profile, click  *Create profile* on the row containing the image and complete the relevant fields. If the image does not contain an accelerator identifier, you must manually configure one before creating an associated accelerator profile.  
+. Optional: If you want to associate an accelerator and you have not already created a hardware profile, click  *Create profile* on the row containing the image and complete the relevant fields. If the image does not contain an accelerator identifier, you must manually configure one before creating an associated hardware profile.  
 
 . Click *Import new image*. Alternatively, if no previously imported images were found, click *Import image*.
 +

--- a/modules/intel-gaudi-ai-accelerator-integration.adoc
+++ b/modules/intel-gaudi-ai-accelerator-integration.adoc
@@ -12,7 +12,7 @@ Before you can enable Intel Gaudi AI accelerators in {productname-short}, you mu
 
 . Install the latest version of the Intel Gaudi AI Accelerator Operator from OperatorHub.  
 . Create and configure a custom workbench image for Intel Gaudi AI accelerators. A prebuilt workbench image for Gaudi accelerators is not included in {productname-short}.  
-. Manually define and configure an accelerator profile for each Intel Gaudi AI device in your environment.  
+. Manually define and configure a hardware profile for each Intel Gaudi AI device in your environment.  
 
 {org-name} supports Intel Gaudi devices up to Intel Gaudi 3. The Intel Gaudi 3 accelerators, in particular, offer the following benefits:
 
@@ -20,7 +20,7 @@ Before you can enable Intel Gaudi AI accelerators in {productname-short}, you mu
 * Energy efficiency: Lower power consumption while maintaining high performance, reducing operational costs for large-scale deployments.  
 * Scalable architecture: Scale across multiple nodes for distributed training configurations.  
 
-Your OpenShift platform must support EC2 DL1 instances to use Intel Gaudi AI accelerators in an Amazon EC2 DL1 instance. You can use Intel Gaudi AI accelerators in workbench instances or model serving after you enable the accelerators, create a custom workbench image, and configure the accelerator profile.
+Your OpenShift platform must support EC2 DL1 instances to use Intel Gaudi AI accelerators in an Amazon EC2 DL1 instance. You can use Intel Gaudi AI accelerators in workbench instances or model serving after you enable the accelerators, create a custom workbench image, and configure the hardware profile.
 
 To identify the Intel Gaudi AI accelerators present in your deployment, use the `lspci` utility. For more information, see link:https://linux.die.net/man/8/lspci[lspci(8) - Linux man page].  
 

--- a/modules/overview-of-accelerators.adoc
+++ b/modules/overview-of-accelerators.adoc
@@ -34,7 +34,7 @@ endif::[]
 ifdef::upstream[]
 * Before you can use an accelerator in {productname-short}, you must enable GPU support in {productname-short}. This includes installing the Node Feature Discovery and NVIDIA GPU Operators. For more information, see link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/index.html[NVIDIA GPU Operator on {org-name} OpenShift Container Platform^] in the NVIDIA documentation. 
 endif::[]
-In addition, your OpenShift instance must contain an associated accelerator profile. For accelerators that are new to your deployment, you must configure an accelerator profile for the accelerator in context. You can create an accelerator profile from the *Settings* -> *Accelerator profiles* page on the {productname-short} dashboard. If your deployment contains existing accelerators that had associated accelerator profiles already configured, an accelerator profile is automatically created after you upgrade to the latest version of {productname-short}.
+In addition, your OpenShift instance must contain an associated hardware profile. For accelerators that are new to your deployment, you must configure a hardware profile for the accelerator in context. You can create a hardware profile from the *Settings* -> *Hardware profiles* page on the {productname-short} dashboard. If your deployment contains existing accelerators that had associated hardware profiles already configured, a hardware profile is automatically created after you upgrade to the latest version of {productname-short}.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/updating-a-hardware-profile.adoc
+++ b/modules/updating-a-hardware-profile.adoc
@@ -4,7 +4,7 @@
 = Updating a hardware profile
 
 [role='_abstract']
-You can update the existing hardware profiles in your deployment. You might want to change important identifying information, such as the display name, the identifier, or the description. 
+You can update the existing hardware profiles in your deployment. You can change important identifying information, such as the display name, the identifier, or the description. 
 
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges.

--- a/modules/updating-a-hardware-profile.adoc
+++ b/modules/updating-a-hardware-profile.adoc
@@ -13,7 +13,7 @@ You can update the existing hardware profiles in your deployment. You can change
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Hardware profiles*.
 +
-The *Hardware profiles* page appears. Existing hardware profiles are displayed. To enable or disable a hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enable* column.
+The *Hardware profiles* page appears. Existing hardware profiles are displayed. To enable or disable a hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enabled* column.
 . Click the action menu (&#8942;) and select *Edit* from the list.
 +
 The *Edit hardware profile* dialog opens.

--- a/modules/updating-a-hardware-profile.adoc
+++ b/modules/updating-a-hardware-profile.adoc
@@ -1,0 +1,30 @@
+:_module-type: PROCEDURE
+
+[id="updating-a-hardware-profile_{context}"]
+= Updating a hardware profile
+
+[role='_abstract']
+You can update the existing hardware profiles in your deployment. You might want to change important identifying information, such as the display name, the identifier, or the description. 
+
+.Prerequisites
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
+* The hardware profile exists in your deployment.
+
+.Procedure
+. From the {productname-short} dashboard, click *Settings* -> *Hardware profiles*.
++
+The *Hardware profiles* page appears. Existing hardware profiles are displayed. To enable or disable a hardware profile, on the row containing the relevant hardware profile, click the toggle in the *Enable* column.
+. Click the action menu (&#8942;) and select *Edit* from the list.
++
+The *Edit hardware profile* dialog opens.
+. Make your changes.
+. Click *Update hardware profile*.
+
+.Verification
+* If your hardware profile has new identifying information, this information appears in the *Hardware profile* list on the *Create workbench* page. 
+
+[role='_additional-resources']
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration v1 core]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/understanding-operators#crd-managing-resources-from-crds[Managing resources from custom resource definitions]

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -32,16 +32,13 @@ The *Edit model server* dialog opens.
 NOTE: You cannot change the *Serving runtime* selection for a model server that is already configured. This protects against changing to a runtime that does not support already-deployed models.
 
 .. In the *Model server name* field, enter a new, unique name for the model server.
-
 .. In the *Number of model replicas to deploy* field, specify a value.
-.. From the *Model server size* list, select a value.
-.. Optional: If you selected *Custom* in the preceding step, configure the following settings in the *Model server size* section to customize your model server:
-... In the *CPUs requested* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
-... In the *CPU limit* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
-... In the *Memory requested* field, specify the requested memory for the model server in gibibytes (Gi).
-... In the *Memory limit* field, specify the maximum memory limit for the model server in gibibytes (Gi).
-.. Optional: From the *Accelerator* list, select an accelerator.
-.. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
+.. From the *Hardware profile* list, select a hardware profile.
+.. Optional: Click *Customize resource requests and limit* and update the following values:
+... In the *CPUs requests* field, specify the number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+... In the *CPU limits* field, specify the maximum number of CPUs to use with your model server. Use the list beside this field to specify the value in cores or millicores.
+... In the *Memory requests* field, specify the requested memory for the model server in gibibytes (Gi).
+... In the *Memory limits* field, specify the maximum memory limit for the model server in gibibytes (Gi).
 .. Optional: In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.
 .. Optional: In the *Token authentication* section, select the *Require token authentication* checkbox to require token authentication for your model server. To finish configuring token authentication, perform the following actions:
 ... In the *Service account name* field, enter a service account name for which the token will be generated. The generated token is created and displayed in the *Token secret* field when the model server is configured.

--- a/modules/using-accelerators-with-vllm.adoc
+++ b/modules/using-accelerators-with-vllm.adoc
@@ -20,13 +20,13 @@ endif::[]
 == Intel Gaudi accelerators
 
 ifdef::upstream[]
-You can serve models with Intel Gaudi accelerators by using the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime. To use the runtime, you must enable hybrid processing support (HPU) support in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring an accelerator profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+You can serve models with Intel Gaudi accelerators by using the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime. To use the runtime, you must enable hybrid processing support (HPU) support in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring a hardware profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 
 For information about recommended vLLM parameters, environment variables, supported configurations and more, see link:https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md[vLLM with Intel® Gaudi® AI Accelerators^].
 endif::[]
 
 ifndef::upstream[]
-You can serve models with Intel Gaudi accelerators by using the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime. To use the runtime, you must enable hybrid processing support (HPU) support in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring an accelerator profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles^]. 
+You can serve models with Intel Gaudi accelerators by using the *vLLM Intel Gaudi Accelerator ServingRuntime for KServe* runtime. To use the runtime, you must enable hybrid processing support (HPU) support in {productname-short}. This includes installing the Intel Gaudi AI accelerator operator and configuring a hardware profile. For more information, see link:https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/OpenShift_Installation/index.html#openshift-installation[Setting up Gaudi for OpenShift^] and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-hardware-profiles_accelerators[Working with hardware profiles^]. 
 
 For information about recommended vLLM parameters, environment variables, supported configurations and more, see link:https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md[vLLM with Intel® Gaudi® AI Accelerators^].
 endif::[]
@@ -54,11 +54,11 @@ endif::[]
 == AMD GPUs
 
 ifdef::upstream[]
-You can serve models with AMD GPUs by using the *vLLM AMD GPU ServingRuntime for KServe* runtime. To use the runtime, you must enable support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring an accelerator profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+You can serve models with AMD GPUs by using the *vLLM AMD GPU ServingRuntime for KServe* runtime. To use the runtime, you must enable support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring a hardware profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] and link:{odhdocshome}/working-with-accelerators/#working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 
 ifndef::upstream[]
-You can serve models with AMD GPUs by using the *vLLM AMD GPU ServingRuntime for KServe* runtime. To use the runtime, you must enable support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring an accelerator profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] in the AMD documentation and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-accelerator-profiles_accelerators[Working with accelerator profiles^].
+You can serve models with AMD GPUs by using the *vLLM AMD GPU ServingRuntime for KServe* runtime. To use the runtime, you must enable support for AMD graphic processing units (GPUs) in {productname-short}. This includes installing the AMD GPU operator and configuring a hardware profile. For more information, see link:https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html[Deploying the AMD GPU operator on OpenShift^] in the AMD documentation and link:{rhoaidocshome}{default-format-url}/working_with_accelerators/working-with-hardware-profiles_accelerators[Working with hardware profiles^].
 endif::[]
 
 [role="_additional-resources"]

--- a/modules/working-with-hardware-profiles.adoc
+++ b/modules/working-with-hardware-profiles.adoc
@@ -1,0 +1,32 @@
+:_module-type: CONCEPT
+
+[id='working-with-hardware-profiles_{context}']
+= Working with hardware profiles
+
+[role='_abstract']
+ifndef::upsream[]
+[IMPORTANT]
+====
+*Hardware profiles are currently available in {productname-long} as a Technology Preview feature only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete. {org-name} does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings → Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+====
+endif::[]
+
+In {productname-long}, you can schedule user workloads on worker nodes that have specific hardware configurations, such as hardware accelerators, CPU-only nodes, or specialized memory allocations. With hardware profiles, you can define these hardware resources explicitly, enabling precise targeting of workloads to specific nodes and improving resource management efficiency.
+
+You can use hardware profiles to create profiles with hardware identifiers, explicit resource allocation limits (CPU, memory, and accelerators), tolerations, and node selectors. These capabilities are particularly beneficial in environments with heterogeneous hardware, including multiple GPU types, CPU-only configurations, memory-intensive workloads, or even single-node deployments. This targeted scheduling significantly enhances resource utilization, reduces overhead, and optimizes costs, especially in complex environments, such as clusters with diverse hardware.
+
+To get started, contact your cluster administrator to identify hardware resources available in your cluster. 
+
+To configure specific hardware configurations for your data scientists to use in {productname-short}, you must create an associated hardware profile. A hardware profile is a custom resource definition (CRD) on OpenShift that has an HardwareProfile resource, and defines the hardware specification. You can create and manage hardware profiles by selecting *Settings* -> *Hardware profiles* on the {productname-short} dashboard.
+
+After you create and enable a hardware profile, users can select the hardware profile in the user interface when deploying workbenches, model-serving workloads, and pipelines, where applicable.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration v1 core]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/understanding-operators#crd-managing-resources-from-crds[Managing resources from custom resource definitions]

--- a/modules/working-with-hardware-profiles.adoc
+++ b/modules/working-with-hardware-profiles.adoc
@@ -7,11 +7,11 @@
 ifndef::upsream[]
 [IMPORTANT]
 ====
-*Hardware profiles are currently available in {productname-long} as a Technology Preview feature only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete. {org-name} does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+Hardware profiles are currently available in {productname-long} as a Technology Preview feature only. Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete. {org-name} does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings → Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 ====
 endif::[]
 
@@ -21,7 +21,7 @@ You can use hardware profiles to create profiles with hardware identifiers, expl
 
 To get started, contact your cluster administrator to identify hardware resources available in your cluster. 
 
-To configure specific hardware configurations for your data scientists to use in {productname-short}, you must create an associated hardware profile. A hardware profile is a custom resource definition (CRD) on OpenShift that has an HardwareProfile resource, and defines the hardware specification. You can create and manage hardware profiles by selecting *Settings* -> *Hardware profiles* on the {productname-short} dashboard.
+To configure specific hardware configurations for your data scientists to use in {productname-short}, you must create an associated hardware profile. A hardware profile is a custom resource definition (CRD) on OpenShift that has a HardwareProfile resource, and defines the hardware specification. You can create and manage hardware profiles by selecting *Settings* -> *Hardware profiles* on the {productname-short} dashboard.
 
 After you create and enable a hardware profile, users can select the hardware profile in the user interface when deploying workbenches, model-serving workloads, and pipelines, where applicable.
 

--- a/working-with-accelerators.adoc
+++ b/working-with-accelerators.adoc
@@ -39,16 +39,14 @@ include::modules/verifying-amd-gpu-availability-on-your-cluster.adoc[leveloffset
 
 include::modules/enabling-amd-gpus.adoc[leveloffset=+2]
 
-//Using accelerator profiles
-include::modules/working-with-accelerator-profiles.adoc[leveloffset=+1]
+//Using hardware profiles
+include::modules/working-with-hardware-profiles.adoc[leveloffset=+1]
 
-include::modules/creating-an-accelerator-profile.adoc[leveloffset=+2]
+include::modules/creating-a-hardware-profile.adoc[leveloffset=+2]
 
-include::modules/updating-an-accelerator-profile.adoc[leveloffset=+2]
+include::modules/updating-a-hardware-profile.adoc[leveloffset=+2]
 
-include::modules/deleting-an-accelerator-profile.adoc[leveloffset=+2]
-
-include::modules/viewing-accelerator-profiles.adoc[leveloffset=+2]
+include::modules/deleting-a-hardware-profile.adoc[leveloffset=+2]
 
 include::modules/configuring-a-recommended-accelerator-for-notebook-images.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This MR documents the introduction of hardware profiles, which acts as a superset of the accelerator profiles feature. Accelerator profiles will be officially deprecated at 2.19, yet will still appear in the UI by default until the GA of hardware profiles. Hardware profiles is tech preview at this release and is hidden behind a feature flag by default. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
