### PR TITLE
RHOAIENG-26326:Adding Seldon MLServer

### DIFF
--- a/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
@@ -338,7 +338,7 @@ spec:
       autoSelect: true
       priority: 1
 ----
-. In the `metadata.name` field, make sure that the value of the runtime you are adding does not match a runtime that you have already added).
+. In the `metadata.name` field, make sure that the value of the runtime you are adding does not match a runtime that you have already added.
 
 . Optional: To use a custom display name for the runtime that you are adding, add a `metadata.annotations.openshift.io/display-name` field and specify a value, as shown in the following example:
 +

--- a/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
+++ b/modules/adding-a-tested-and-verified-runtime-for-the-single-model-serving-platform.adoc
@@ -6,7 +6,7 @@
 
 In addition to preinstalled and custom model-serving runtimes, you can also use {org-name} tested and verified model-serving runtimes such as the *NVIDIA Triton Inference Server* to support your needs. For more information about {org-name} tested and verified runtimes, see link:https://access.redhat.com/articles/7089743[Tested and verified runtimes for {productname-long}^].
  
-You can use the {productname-long} dashboard to add and enable the *NVIDIA Triton Inference Server* runtime for the single-model serving platform. You can then choose the runtime when you deploy a model on the single-model serving platform.
+You can use the {productname-long} dashboard to add and enable the *NVIDIA Triton Inference Server* or the *Seldon MLServer* runtime for the single-model serving platform. You can then choose the runtime when you deploy a model on the single-model serving platform.
 
 [role='_abstract']
 
@@ -25,6 +25,8 @@ The *Serving runtimes* page opens and shows the model-serving runtimes that are 
 . In the *Select the API protocol this runtime supports* list, select *REST* or *gRPC*.
 
 . Click *Start from scratch*.
+
+. Follow these steps to add the *NVIDIA Triton Inference Server* runtime:
 
 .. If you selected the *REST* API protocol, enter or paste the following YAML code directly in the embedded editor.
 +
@@ -159,6 +161,182 @@ volumes:
     medium: Memory
     sizeLimit: 2Gi
     name: shm
+----
+. Follow these steps to add the *Seldon MLServer* runtime:
+.. If you selected the *REST* API protocol, enter or paste the following YAML code directly in the embedded editor.
++
+[source]
+----
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: mlserver-kserve-rest
+  labels:
+    opendatahub.io/dashboard: "true"
+spec:
+  annotations:
+    openshift.io/display-name: Seldon MLServer
+    prometheus.kserve.io/port: "8080"
+    prometheus.kserve.io/path: /metrics
+  containers:
+    - name: kserve-container
+      image: 'docker.io/seldonio/mlserver@sha256:07890828601515d48c0fb73842aaf197cbcf245a5c855c789e890282b15ce390'
+      env:
+        - name: MLSERVER_HTTP_PORT
+          value: "8080"
+        - name: MLSERVER_GRPC_PORT
+          value: "9000"
+        - name: MODELS_DIR
+          value: /mnt/models
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsNonRoot: true
+  protocolVersions:
+    - v2
+  multiModel: false
+  supportedModelFormats:
+    - name: sklearn
+      version: "0"
+      autoSelect: true
+      priority: 2
+    - name: sklearn
+      version: "1"
+      autoSelect: true
+      priority: 2
+    - name: xgboost
+      version: "1"
+      autoSelect: true
+      priority: 2
+    - name: xgboost
+      version: "2"
+      autoSelect: true
+      priority: 2
+    - name: lightgbm
+      version: "3"
+      autoSelect: true
+      priority: 2
+    - name: lightgbm
+      version: "4"
+      autoSelect: true
+      priority: 2
+    - name: mlflow
+      version: "1"
+      autoSelect: true
+      priority: 1
+    - name: mlflow
+      version: "2"
+      autoSelect: true
+      priority: 1
+    - name: catboost
+      version: "1"
+      autoSelect: true
+      priority: 1
+    - name: huggingface
+      version: "1"
+      autoSelect: true
+      priority: 1
+----
+.. If you selected the *gRPC* API protocol, enter or paste the following YAML code directly in the embedded editor.
++
+[source]
+----
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: mlserver-kserve-grpc
+  labels:
+    opendatahub.io/dashboard: "true"
+spec:
+  annotations:
+    openshift.io/display-name: Seldon MLServer
+    prometheus.kserve.io/port: "8080"
+    prometheus.kserve.io/path: /metrics
+  containers:
+    - name: kserve-container
+      image: 'docker.io/seldonio/mlserver@sha256:07890828601515d48c0fb73842aaf197cbcf245a5c855c789e890282b15ce390'
+      env:
+        - name: MLSERVER_HTTP_PORT
+          value: "8080"
+        - name: MLSERVER_GRPC_PORT
+          value: "9000"
+        - name: MODELS_DIR
+          value: /mnt/models
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+      ports:
+        - containerPort: 9000
+          name: h2c
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsNonRoot: true
+  protocolVersions:
+    - v2
+  multiModel: false
+  supportedModelFormats:
+    - name: sklearn
+      version: "0"
+      autoSelect: true
+      priority: 2
+    - name: sklearn
+      version: "1"
+      autoSelect: true
+      priority: 2
+    - name: xgboost
+      version: "1"
+      autoSelect: true
+      priority: 2
+    - name: xgboost
+      version: "2"
+      autoSelect: true
+      priority: 2
+    - name: lightgbm
+      version: "3"
+      autoSelect: true
+      priority: 2
+    - name: lightgbm
+      version: "4"
+      autoSelect: true
+      priority: 2
+    - name: mlflow
+      version: "1"
+      autoSelect: true
+      priority: 1
+    - name: mlflow
+      version: "2"
+      autoSelect: true
+      priority: 1
+    - name: catboost
+      version: "1"
+      autoSelect: true
+      priority: 1
+    - name: huggingface
+      version: "1"
+      autoSelect: true
+      priority: 1
 ----
 . In the `metadata.name` field, make sure that the value of the runtime you are adding does not match a runtime that you have already added).
 

