### PR TITLE
ENG-24978: Document how to ingest content into a llamstack model from within a Jupyter notebook

### DIFF
--- a/modules/ingesting-content-into-a-llama-model.adoc
+++ b/modules/ingesting-content-into-a-llama-model.adoc
@@ -1,0 +1,155 @@
+:_module-type: PROCEDURE
+
+[id="ingesting-content-into-a-llama-model_{context}"]
+= Ingesting content into a Llama model
+
+[role='_abstract']
+You can quickly customize and prototype your retrievable content by ingesting raw text into your model from inside a Jupyter notebook. This approach voids requiring a separate ingestion pipeline. By using the LlamaStack SDK, you can embed and store text in your vector store in real-time, enabling immediate RAG workflows. 
+
+.Prerequisites
+* You have deployed a Llama 3.2 model with a vLLM model server and you have integrated LlamaStack.
+* You have created a project workbench within a data science project.
+* You have opened a Jupyter notebook and it is running in your workbench environment.
+* You have a created and configured a vector database instance and you know its identifier.
+ifdef::self-managed[]
+* Ensure that your environment has network access to the vector database service through {openshift-platform}.
+endif::self-managed[]
+
+.Procedure
+. In a new notebook cell, install the `llama_stack` client package:
++
+[source,python]
+----
+%pip install llama_stack
+----
+
+. In a new notebook cell, import RAGDocument and LlamaStackClient:
++
+[source,python]
+----
+from llama_stack_client import RAGDocument, LlamaStackClient
+----
+
+. In a new notebook cell, assign your deployment endpoint to the `base_url` parameter to create a LlamaStackClient instance:
++
+[source,python]
+----
+client = LlamaStackClient(base_url="<your deployment endpoint>")
+----
+
+. List the available models. and select the first LLM and the first embedding model:
++
+[source,python]
+----
+# Fetch all registered models
+models = client.models.list()
+----
+
+. Verify that the list of registered models includes your Llama model and an embedding model. Here is an example of a list of registered models:
++
+[source,python]
+----
+[Model(identifier='llama-32-3b-instruct', metadata={}, api_model_type='llm', provider_id='vllm-inference', provider_resource_id='llama-32-3b-instruct', type='model', model_type='llm'),
+ Model(identifier='ibm-granite/granite-embedding-125m-english', metadata={'embedding_dimension': 768.0}, api_model_type='embedding', provider_id='sentence-transformers', provider_resource_id='ibm-granite/granite-embedding-125m-english', type='model', model_type='embedding')]
+----
+
+. Select the first LLM and the first embedding model:
++
+[source,python]
+----
+model_id = next(m.identifier for m in models if m.model_type == "llm")
+
+embedding_model = next(m for m in models if m.model_type == "embedding")
+embedding_model_id = embedding_model.identifier
+embedding_dimension = embedding_model.metadata["embedding_dimension"]
+----
+
+. In a new notebook cell, register or confirm your vector database to store embeddings:
++
+[source,python]
+----
+vector_db_id = "<your vector database ID>"
+
+_ = client.vector_dbs.register(
+vector_db_id=vector_db_id,
+embedding_model=embedding_model_id,
+embedding_dimension=embedding_dimension,
+provider_id="<your provider ID>",
+)
+print(f"Registered vector DB: {vector_db_id}")
+----
++
+[IMPORTANT]
+====
+If you skip this step, and as a result, you do not register your vector database with your vector database ID, an error occurs if you attempt to ingest text into your vector database. 
+====
+
+. In a new notebook cell, define the raw text that you want to ingest into the vector store: 
++ 
+[source,python]
+----
+# Example raw text passage
+raw_text = """
+LlamaStack can embed raw text into a vector store for retrieval.
+This example ingests a small passage for demonstration.
+"""
+----
+
+. In a new notebook cell, create a RAGDocument object to contain the raw text:
++
+[source,python]
+----
+document = RAGDocument(
+document_id="raw_text_001",
+content=raw_text,
+mime_type="text/plain",
+metadata={"source": "example_passage"},
+)
+----
+
+. In a new notebook cell, ingest the raw text:  
++
+[source,python]
+----
+vector_db_id = "<your vector database ID>"
+# Ingest the RAGDocument
+insert_response = await client.tool_runtime.rag_tool.insert(
+documents=[document],
+vector_db_id=vector_db_id,
+chunk_size_in_tokens=100,
+)
+
+print(insert_response)
+----
+
+. In a new notebook cell, create a RAGDocument from an HTML source and ingest it into the vector store:
++
+[source,python]
+----
+source = "https://www.paulgraham.com/greatwork.html"
+print("rag_tool> Ingesting document:", source)
+
+document = RAGDocument(
+document_id="document_1",
+content=source,
+mime_type="text/html",
+metadata={},
+)
+----
+
+. In a new notebook cell, ingest the content into the vector store:
++
+[source,python]
+----
+await client.tool_runtime.rag_tool.insert(
+documents=[document],
+vector_db_id=vector_db_id,
+chunk_size_in_tokens=50,
+)
+----
+
+.Verification
+
+* Review the output to confirm successful ingestion. A typical response after ingestion includes the number of text chunks inserted and any warnings or errors.
+* The insert() call returns the number of embedded text chunks.
+* The model list returned by client.models.list() includes your Llama 3.2 model and an embedding model.

