### PR TITLE
ENG-25590: Adds info about project-scoped items in lists

### DIFF
--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -57,7 +57,7 @@ You can edit only the display name and the description.
 . In the *Notebook image* section, complete the fields to specify the workbench image to use with your workbench.
 +
 From the *Image selection* list, select a workbench image that suits your use case. A workbench image includes an IDE and Python packages (reusable code). 
-If project-scoped images exist, then subheadings distinguish between global images and project-scoped images in the list.
+If project-scoped images exist, the *Image selection* list includes subheadings to distinguish between global images and project-scoped images.
 +
 Optionally, click *View package information* to view a list of packages that are included in the image that you selected.
 +
@@ -66,7 +66,7 @@ If the workbench image has multiple versions available, select the workbench ima
 NOTE: You can change the workbench image after you create the workbench.
 
 . In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. 
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
 +
 [IMPORTANT]

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -65,20 +65,62 @@ If the workbench image has multiple versions available, select the workbench ima
 +
 NOTE: You can change the workbench image after you create the workbench.
 
-. In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. 
+. In the *Deployment size* section, select one of the following options, depending on whether the hardware profiles feature is enabled.
++
+ifndef::upstream[]
+[IMPORTANT]
+====
+ifdef::self-managed[]
+The hardware profiles feature is currently available in {productname-long} {vernum} as a Technology Preview feature.
+endif::[]
+ifdef::cloud-service[]
+The hardware profiles feature is currently available in {productname-long} as a Technology Preview feature.
+endif::[]
+Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete.
+{org-name} does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[]
+
+* If the hardware profiles feature is not enabled:
+
+.. From the *Container size* list, select the appropriate size for the size of the model that you want to train or tune.
++
+ifndef::upstream[]
+For example, to run the example fine-tuning job described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/running-kfto-based-distributed-training-workloads_distributed-workloads#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *Medium*.
+endif::[]
+ifdef::upstream[]
+For example, to run the example fine-tuning job described in link:{odhdocshome}/working-with-distributed-workloads/#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *Medium*.
+endif::[]
+
+.. From the *Accelerator* list, select a suitable accelerator profile for your workbench.
++
+If project-scoped accelerator profiles exist, the *Accelerator* list includes subheadings to distinguish between global accelerator profiles and project-scoped accelerator profiles.
+
+* If the hardware profiles feature is enabled:
+
+.. From the *Hardware profile* list, select a suitable hardware profile for your workbench. 
++
 If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
-The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
++
+The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. 
+
+.. If you want to change the default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
 +
 [IMPORTANT]
 ====
-By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
+By default, the hardware profiles feature is not enabled: hardware profiles are not shown in the dashboard navigation menu or elsewhere in the user interface. 
+In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
+To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
 For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
-====
+==== 
 
 . Optional: In the *Environment variables* section, select and specify values for any environment variables. 
 +

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -56,13 +56,18 @@ You can edit only the display name and the description.
 . Optional: In the *Description* field, enter a description for your workbench.
 . In the *Notebook image* section, complete the fields to specify the workbench image to use with your workbench.
 +
-From the *Image selection* list, select a workbench image that suits your use case. A workbench image includes an IDE and Python packages (reusable code). Optionally, click *View package information* to view a list of packages that are included in the image that you selected.
+From the *Image selection* list, select a workbench image that suits your use case. A workbench image includes an IDE and Python packages (reusable code). 
+If project-scoped images exist, then subheadings distinguish between global images and project-scoped images in the list.
++
+Optionally, click *View package information* to view a list of packages that are included in the image that you selected.
 +
 If the workbench image has multiple versions available, select the workbench image version to use from the *Version selection* list. To use the latest package versions, Red Hat recommends that you use the most recently added image. 
 +
 NOTE: You can change the workbench image after you create the workbench.
 
-. In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
+. In the *Deployment size* section, from the *Hardware profile* list, select a suitable hardware profile for your workbench. 
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. To change these default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
 +
 [IMPORTANT]
 ====

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -61,7 +61,28 @@ ifdef::upstream[]
 For example, to run the example fine-tuning job described in link:{odhdocshome}/working-with-distributed-workloads/#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *PyTorch*.
 endif::[]
 