--- a/modules/customizable-model-serving-runtime-parameters.adoc
+++ b/modules/customizable-model-serving-runtime-parameters.adoc
@@ -12,12 +12,13 @@ For more information about parameters for each of the supported serving runtimes
 |===
 | Serving runtime | Resource 
 
-| NVIDIA Triton Inference Server | link:https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/tensorrtllm_backend/docs/model_config.html?#model-configuration[NVIDIA Triton Inference Server: Model Parameters]
 | Caikit Text Generation Inference Server (Caikit-TGIS) ServingRuntime for KServe | 
 link:https://github.com/opendatahub-io/caikit-nlp?tab=readme-ov-file#configuration[Caikit NLP: Configuration] +
 link:https://github.com/IBM/text-generation-inference?tab=readme-ov-file#model-configuration[TGIS: Model configuration]
 | Caikit Standalone ServingRuntime for KServe | link:https://github.com/opendatahub-io/caikit-nlp?tab=readme-ov-file#configuration[Caikit NLP: Configuration]
+| NVIDIA Triton Inference Server | link:https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/tensorrtllm_backend/docs/model_config.html?#model-configuration[NVIDIA Triton Inference Server: Model Parameters]
 |OpenVINO Model Server | link:https://docs.openvino.ai/2024/openvino-workflow/model-server/ovms_docs_dynamic_input.html[OpenVINO Model Server Features: Dynamic Input Parameters]
+| Seldon MLServer | link:https://mlserver.readthedocs.io/en/stable/reference/model-settings.html[MLServer Documentation: Model Settings] 
 |[Deprecated] Text Generation Inference Server (TGIS) Standalone ServingRuntime for KServe	| link:https://github.com/IBM/text-generation-inference?tab=readme-ov-file#model-configuration[TGIS: Model configuration]
 |vLLM NVIDIA GPU ServingRuntime for KServe | link:https://docs.vllm.ai/en/stable/serving/engine_args.html[vLLM: Engine Arguments] +
 link:https://docs.vllm.ai/en/stable/serving/openai_compatible_server.html[OpenAI-Compatible Server] 

--- a/modules/ref-inference-endpoints.adoc
+++ b/modules/ref-inference-endpoints.adoc
@@ -284,6 +284,66 @@ grpcurl -cacert ./openshift_ca_istio_knative.crt -proto ./grpc_predict_v2.proto 
 ----
 endif::[]
 