--- a/modules/ingesting-content-into-a-llama-model.adoc
+++ b/modules/ingesting-content-into-a-llama-model.adoc
@@ -156,24 +156,7 @@ client.tool_runtime.rag_tool.insert(
 print("Raw text ingested successfully")
 ----
 
-. Retrieve metadata for the ingested documents:
-+
-[source,python]
-----
-metadata_raw = await client.tool_runtime.rag_tool.get_metadata(
-    vector_db_id=vector_db_id,
-    document_ids=["raw_text_001"],
-)
-metadata_html = await client.tool_runtime.rag_tool.get_metadata(
-    vector_db_id=vector_db_id,
-    document_ids=["document_1"],
-)
-print("Raw text metadata:", metadata_raw)
-print("HTML document metadata:", metadata_html)
-----
-
 .Verification
 
 * Review the output to confirm successful ingestion. A typical response after ingestion includes the number of text chunks inserted and any warnings or errors.
-* The metadata output displays chunk counts and any stored metadata fields.  
 * The model list returned by `client.models.list()` includes your Llama 3.2 model and an embedding model.

--- a/modules/ingesting-content-into-a-llama-model.adoc
+++ b/modules/ingesting-content-into-a-llama-model.adoc
@@ -12,8 +12,8 @@ You can quickly customize and prototype your retrievable content by ingesting ra
 * You have opened a Jupyter notebook and it is running in your workbench environment.
 * You have a created and configured a vector database instance and you know its identifier.
 ifdef::self-managed[]
-* Ensure that your environment has network access to the vector database service through {openshift-platform}.
-endif::self-managed[]
+* Your environment has network access to the vector database service through {openshift-platform}.
+endif::[]
 
 .Procedure
 . In a new notebook cell, install the `llama_stack` client package:
@@ -37,7 +37,7 @@ from llama_stack_client import RAGDocument, LlamaStackClient
 client = LlamaStackClient(base_url="<your deployment endpoint>")
 ----
 
-. List the available models. and select the first LLM and the first embedding model:
+. List the available models:
 +
 [source,python]
 ----

--- a/modules/ingesting-content-into-a-llama-model.adoc
+++ b/modules/ingesting-content-into-a-llama-model.adoc
@@ -64,17 +64,27 @@ embedding_model_id = embedding_model.identifier
 embedding_dimension = embedding_model.metadata["embedding_dimension"]
 ----
 
+. In a new notebook cell, define the following parameters:
+* `vector_db_id`: a unique name that identifies your vector database, for example, `my_milvus_db`.  
+* `provider_id`: the connector key that your Llama Stack gateway has enabled. For the Milvus vector database, this connector key is `"milvus"`. You can also list the available connectors:
++
+[source,python]
+----
+print(client.vector_dbs.list_providers()) # lists available connectors
+
+vector_db_id = "<your vector database ID>"
+provider_id  = "<your provider ID>"
+----
+
 . In a new notebook cell, register or confirm your vector database to store embeddings:
 +
 [source,python]
 ----
-vector_db_id = "<your vector database ID>"
-
 _ = client.vector_dbs.register(
 vector_db_id=vector_db_id,
 embedding_model=embedding_model_id,
 embedding_dimension=embedding_dimension,
-provider_id="<your provider ID>",
+provider_id=provider_id,
 )
 print(f"Registered vector DB: {vector_db_id}")
 ----
@@ -111,15 +121,12 @@ metadata={"source": "example_passage"},
 +
 [source,python]
 ----
-vector_db_id = "<your vector database ID>"
-# Ingest the RAGDocument
-insert_response = await client.tool_runtime.rag_tool.insert(
-documents=[document],
-vector_db_id=vector_db_id,
-chunk_size_in_tokens=100,
+client.tool_runtime.rag_tool.insert(
+    documents=[document],
+    vector_db_id=vector_db_id,
+    chunk_size_in_tokens=100,
 )
-
-print(insert_response)
+print("Raw text ingested successfully")
 ----
 
 . In a new notebook cell, create a RAGDocument from an HTML source and ingest it into the vector store:
@@ -130,10 +137,10 @@ source = "https://www.paulgraham.com/greatwork.html"
 print("rag_tool> Ingesting document:", source)
 
 document = RAGDocument(
-document_id="document_1",
-content=source,
-mime_type="text/html",
-metadata={},
+    document_id="document_1",
+    content=source,
+    mime_type="text/html",
+    metadata={},
 )
 ----
 
@@ -141,15 +148,32 @@ metadata={},
 +
 [source,python]
 ----
-await client.tool_runtime.rag_tool.insert(
-documents=[document],
-vector_db_id=vector_db_id,
-chunk_size_in_tokens=50,
+client.tool_runtime.rag_tool.insert(
+    documents=[document],
+    vector_db_id=vector_db_id,
+    chunk_size_in_tokens=50,
 )
+print("Raw text ingested successfully")
+----
+
+. Retrieve metadata for the ingested documents:
++
+[source,python]
+----
+metadata_raw = await client.tool_runtime.rag_tool.get_metadata(
+    vector_db_id=vector_db_id,
+    document_ids=["raw_text_001"],
+)
+metadata_html = await client.tool_runtime.rag_tool.get_metadata(
+    vector_db_id=vector_db_id,
+    document_ids=["document_1"],
+)
+print("Raw text metadata:", metadata_raw)
+print("HTML document metadata:", metadata_html)
 ----
 
 .Verification
 
 * Review the output to confirm successful ingestion. A typical response after ingestion includes the number of text chunks inserted and any warnings or errors.
-* The insert() call returns the number of embedded text chunks.
-* The model list returned by client.models.list() includes your Llama 3.2 model and an embedding model.
+* The metadata output displays chunk counts and any stored metadata fields.  
+* The model list returned by `client.models.list()` includes your Llama 3.2 model and an embedding model.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This module describes how to ingest content into a Llama 3.2 LLM model from within a Jupyter notebook. The commands must be written inside Jupyter notebook cells. It is important to note that this module only covers ingesting content, and does not cover querying the model, which will come later as part of another Jira. The content ingested can be raw text, which is declared within the notebook, or from an external source, such as a HTML file. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive guide for ingesting raw text content into a Llama model using the LlamaStack SDK in a Jupyter notebook environment, including setup, ingestion steps, and verification procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->