-.. In the *Deployment size* section, from the *Container size* list, select the appropriate size for the size of the model that you want to train or tune.
+.. In the *Deployment size* section, select one of the following options, depending on whether the hardware profiles feature is enabled.
++
+ifndef::upstream[]
+[IMPORTANT]
+====
+ifdef::self-managed[]
+The hardware profiles feature is currently available in {productname-long} {vernum} as a Technology Preview feature.
+endif::[]
+ifdef::cloud-service[]
+The hardware profiles feature is currently available in {productname-long} as a Technology Preview feature.
+endif::[]
+Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete.
+{org-name} does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[]
+
+* If the hardware profiles feature is not enabled:
+
+... From the *Container size* list, select the appropriate size for the size of the model that you want to train or tune.
 +
 ifndef::upstream[]
 For example, to run the example fine-tuning job described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/running-kfto-based-distributed-training-workloads_distributed-workloads#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *Medium*.
@@ -69,6 +90,34 @@ endif::[]
 ifdef::upstream[]
 For example, to run the example fine-tuning job described in link:{odhdocshome}/working-with-distributed-workloads/#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *Medium*.
 endif::[]
+
+... From the *Accelerator* list, select a suitable accelerator profile for your workbench.
++
+If project-scoped accelerator profiles exist, the *Accelerator* list includes subheadings to distinguish between global accelerator profiles and project-scoped accelerator profiles.
+
+* If the hardware profiles feature is enabled:
+
+... From the *Hardware profile* list, select a suitable hardware profile for your workbench. 
++
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
++
+The hardware profile specifies the number of CPUs and the amount of memory allocated to the container, setting the guaranteed minimum (request) and maximum (limit) for both. 
+
+... If you want to change the default values, click *Customize resource requests and limit* and enter new minimum (request) and maximum (limit) values.
++
+[IMPORTANT]
+====
+By default, the hardware profiles feature is not enabled: hardware profiles are not shown in the dashboard navigation menu or elsewhere in the user interface. 
+In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
+To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
+ifndef::upstream[]
+For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+ifdef::upstream[]
+For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[] 
+==== 
+
 .. In the *Cluster storage* section, click either *Attach existing storage* or *Create storage* to specify the storage details so that you can share data between the workbench and the training or tuning runs.
 +
 ifndef::upstream[]

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -52,7 +52,7 @@ The project details page opens, with the *Overview* tab selected by default.
 .. On the project details page, click the *Workbench* tab, and click *Create workbench*.
 .. Enter a workbench name, and optionally a description.
 .. In the *Notebook image* section, from the *Image selection* list, select the appropriate image for your training or tuning job.
-If project-scoped images exist, then subheadings distinguish between global images and project-scoped images in the list.
+If project-scoped images exist, the *Image selection* list includes subheadings to distinguish between global images and project-scoped images.
 +
 ifndef::upstream[]
 For example, to run the example fine-tuning job described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/running-kfto-based-distributed-training-workloads_distributed-workloads#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *PyTorch*.

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -52,6 +52,7 @@ The project details page opens, with the *Overview* tab selected by default.
 .. On the project details page, click the *Workbench* tab, and click *Create workbench*.
 .. Enter a workbench name, and optionally a description.
 .. In the *Notebook image* section, from the *Image selection* list, select the appropriate image for your training or tuning job.
+If project-scoped images exist, then subheadings distinguish between global images and project-scoped images in the list.
 +
 ifndef::upstream[]
 For example, to run the example fine-tuning job described in link:{rhoaidocshome}{default-format-url}/working_with_distributed_workloads/running-kfto-based-distributed-training-workloads_distributed-workloads#fine-tuning-a-model-by-using-kubeflow-training_distributed-workloads[Fine-tuning a model by using Kubeflow Training], select *PyTorch*.

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -70,7 +70,7 @@ Resource names are what your resources are labeled as in OpenShift. Your resourc
 The resource name must not match the name of any other model deployment resource in your {openshift-platform} cluster.
 ====
 .. From the *Serving runtime* list, select a model-serving runtime that is installed and enabled in your {productname-short} deployment.
-If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
+If project-scoped runtimes exist, the *Serving runtime* list includes subheadings to distinguish between global runtimes and project-scoped runtimes.
 .. From the *Model framework* list, select a framework for your model.
 +
 NOTE: The *Model framework* list shows only the frameworks that are supported by the model-serving runtime that you specified when you deployed your model.
@@ -84,7 +84,7 @@ endif::[]
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
 .. If you have created a hardware profile, select a hardware profile from the *Hardware profile* list.
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 +
 [IMPORTANT]
 ====

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -70,6 +70,7 @@ Resource names are what your resources are labeled as in OpenShift. Your resourc
 The resource name must not match the name of any other model deployment resource in your {openshift-platform} cluster.
 ====
 .. From the *Serving runtime* list, select a model-serving runtime that is installed and enabled in your {productname-short} deployment.
+If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
 .. From the *Model framework* list, select a framework for your model.
 +
 NOTE: The *Model framework* list shows only the frameworks that are supported by the model-serving runtime that you specified when you deployed your model.
