### PR TITLE
ENG-27595 - Update to add 2 new fields to LMEVAL Job Properties

### DIFF
--- a/modules/lmeval-evaluation-job-properties.adoc
+++ b/modules/lmeval-evaluation-job-properties.adoc
@@ -114,15 +114,11 @@ a| Creates an operator-managed PVC to store the job results. The PVC is named `<
 
 | `chatTemplate`
 a| chatTemplate applies the specified chat template to prompts. It has two fields:
-
 * `enabled`: `true` or `false`. If it's set to `true`, a chat template is used, if it's set to `false`, no template is used.
 * `name`: If a template name is passed, it is used.I f no name argument is present, the default template for the model is used.
 |===
 
-//// | `outputs.pvcManaged`
-a| Creates an operator-managed PVC to store the job results. The PVC is named `<job-name>-pvc` and is owned by the `LMEvalJob`. After the job finishes, the PVC is still available, but it is deleted with the `LMEvalJob`. Supports the following fields: 
 
-* `size`: ////
 
 
 

--- a/modules/lmeval-evaluation-job-properties.adoc
+++ b/modules/lmeval-evaluation-job-properties.adoc
@@ -110,12 +110,12 @@ a| Creates an operator-managed PVC to store the job results. The PVC is named `<
 | Mount a PVC as the local storage for models and datasets.
 
 | `systemInstruction`
-| Optional parameter. This sets the system instruction for all prompts passed to the evaluated model.
+| (Optional) Sets the system instruction for all prompts passed to the evaluated model.
 
 | `chatTemplate`
-a| chatTemplate applies the specified chat template to prompts. It has two fields:
-* `enabled`: `true` or `false`. If it's set to `true`, a chat template is used, if it's set to `false`, no template is used.
-* `name`: If a template name is passed, it is used.I f no name argument is present, the default template for the model is used.
+a| Applies the specified chat template to prompts. Contains two fields:
+* `enabled`: If set to `true`, a chat template is used. If set to `false`, no template is used.
+* `name`: Uses the provided template name, if used. If no name argument is provided, uses the default template for the model.
 |===
 
 

--- a/modules/lmeval-evaluation-job-properties.adoc
+++ b/modules/lmeval-evaluation-job-properties.adoc
@@ -113,9 +113,17 @@ a| Creates an operator-managed PVC to store the job results. The PVC is named `<
 | Optional parameter. This sets the system instruction for all prompts passed to the evaluated model.
 
 | `chatTemplate`
-|  ApplyChatTemplate will apply the specified chat template to prompts. This is required for chat-completions models.
+a| chatTemplate applies the specified chat template to prompts. It has two fields:
 
+* `enabled`: `true` or `false`. If it's set to `true`, a chat template is used, if it's set to `false`, no template is used.
+* `name`: If a template name is passed, it is used.I f no name argument is present, the default template for the model is used.
 |===
+
+//// | `outputs.pvcManaged`
+a| Creates an operator-managed PVC to store the job results. The PVC is named `<job-name>-pvc` and is owned by the `LMEvalJob`. After the job finishes, the PVC is still available, but it is deleted with the `LMEvalJob`. Supports the following fields: 
+
+* `size`: ////
+
 
 
 

--- a/modules/lmeval-evaluation-job-properties.adoc
+++ b/modules/lmeval-evaluation-job-properties.adoc
@@ -109,6 +109,12 @@ a| Creates an operator-managed PVC to store the job results. The PVC is named `<
 | `offline`
 | Mount a PVC as the local storage for models and datasets.
 
+| `systemInstruction`
+| Optional parameter. This sets the system instruction for all prompts passed to the evaluated model.
+
+| `chatTemplate`
+|  ApplyChatTemplate will apply the specified chat template to prompts. This is required for chat-completions models.
+
 |===
 
 

--- a/modules/lmeval-evaluation-job-properties.adoc
+++ b/modules/lmeval-evaluation-job-properties.adoc
@@ -115,7 +115,7 @@ a| Creates an operator-managed PVC to store the job results. The PVC is named `<
 | `chatTemplate`
 a| Applies the specified chat template to prompts. Contains two fields:
 * `enabled`: If set to `true`, a chat template is used. If set to `false`, no template is used.
-* `name`: Uses the provided template name, if used. If no name argument is provided, uses the default template for the model.
+* `name`: Uses the template name, if provided. If no name argument is provided, uses the default template for the model.
 |===
 
 


### PR DESCRIPTION
Update to add 2 new fields to LMEVAL Job Properties; wording is to be approved by SME (and peer-reviewed by Docs team member) before publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added descriptions for new optional parameters: `systemInstruction` (sets a system instruction for all prompts) and `chatTemplate` (specifies a chat template for prompts) in the LM-EvalJob properties table.
	- Expanded details on output storage management, clarifying persistence and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->