### PR TITLE
ENG-26700: Updating Ray 2.44.1 > 2.46.0.

### DIFF
--- a/modules/creating-a-custom-training-image.adoc
+++ b/modules/creating-a-custom-training-image.adoc
@@ -27,8 +27,8 @@ The following table shows some example base training images:
 | Ray
 | CUDA
 | 3.11
-| `ray:2.44.1-py311-cu121`
-| Ray 2.44.1, Python 3.11, CUDA 12.1
+| `ray:2.46.0-py311-cu121`
+| Ray 2.46.0, Python 3.11, CUDA 12.1
 
 | Ray
 | ROCm
@@ -39,8 +39,8 @@ The following table shows some example base training images:
 | Ray
 | ROCm
 | 3.11
-| `ray:2.44.1-py311-rocm62`
-| Ray 2.44.1, Python 3.11, ROCm 6.2
+| `ray:2.46.0-py311-rocm62`
+| Ray 2.46.0, Python 3.11, ROCm 6.2
 
 | KFTO
 | CUDA
@@ -93,7 +93,7 @@ Examples:
 +
 [source,bash]
 ----
-FROM quay.io/modh/ray:2.44.1-py311-cu121
+FROM quay.io/modh/ray:2.46.0-py311-cu121
 ----
 +
 [source,bash]

--- a/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
+++ b/modules/running-distributed-data-science-workloads-from-ds-pipelines.adoc
@@ -98,7 +98,7 @@ def ray_fn():
            worker_memory_requests=1,
            worker_memory_limits=1,
            worker_extended_resource_requests={“nvidia.com/gpu”: 1}, <5>
-           image="quay.io/modh/ray:2.44.1-py311-cu121", <6>
+           image="quay.io/modh/ray:2.46.0-py311-cu121", <6>
            local_queue="local_queue_name", <7>
        )
    )

--- a/modules/running-the-demo-jupyter-notebooks-from-the-codeflare-sdk.adoc
+++ b/modules/running-the-demo-jupyter-notebooks-from-the-codeflare-sdk.adoc
@@ -116,7 +116,7 @@ The Python version in the Ray cluster image must be the same as the Python versi
 If you omit this line, one of the following Ray cluster images is used by default, based on the Python version detected in the workbench:
 
 * Python 3.9: `quay.io/modh/ray:2.35.0-py39-cu121`
-* Python 3.11: `quay.io/modh/ray:2.44.1-py311-cu121`
+* Python 3.11: `quay.io/modh/ray:2.46.0-py311-cu121`
 
 The default Ray images are compatible with NVIDIA GPUs that are supported by the specified CUDA version.
 The default images are AMD64 images, which might not work on other architectures. 


### PR DESCRIPTION
Updates Ray image to 2.46.0 for Python 3.11.

@coderabbitai ignore