@@ -83,6 +84,7 @@ endif::[]
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
 .. If you have created a hardware profile, select a hardware profile from the *Hardware profile* list.
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
 +
 [IMPORTANT]
 ====

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -108,6 +108,7 @@ The *Deploy model* dialog opens.
 
 . In the *Model deployment name* field, enter a unique name for the model that you are deploying.
 . In the *Serving runtime* field, select an enabled runtime.
+If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
 . From the *Model framework (name - version)* list, select a value.
 ifndef::upstream[]
 . From the **Deployment mode** list, select standard or advanced. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#about-kserve-deployment-modes_serving-large-models[About KServe deployment modes].
@@ -118,6 +119,7 @@ endif::[]
 . In the *Number of model server replicas to deploy* field, specify a value.
 . The following options are only available if you have created a hardware profile:
 .. From the *Hardware profile* list, select a hardware profile.
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
 +
 [IMPORTANT]
 ====

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -108,7 +108,7 @@ The *Deploy model* dialog opens.
 
 . In the *Model deployment name* field, enter a unique name for the model that you are deploying.
 . In the *Serving runtime* field, select an enabled runtime.
-If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
+If project-scoped runtimes exist, the *Serving runtime* list includes subheadings to distinguish between global runtimes and project-scoped runtimes.
 . From the *Model framework (name - version)* list, select a value.
 ifndef::upstream[]
 . From the **Deployment mode** list, select standard or advanced. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#about-kserve-deployment-modes_serving-large-models[About KServe deployment modes].
@@ -119,7 +119,7 @@ endif::[]
 . In the *Number of model server replicas to deploy* field, specify a value.
 . The following options are only available if you have created a hardware profile:
 .. From the *Hardware profile* list, select a hardware profile.
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 +
 [IMPORTANT]
 ====

--- a/modules/deploying-teacher-and-judge-models.adoc
+++ b/modules/deploying-teacher-and-judge-models.adoc
@@ -40,6 +40,7 @@ The `vLLm` *Model framework* is automatically selected.
 * **Advanced**: Use for custom models or when you need to change the model URI, runtime settings, or storage connection.
 . Enter the *Number of model server replicas to deploy*. Set this number based on expected traffic and availability needs, such as support for failover.
 . Select a *Hardware profile* with the `Compatible` label.
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
 //Customize resource requests and limits
 . For *Model route*, select the *Make deployed models available through an external route* checkbox.
 . For *Token authentication*, select whether to *Require token authentication*. Enabling this option is recommended to reduce the risk of security vulnerabilities.

--- a/modules/deploying-teacher-and-judge-models.adoc
+++ b/modules/deploying-teacher-and-judge-models.adoc
@@ -32,6 +32,7 @@ The *Deploy model* form appears.
 . For *Model deployment name*, enter the name of the inference service to be created when the model is deployed.
 . For *Serving runtime*, select *vLLM NVIDIA GPU ServingRuntime for KServe*.
 //Select a *Serving runtime* with the `Compatible with hardware profile` label. For more information, see _Supported model-serving runtimes_.
+//If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
 +
 The `vLLm` *Model framework* is automatically selected.
 . For *Deployment mode*, select one of the following options:

--- a/modules/deploying-teacher-and-judge-models.adoc
+++ b/modules/deploying-teacher-and-judge-models.adoc
@@ -32,7 +32,7 @@ The *Deploy model* form appears.
 . For *Model deployment name*, enter the name of the inference service to be created when the model is deployed.
 . For *Serving runtime*, select *vLLM NVIDIA GPU ServingRuntime for KServe*.
 //Select a *Serving runtime* with the `Compatible with hardware profile` label. For more information, see _Supported model-serving runtimes_.
-//If project-scoped runtimes exist, then subheadings distinguish between global runtimes and project-scoped runtimes in the list.
+//If project-scoped runtimes exist, the *Serving runtime* list includes subheadings to distinguish between global runtimes and project-scoped runtimes.
 +
 The `vLLm` *Model framework* is automatically selected.
 . For *Deployment mode*, select one of the following options:
@@ -40,7 +40,7 @@ The `vLLm` *Model framework* is automatically selected.
 * **Advanced**: Use for custom models or when you need to change the model URI, runtime settings, or storage connection.
 . Enter the *Number of model server replicas to deploy*. Set this number based on expected traffic and availability needs, such as support for failover.
 . Select a *Hardware profile* with the `Compatible` label.
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 //Customize resource requests and limits
 . For *Model route*, select the *Make deployed models available through an external route* checkbox.
 . For *Token authentication*, select whether to *Require token authentication*. Enabling this option is recommended to reduce the risk of security vulnerabilities.