+== Seldon MLServer
+
+--
+.REST endpoints
+* `v2/models/[/versions/<model_version>]/infer`
+* `v2/models/<model_name>[/versions/<model_version>]`
+* `v2/health/ready`
+* `v2/health/live`
+* `v2/models/<model_name>[/versions/]/ready`
+* `v2`
+--
+
+.Example command
+ifndef::upstream[]
+[source]
+----
+curl -ks <inference_endpoint_url>/v2/models/<model_name>/infer -d '{ "model_name": "<model_name>", "inputs": [{ "name": "<name_of_model_input>", "shape": [<shape>], "datatype": "<data_type>", "data": [<data>] }]}' -H 'Authorization: Bearer <token>'
+----
+endif::[]
+ifdef::upstream[]
+[source]
+----
+curl -ks <inference_endpoint_url>/v2/models/<model_name>/infer -d /
+'{ "model_name": "<model_name>", \
+   "inputs": \
+        [{ "name": "<name_of_model_input>", \
+           "shape": [<shape>], \
+           "datatype": "<data_type>", \
+           "data": [<data>] \
+         }]}' -H 'Authorization: Bearer <token>'
+----
+endif::[]
+--
+.gRPC endpoints
+* `:443 inference.GRPCInferenceService/ModelInfer`
+* `:443 inference.GRPCInferenceService/ModelReady`
+* `:443 inference.GRPCInferenceService/ModelMetadata`
+* `:443 inference.GRPCInferenceService/ServerReady`
+* `:443 inference.GRPCInferenceService/ServerLive`
+* `:443 inference.GRPCInferenceService/ServerMetadata`
+--
+
+.Example command
+ifdef::upstream[]
+[source]
+----
+grpcurl -cacert ./openshift_ca_istio_knative.crt \
+        -proto ./grpc_predict_v2.proto \
+        -d @ \
+        -H "Authorization: Bearer <token>" \
+        <inference_endpoint_url>:443 \
+        inference.GRPCInferenceService/ModelMetadata
+----
+endif::[]
+ifndef::upstream[]
+----
+grpcurl -cacert ./openshift_ca_istio_knative.crt -proto ./grpc_predict_v2.proto -d @ -H "Authorization: Bearer <token>" <inference_endpoint_url>:443 inference.GRPCInferenceService/ModelMetadata
+----
+endif::[]
+
 [role='_additional-resources']
 == Additional resources
 * link:https://github.com/IBM/text-generation-inference[Text Generation Inference Server (TGIS)^]

--- a/modules/ref-tested-verified-runtimes.adoc
+++ b/modules/ref-tested-verified-runtimes.adoc
@@ -28,6 +28,7 @@ endif::[]
 | Name | Description | Exported model format 
 
 | NVIDIA Triton Inference Server | An open-source inference-serving software for fast and scalable AI in applications. | TensorRT, TensorFlow, PyTorch, ONNX, OpenVINO, Python, RAPIDS FIL, and more
+| Seldon MLServer | An open-source inference server designed to simplify the deployment of machine learning models. | Scikit-Learn (sklearn), XGBoost, LightGBM, CatBoost, HuggingFace and MLflow
 
 |===
 
@@ -37,6 +38,7 @@ endif::[]
 | Name | Default protocol | Additonal protocol | Model mesh support | Single node OpenShift support | Deployment mode
 
 | NVIDIA Triton Inference Server | gRPC | REST | Yes | Yes | Raw and serverless
+| Seldon MLServer | gRPC | REST | No | Yes | Raw and serverless
 
 |===
 

--- a/modules/ref-tested-verified-runtimes.adoc
+++ b/modules/ref-tested-verified-runtimes.adoc
@@ -9,10 +9,6 @@ Tested and verified runtimes are community versions of model-serving runtimes th
 
 {org-name} tests the current version of a tested and verified runtime each time there is a new version of {productname-short}. If a new version of a tested and verified runtime is released in the middle of an {productname-short} release cycle, it will be tested and verified in an upcoming release.
 
-ifndef::upstream[]
-A list of the tested and verified runtimes and compatible versions is available in the link:{rhoaidocshome}html-single/release_notes[{productname-short} release notes].
-endif::[]
-
 [NOTE]
 --
 Tested and verified runtimes are not directly supported by {org-name}. You are responsible for ensuring that you are licensed to use any tested and verified runtimes that you add, and for correctly configuring and maintaining them.

