### PR TITLE
ENG-717: Updating annotations for custom workbench images

### DIFF
--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -61,7 +61,7 @@ spec:
         opendatahub.io/notebook-build-commit: '3e71410' # <11>
       from:
         kind: DockerImage
-        name: 'quay.io/example/my-custom-notebook:latest' # <12>
+        name: 'quay.io/modh/rocm-notebooks@sha256:199367d2946..b411433ffbb5f0988279b10150020af22db' # <12>
       importPolicy: 
       importPolicy:
         importMode: Legacy

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -58,7 +58,7 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]' # <8>
         opendatahub.io/workbench-image-recommended: 'true' # <9>
         opendatahub.io/image-tag-outdated: 'true' # <10>
-        opendatahub.io/notebook-build-commit: 3e71410 # <11>
+        opendatahub.io/notebook-build-commit: '3e71410' # <11>
       from:
         kind: DockerImage
         name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-notebook:latest' # <12>
@@ -81,8 +81,8 @@ The example YAML file includes the following information:
 <8> An annotation that specifies information such as the Python version, Jupyter version, or CUDA version.
 <9> An annotation that specifies whether the `ImageStream` version is the default version of the image. Set this field to `'true'` if the `ImageStream` version is the default. Otherwise, set it to `'false'`. You must specify the `opendatahub.io/workbench-image-recommended` annotation field if there are multiple versions of the image with different configurations. If you have only one version of the image, set the field to `'true'`. 
 <10> An annotation that specifies whether the image version has tags that are outdated and out of the regular maintenance cycle.
-<11> An annotation that is a reference to the build commit with the ID for the updated information.
-<12> The image registry URL to store the image stream. Store the image stream in an image registry outside of the cluster where {productname-short} is installed.
+<11> An annotation that is a reference to the build commit ID containing the latest content.
+<12> The image registry path where the image has been uploaded. Store the image stream in your preferred image registry.
 
 . To create the `ImageStream` CR, run the following command, where the `ImageStream` CRD YAML manifest file name is `notebook-image-stream.yaml`:
 +

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -81,7 +81,7 @@ The example YAML file includes the following information:
 <8> An annotation that specifies information such as the Python version, Jupyter version, or CUDA version.
 <9> An annotation that specifies whether the `ImageStream` version is the default version of the image. Set this field to `'true'` if the `ImageStream` version is the default. Otherwise, set it to `'false'`. You must specify the `opendatahub.io/workbench-image-recommended` annotation field if there are multiple versions of the image with different configurations. If you have only one version of the image, set the field to `'true'`. 
 <10> An annotation that specifies whether the image version has tags that are outdated and out of the regular maintenance cycle.
-<11> An annotation that is a reference to the build commit ID containing the latest content.
+<11> An annotation that references the commit hash's build commit ID to identify the sources that the specific tag was built from.
 <12> The image registry path where the image has been uploaded. Store the image stream in your preferred image registry.
 
 . To create the `ImageStream` CR, run the following command, where the `ImageStream` CRD YAML manifest file name is `notebook-image-stream.yaml`:

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -57,9 +57,11 @@ spec:
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.2"}]' # <7>
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.11"}]' # <8>
         opendatahub.io/workbench-image-recommended: 'true' # <9>
+        opendatahub.io/image-tag-outdated: 'true' # <10>
+        opendatahub.io/notebook-build-commit: 3e71410 # <11>
       from:
         kind: DockerImage
-        name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-workbench:latest' # <10>
+        name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-workbench:latest' # <12>
       importPolicy: 
       importPolicy:
         importMode: Legacy
@@ -77,8 +79,10 @@ The example YAML file includes the following information:
 <6> The version for the image. You can configure multiple versions for the same image. For this example, the version is 1.0.
 <7> An annotation that gives the user information about the Python packages and versions that are pre-installed in the image.
 <8> An annotation that specifies information such as the Python version, Jupyter version, or CUDA version.
-<9> An annotation that specifies whether the `ImageStream` version is the default version of the image. Set this field to `'true'` if the `ImageStream` version is the default. Otherwise, set it to `'false'`. You must specify the `opendatahub.io/workbench-image-recommended` annotation field if there are multiple versions of the image with different configurations. If you have only one version of the image, set the field to `'true'`.
-<10> The image registry URL to store the image stream. Store the image stream in an image registry outside of the cluster where {productname-short} is installed.
+<9> An annotation that specifies whether the `ImageStream` version is the default version of the image. Set this field to `'true'` if the `ImageStream` version is the default. Otherwise, set it to `'false'`. You must specify the `opendatahub.io/workbench-image-recommended` annotation field if there are multiple versions of the image with different configurations. If you have only one version of the image, set the field to `'true'`. 
+<10> An annotation that specifies whether the image version has tags that are outdated and out of the regular maintenance cycle.
+<11> An annotation that is a reference to the build commit with the ID for the updated information.
+<12> The image registry URL to store the image stream. Store the image stream in an image registry outside of the cluster where {productname-short} is installed.
 
 . To create the `ImageStream` CR, run the following command, where the `ImageStream` CRD YAML manifest file name is `notebook-image-stream.yaml`:
 +

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -61,7 +61,7 @@ spec:
         opendatahub.io/notebook-build-commit: '3e71410' # <11>
       from:
         kind: DockerImage
-        name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-notebook:latest' # <12>
+        name: 'quay.io/example/my-custom-notebook:latest' # <12>
       importPolicy: 
       importPolicy:
         importMode: Legacy

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -61,7 +61,7 @@ spec:
         opendatahub.io/notebook-build-commit: 3e71410 # <11>
       from:
         kind: DockerImage
-        name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-workbench:latest' # <12>
+        name: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-notebook:latest' # <12>
       importPolicy: 
       importPolicy:
         importMode: Legacy

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -82,7 +82,7 @@ The example YAML file includes the following information:
 <9> An annotation that specifies whether the `ImageStream` version is the default version of the image. Set this field to `'true'` if the `ImageStream` version is the default. Otherwise, set it to `'false'`. You must specify the `opendatahub.io/workbench-image-recommended` annotation field if there are multiple versions of the image with different configurations. If you have only one version of the image, set the field to `'true'`. 
 <10> An annotation that specifies whether the image version has tags that are outdated and out of the regular maintenance cycle.
 <11> An annotation that references the commit hash's build commit ID to identify the sources that the specific tag was built from.
-<12> The image registry path where the image has been uploaded. Store the image stream in your preferred image registry.
+<12> The image registry path where the image has been uploaded.
 
 . To create the `ImageStream` CR, run the following command, where the `ImageStream` CRD YAML manifest file name is `notebook-image-stream.yaml`:
 +


### PR DESCRIPTION
Updating the YAML and descriptions for two additional annotations: `opendatahub.io/image-tag-outdated: 'true'` and `opendatahub.io/notebook-build-commit: 3e71410`

JIRA: https://issues.redhat.com/browse/RHOAIENG-717


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the example YAML manifest for custom image creation with new annotations indicating image tag status and build commit ID.
  - Clarified the image registry URL description and enhanced explanatory notes for improved understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->