--- a/modules/starting-a-jupyter-notebook-server.adoc
+++ b/modules/starting-a-jupyter-notebook-server.adoc
@@ -44,7 +44,6 @@ When a new version of a notebook image is released, the previous version remains
 --
 .. From the *Container size* list, select a suitable container size for your server.
 .. Optional: From the *Accelerator* list, select an accelerator. 
-If project-scoped accelerators exist, the *Accelerator* list includes subheadings to distinguish between global accelerators and project-scoped accelerators.
 .. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
 +
 [IMPORTANT]

--- a/modules/starting-a-jupyter-notebook-server.adoc
+++ b/modules/starting-a-jupyter-notebook-server.adoc
@@ -44,7 +44,7 @@ When a new version of a notebook image is released, the previous version remains
 --
 .. From the *Container size* list, select a suitable container size for your server.
 .. Optional: From the *Accelerator* list, select an accelerator. 
-If project-scoped accelerators exist, then subheadings distinguish between global accelerators and project-scoped accelerators in the list.
+If project-scoped accelerators exist, the *Accelerator* list includes subheadings to distinguish between global accelerators and project-scoped accelerators.
 .. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
 +
 [IMPORTANT]

--- a/modules/starting-a-jupyter-notebook-server.adoc
+++ b/modules/starting-a-jupyter-notebook-server.adoc
@@ -44,6 +44,7 @@ When a new version of a notebook image is released, the previous version remains
 --
 .. From the *Container size* list, select a suitable container size for your server.
 .. Optional: From the *Accelerator* list, select an accelerator. 
+If project-scoped accelerators exist, then subheadings distinguish between global accelerators and project-scoped accelerators in the list.
 .. If you selected an accelerator in the preceding step, specify the number of accelerators to use.
 +
 [IMPORTANT]

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -34,6 +34,7 @@ NOTE: You cannot change the *Serving runtime* selection for a model server that 
 .. In the *Model server name* field, enter a new, unique name for the model server.
 .. In the *Number of model replicas to deploy* field, specify a value.
 .. From the *Hardware profile* list, select a hardware profile.
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
 +
 [IMPORTANT]
 ====

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -34,7 +34,7 @@ NOTE: You cannot change the *Serving runtime* selection for a model server that 
 .. In the *Model server name* field, enter a new, unique name for the model server.
 .. In the *Number of model replicas to deploy* field, specify a value.
 .. From the *Hardware profile* list, select a hardware profile.
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 +
 [IMPORTANT]
 ====

--- a/modules/using-lab-tuning.adoc
+++ b/modules/using-lab-tuning.adoc
@@ -128,7 +128,7 @@ To find authentication details for your judge and teacher models, go to the *Mod
 .. If authenticated, enter the *Token*.
 . In the *Training hardware* section, configure the following settings:
 .. For *Hardware profile*, select a hardware profile to match the hardware requirements of your workload to available node resources. 
-If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
+If project-scoped hardware profiles exist, the *Hardware profile* list includes subheadings to distinguish between global hardware profiles and project-scoped hardware profiles.
 .. For *Training nodes*, enter the total number of nodes to use for the run. One node is used for the evaluation run phase.
 .. For *Storage class*, select a storage class that is compatible with LAB-tuning and distributed training.
 . Optional: In the *Hyperparameters* section, configure advanced settings for the run.

--- a/modules/using-lab-tuning.adoc
+++ b/modules/using-lab-tuning.adoc
@@ -128,6 +128,7 @@ To find authentication details for your judge and teacher models, go to the *Mod
 .. If authenticated, enter the *Token*.
 . In the *Training hardware* section, configure the following settings:
 .. For *Hardware profile*, select a hardware profile to match the hardware requirements of your workload to available node resources. 
+If project-scoped hardware profiles exist, then subheadings distinguish between global hardware profiles and project-scoped hardware profiles in the list.
 .. For *Training nodes*, enter the total number of nodes to use for the run. One node is used for the evaluation run phase.
 .. For *Storage class*, select a storage class that is compatible with LAB-tuning and distributed training.
 . Optional: In the *Hyperparameters* section, configure advanced settings for the run.


### PR DESCRIPTION
ENG-25590: Adds info about project-scoped items in lists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that selection lists for images, hardware profiles, accelerators, and serving runtimes now display subheadings to distinguish between global and project-scoped options where applicable.
  - Added detailed explanations and notes about UI behavior for project-scoped entities in workbench creation, distributed training, model deployment, model server updates, and LAB-tuning procedures.
  - Updated guidance on enabling and using hardware profiles, including their Technology Preview status and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->