--- a/modules/ref-tested-verified-runtimes.adoc
+++ b/modules/ref-tested-verified-runtimes.adoc
@@ -35,7 +35,7 @@ endif::[]
 .Deployment requirements
 
 |===
-| Name | Default protocol | Additonal protocol | Model mesh support | Single node OpenShift support | Deployment mode
+| Name | Default protocol | Additional protocol | Model mesh support | Single node OpenShift support | Deployment mode
 
 | NVIDIA Triton Inference Server | gRPC | REST | Yes | Yes | Raw and serverless
 | Seldon MLServer | gRPC | REST | No | Yes | Raw and serverless

--- a/modules/ref-tested-verified-runtimes.adoc
+++ b/modules/ref-tested-verified-runtimes.adoc
@@ -41,7 +41,7 @@ endif::[]
 
 [NOTE]
 --
-The `alibi-detect` and `alibi-explain` libraries from Seldon are under the Business Source License 1.1 (BSL 1.1). Please note that these libraries are not tested, verified, or supported by {org-name} as part of the certified *Seldon MLServer* runtime. It is recommended to refrain from using these libraries in production environments with the runtime.
+The `alibi-detect` and `alibi-explain` libraries from Seldon are under the Business Source License 1.1 (BSL 1.1). These libraries are not tested, verified, or supported by {org-name} as part of the certified *Seldon MLServer* runtime. It is not recommended that you use these libraries in production environments with the runtime.
 --
 
 [role="_additional-resources"]

--- a/modules/ref-tested-verified-runtimes.adoc
+++ b/modules/ref-tested-verified-runtimes.adoc
@@ -42,6 +42,12 @@ endif::[]
 
 |===
 
+
+[NOTE]
+--
+The `alibi-detect` and `alibi-explain` libraries from Seldon are under the Business Source License 1.1 (BSL 1.1). Please note that these libraries are not tested, verified, or supported by {org-name} as part of the certified *Seldon MLServer* runtime. It is recommended to refrain from using these libraries in production environments with the runtime.
+--
+
 [role="_additional-resources"]
 .Additional resources
 ifdef::upstream[]


### PR DESCRIPTION
## Description
@coderabbitai ignore
- Added Seldon MLServer to list of tested and verified runtimes
- Updated deployment procedure to include example yaml for Seldon MLServer
- Added link to MLServer model settings
- Added REST and gRPC inference endpoints and example commands
- Added note about alibi-detect and alibi-explain libraries, specifically to state that RH does not support them.


## How Has This Been Tested?
Local build

## Previews

Added to tested and verified runtimes:
<img width="706" alt="Screenshot 2025-07-07 at 10 48 58 AM" src="https://github.com/user-attachments/assets/28126c1b-69ba-44e8-ad24-46e039059a30" />


Inference endpoints:
<img width="569" alt="Screenshot 2025-07-03 at 10 52 04 AM" src="https://github.com/user-attachments/assets/61e38a54-6470-4654-89d1-ede894b213ed" />

Link to MLServer customizable paramters
<img width="696" alt="Screenshot 2025-07-03 at 12 39 44 PM" src="https://github.com/user-attachments/assets/86b7fbfe-6475-4039-b4cf-acc97660ea95" />

Adding MLServer as a custom runtime:
<img width="690" alt="Screenshot 2025-07-03 at 12 40 44 PM" src="https://github.com/user-attachments/assets/ab9a1686-63b6-4832-ad1c-6d3001d5701b" />
<img width="449" alt="Screenshot 2025-07-03 at 12 41 34 PM" src="https://github.com/user-attachments/assets/948c0104-0b3e-4a37-a099-d03b57b323cd" />
<img width="403" alt="Screenshot 2025-07-03 at 12 41 46 PM" src="https://github.com/user-attachments/assets/954e5864-852c-4601-902a-20514bc3c952" />
<img width="421" alt="Screenshot 2025-07-03 at 12 41 55 PM" src="https://github.com/user-attachments/assets/d532c439-74c3-4755-9ad8-f08d1c97c208" />




