### PR TITLE
RHOAI-27562 LAB tuning hardware profile memory

### DIFF
--- a/modules/creating-a-hardware-profile-for-lab-tuning.adoc
+++ b/modules/creating-a-hardware-profile-for-lab-tuning.adoc
@@ -29,7 +29,7 @@ endif::[]
 | Default: 4 Cores; Minimum allowed: 2 Cores; Maximum allowed: 4 Cores
 
 | Memory
-| Maximum allowed: Greater than 100 GiB
+| Maximum allowed: Greater than 250 GiB
 
 | Resource label
 | `nvidia.com/gpu`


### PR DESCRIPTION
Updated to 250 GiB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the hardware profile configuration guidelines to reflect a higher maximum allowed memory value, increasing it from "Greater than 100 GiB" to "Greater than 250 GiB" in the LAB-tuning procedure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->