### PR TITLE
odh-fix-case-for-pvc-file

### DIFF
--- a/modules/ref-example-PVC-configuration.adoc
+++ b/modules/ref-example-PVC-configuration.adoc
@@ -59,5 +59,5 @@ spec:
       storage: 5Gi
 ----
 <1> The online store specifies a PVC that must already exist.
-<2> The online store specifies a storage class name and storage size.
+<2> The offline store specifies a storage class name and storage size.
 <3> The registry configuration specifies that the Feature Store Operator creates a PVC with default settings.

--- a/modules/ref-example-pvc-configuration.adoc
+++ b/modules/ref-example-pvc-configuration.adoc
@@ -1,0 +1,63 @@
+:_module-type: REFERENCE
+
+[id="ref-example-pvc-configuration_{context}"]
+= Example PVC configuration
+
+[role='_abstract']
+When you configure the online store, offline store, or registry, you can also configure persistent volume claims (PVCs) as shown in the following Feature Store custom resource defintion (CRD) example.
+
+NOTE: The following example code requires that you edit it with values that are specific to your use case.
+
+[.lines_space]
+[.console-input]
+[source, yaml]
+----
+apiVersion: feast.dev/v1alpha1
+kind: FeatureStore
+metadata:
+  name: sample-pvc-persistence
+spec:
+  feastProject: my_project
+  services:
+    onlineStore:   # <1>
+      persistence:
+        file:
+          path: online_store.db
+          pvc:
+            ref:
+              name: online-pvc
+            mountPath: /data/online
+    offlineStore:   # <2>
+      persistence:
+        file:
+          type: duckdb
+          pvc:
+            create:
+              storageClassName: standard
+              resources:
+                requests:
+                  storage: 5Gi
+            mountPath: /data/offline
+    registry:   # <3>
+      local:
+        persistence:
+          file:
+            path: registry.db
+            pvc:
+              create: {}
+              mountPath: /data/registry
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: online-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+----
+<1> The online store specifies a PVC that must already exist.
+<2> The online store specifies a storage class name and storage size.
+<3> The registry configuration specifies that the Feature Store Operator creates a PVC with default settings.

--- a/modules/ref-example-pvc-configuration.adoc
+++ b/modules/ref-example-pvc-configuration.adoc
@@ -59,5 +59,5 @@ spec:
       storage: 5Gi
 ----
 <1> The online store specifies a PVC that must already exist.
-<2> The online store specifies a storage class name and storage size.
+<2> The offline store specifies a storage class name and storage size.
 <3> The registry configuration specifies that the Feature Store Operator creates a PVC with default settings.


### PR DESCRIPTION
Fixing case of filename to avoid fetch issues downstream

 modules/ref-example-PVC-configuration.adoc
 to
 modules/ref-example-pvc-configuration.adoc
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new reference guide demonstrating example persistent volume claim (PVC) configurations for the online store, offline store, and registry within a Feature Store resource. The guide includes annotated YAML examples and notes for user customization.
  - Corrected descriptive comments to accurately reflect the offline store's PVC configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->