### PR TITLE
Fix typo in enabling-trustyai-component.adoc

### DIFF
--- a/modules/enabling-trustyai-component.adoc
+++ b/modules/enabling-trustyai-component.adoc
@@ -42,7 +42,7 @@ ifdef::upstream[]
 endif::[]
 
 . Click *Workloads* -> *Deployments*.
-. Search for the *trustyai-service-operator-contoller-manager* deployment.
+. Search for the *trustyai-service-operator-controller-manager* deployment.
 Check the status:
 .. Click the deployment name to open the deployment details page.
 .. Click the *Pods* tab.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Found a typo while going through the [docs](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.19/html/monitoring_data_science_models/configuring-trustyai_monitor):
<img width="563" alt="Screenshot 2025-05-26 at 1 51 36 PM" src="https://github.com/user-attachments/assets/6d47bd2d-405f-4258-889d-57d68a7dff74" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
