### PR TITLE
ENG-26880: Updates dashboard config info based on previous feedback

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -10,6 +10,7 @@ ifdef::cloud-service[]
 :vernum: 1
 :install-package: Add-on
 :openshift-platform: OpenShift
+:dbd-config-default-namespace: redhat-ods-applications
 endif::[]
 
 // conditional entities for RHOAI-SM
@@ -23,6 +24,7 @@ ifdef::self-managed[]
 :install-package: Operator
 :openshift-platform: OpenShift Container Platform
 :openshift-platform-url: openshift-container-platform
+:dbd-config-default-namespace: redhat-ods-applications
 endif::[]
 
 ifdef::upstream[]
@@ -38,6 +40,7 @@ ifdef::upstream[]
 :openshift-platform: OpenShift Container Platform
 :openshift-platform-url: openshift-container-platform
 :odhdocshome: https://opendatahub.io/docs
+:dbd-config-default-namespace: opendatahub
 endif::[]
 
 ifndef::upstream[]

--- a/assemblies/customizing-the-dashboard.adoc
+++ b/assemblies/customizing-the-dashboard.adoc
@@ -18,7 +18,7 @@ These features are configured in the `OdhDashboardConfig` custom resource (CR).
 
 To see a description of the options in the {productname-short} dashboard configuration, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 
-As an administrator, you can customize the interface of the dashboard.
+As an {productname-short} administrator, you can customize the interface of the dashboard.
 For example, you can show or hide some of the dashboard navigation menu items. 
 To change the default settings of the dashboard, edit the `OdhDashboardConfig` CR as described in link:{odhdocshome}/managing-resources/#editing-the-dashboard-configuration_dashboard[Editing the dashboard configuration].
 

--- a/managing-odh.adoc
+++ b/managing-odh.adoc
@@ -32,8 +32,6 @@ include::assemblies/managing-users-and-groups.adoc[leveloffset=+1]
 
 include::assemblies/creating-custom-workbench-images.adoc[leveloffset=+1]
 
-include::assemblies/customizing-the-dashboard.adoc[leveloffset=+1]
-
 include::assemblies/managing-applications-that-show-in-the-dashboard.adoc[leveloffset=+1]
 
 include::modules/creating-project-scoped-resources.adoc[leveloffset=+1]

--- a/managing-odh.adoc
+++ b/managing-odh.adoc
@@ -20,12 +20,13 @@ include::_artifacts/document-attributes-global.adoc[]
 As an OpenShift cluster administrator, you can manage the following {productname-long} resources:
 
 * Users and groups
-* The dashboard interface, including the visibility of navigation menu items
+* Custom workbench images
 * Applications that show in the dashboard
 * Custom deployment resources that are related to the {productname-long} Operator, for example, CPU and memory limits and requests
 * Accelerators
 * Distributed workloads
 * Data backup
+* Logs and audit records
 
 
 include::assemblies/managing-users-and-groups.adoc[leveloffset=+1]

--- a/managing-resources.adoc
+++ b/managing-resources.adoc
@@ -19,8 +19,10 @@ include::_artifacts/document-attributes-global.adoc[]
 As an {productname-short} administrator, you can manage the following resources:
 
 * {productname-short} admin and user groups
+* Dashboard customization
 * Custom workbench images
 * Cluster PVC size
+* Connection types
 * Cluster storage classes
 * Basic workbenches
 

--- a/managing-resources.adoc
+++ b/managing-resources.adoc
@@ -26,6 +26,8 @@ As an {productname-short} administrator, you can manage the following resources:
 
 include::modules/selecting-admin-and-user-groups.adoc[leveloffset=+1]
 
+include::assemblies/customizing-the-dashboard.adoc[leveloffset=+1]
+
 include::modules/importing-a-custom-workbench-image.adoc[leveloffset=+1]
 
 include::assemblies/managing-cluster-pvc-size.adoc[leveloffset=+1]

--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -69,10 +69,10 @@ If you are using a _custom_ model-serving runtime with your model server and wan
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ====
 

--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -69,7 +69,7 @@ If you are using a _custom_ model-serving runtime with your model server and wan
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
+++ b/modules/adding-a-model-server-for-the-multi-model-serving-platform.adoc
@@ -68,12 +68,12 @@ If you are using a _custom_ model-serving runtime with your model server and wan
 [IMPORTANT]
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[] 
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
+endif::[]
 ====
 
 . Optional: Click *Customize resource requests and limit* and update the following values:

--- a/modules/adding-an-application-to-the-dashboard.adoc
+++ b/modules/adding-an-application-to-the-dashboard.adoc
@@ -4,24 +4,31 @@
 = Adding an application to the dashboard
 
 [role='_abstract']
-If you have installed an application in your {openshift-platform} cluster, you can add a tile for that application to the {productname-short} dashboard (the *Applications* → *Enabled* page) to make it accessible for {productname-short} users.
+If you have installed an application in your {openshift-platform} cluster, an {productname-short} administrator can add a tile for that application to the {productname-short} dashboard (the *Applications* → *Enabled* page) to make it accessible for {productname-short} users.
 
 .Prerequisites
-* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have {productname-short} administrator privileges.
 
-ifndef::upstream[]
-* The dashboard configuration enablement option is set to `true` (the default). Note that a cluster administrator can disable this ability as described in link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
-endif::[]
+* The `spec.dashboardConfig.enablement` dashboard configuration option is set to `true` (the default).
++
 ifdef::upstream[]
-* The dashboard configuration enablement option is set to `true` (the default). Note that a cluster administrator can disable this ability as described in link:{odhdocshome}/managing-odh/#preventing-users-from-adding-applications-to-the-dashboard_dashboard[Preventing users from adding applications to the dashboard].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 
 .Procedure
-. Log in to the {openshift-platform} console as a cluster administrator.
+. Log in to the {openshift-platform} console as an {productname-short} administrator.
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
 . On the *API Explorer* page, search for the `OdhApplication` kind.
 . Click the `OdhApplication` kind to open the resource details page.
-. On the *OdhApplication* details page, select the `redhat-ods-applications` project from the *Project* list.
+ifndef::upstream[]
+. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+endif::[]
+ifdef::upstream[]
+. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+endif::[]
 . Click the *Instances* tab.
 . Click *Create OdhApplication*.
 . On the *Create OdhApplication* page, copy the following code and paste it into the YAML editor.

--- a/modules/adding-an-application-to-the-dashboard.adoc
+++ b/modules/adding-an-application-to-the-dashboard.adoc
@@ -24,10 +24,10 @@ endif::[]
 . On the *API Explorer* page, search for the `OdhApplication` kind.
 . Click the `OdhApplication` kind to open the resource details page.
 ifndef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
 endif::[]
 ifdef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
 endif::[]
 . Click the *Instances* tab.
 . Click *Create OdhApplication*.

--- a/modules/adding-an-application-to-the-dashboard.adoc
+++ b/modules/adding-an-application-to-the-dashboard.adoc
@@ -21,14 +21,9 @@ endif::[]
 .Procedure
 . Log in to the {openshift-platform} console as an {productname-short} administrator.
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
-. On the *API Explorer* page, search for the `OdhApplication` kind.
-. Click the `OdhApplication` kind to open the resource details page.
-ifndef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
-endif::[]
-ifdef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
-endif::[]
+. In the search bar, enter `OdhApplication` to filter by kind.
+. Click the `OdhApplication` custom resource (CR) to open the resource details page.
+. From the *Project* list, select the {productname-short} application namespace; the default is `{dbd-config-default-namespace}`.
 . Click the *Instances* tab.
 . Click *Create OdhApplication*.
 . On the *Create OdhApplication* page, copy the following code and paste it into the YAML editor.
@@ -41,7 +36,7 @@ apiVersion: dashboard.opendatahub.io/v1
 kind: OdhApplication
 metadata:
   name: examplename
-  namespace: redhat-ods-applications
+  namespace: {dbd-config-default-namespace}
   labels:
     app: odh-dashboard
     app.kubernetes.io/part-of: odh-dashboard

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -115,7 +115,7 @@ By default, the hardware profiles feature is not enabled: hardware profiles are 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -114,11 +114,11 @@ The hardware profile specifies the number of CPUs and the amount of memory alloc
 By default, the hardware profiles feature is not enabled: hardware profiles are not shown in the dashboard navigation menu or elsewhere in the user interface. 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ==== 
 

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -115,10 +115,10 @@ By default, the hardware profiles feature is not enabled: hardware profiles are 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ==== 
 

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -111,7 +111,7 @@ By default, the hardware profiles feature is not enabled: hardware profiles are 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -111,10 +111,10 @@ By default, the hardware profiles feature is not enabled: hardware profiles are 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ==== 
 

--- a/modules/creating-a-workbench-for-distributed-training.adoc
+++ b/modules/creating-a-workbench-for-distributed-training.adoc
@@ -110,11 +110,11 @@ The hardware profile specifies the number of CPUs and the amount of memory alloc
 By default, the hardware profiles feature is not enabled: hardware profiles are not shown in the dashboard navigation menu or elsewhere in the user interface. 
 In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. 
 To show the *Settings* -> *Hardware profiles* option in the dashboard navigation menu, and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ==== 
 

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -90,10 +90,10 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ====
 ..  In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -90,7 +90,7 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -89,11 +89,11 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 [IMPORTANT]
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ====
 ..  In the *Model route* section, select the *Make deployed models available through an external route* checkbox to make your deployed models available to external clients.

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -50,10 +50,10 @@ The *Deploy model* dialog opens.
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ====
 

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -50,7 +50,7 @@ The *Deploy model* dialog opens.
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -49,11 +49,11 @@ The *Deploy model* dialog opens.
 [IMPORTANT]
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ====
 

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -125,10 +125,10 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ====
 

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -125,7 +125,7 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -124,11 +124,11 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 [IMPORTANT]
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ====
 

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -35,7 +35,7 @@ To change the default behavior for such options, edit the `OdhDashboardConfig` C
 ====
 +
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -14,8 +14,7 @@ As an {productname-short} administrator, you can customize the interface of the 
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
 . In the search bar, enter `OdhDashboardConfig` to filter by kind.
 . Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-. Select the application namespace from the *Project* list.  
-+
+. Select the application namespace from the *Project* list. 
 `redhat-ods-applications` is the default application namespace.
 . Click the *Instances* tab.
 . Click the `odh-dashboard-config` instance to open the details page.

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -14,8 +14,12 @@ As an {productname-short} administrator, you can customize the interface of the 
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
 . In the search bar, enter `OdhDashboardConfig` to filter by kind.
 . Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-. Select the application namespace from the *Project* list. 
-`redhat-ods-applications` is the default application namespace.
+ifndef::upstream[]
+. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+endif::[]
+ifdef::upstream[]
+. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+endif::[]
 . Click the *Instances* tab.
 . Click the `odh-dashboard-config` instance to open the details page.
 . Click the *YAML* tab. 

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -33,7 +33,7 @@ To change the default behavior for such options, edit the `OdhDashboardConfig` C
 
 .Example
 By default, the *Distributed workloads* menu item is shown in the dashboard navigation menu. 
-To hide this menu item,, set the `disableDistributedWorkloads` value to `true`, as follows:
+To hide this menu item, set the `disableDistributedWorkloads` value to `true`, as follows:
 
 [source]
 ----

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -14,12 +14,7 @@ As an {productname-short} administrator, you can customize the interface of the 
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
 . In the search bar, enter `OdhDashboardConfig` to filter by kind.
 . Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-ifndef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
-endif::[]
-ifdef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
-endif::[]
+. From the *Project* list, select the {productname-short} application namespace; the default is `{dbd-config-default-namespace}`.
 . Click the *Instances* tab.
 . Click the `odh-dashboard-config` instance to open the details page.
 . Click the *YAML* tab. 

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -15,10 +15,10 @@ As an {productname-short} administrator, you can customize the interface of the 
 . In the search bar, enter `OdhDashboardConfig` to filter by kind.
 . Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
 ifndef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
 endif::[]
 ifdef::upstream[]
-. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
 endif::[]
 . Click the *Instances* tab.
 . Click the `odh-dashboard-config` instance to open the details page.

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -35,13 +35,22 @@ To change the default behavior for such options, edit the `OdhDashboardConfig` C
 
 * To show the feature, set the value to `false`
 * To hide the feature, set the value to `true`
+
+.Example
+By default, the *Distributed workloads* menu item is shown in the dashboard navigation menu. 
+To hide this menu item,, set the `disableDistributedWorkloads` value to `true`, as follows:
+
+[source]
+----
+disableDistributedWorkloads: true
+----
 ====
 +
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about dashboard configuration options and their default values, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about dashboard configuration options and their default values, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 . Click *Save* to apply your changes and then click *Reload* to synchronize your changes to the cluster.
 

--- a/modules/editing-the-dashboard-configuration.adoc
+++ b/modules/editing-the-dashboard-configuration.adoc
@@ -4,17 +4,19 @@
 = Editing the dashboard configuration
 
 [role='_abstract']
-As an administrator, you can customize the interface of the dashboard by editing the dashboard configuration.
+As an {productname-short} administrator, you can customize the interface of the dashboard by editing the dashboard configuration.
 
 .Prerequisites
-* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have {productname-short} administrator privileges. 
 
 .Procedure
-. Log in to the {openshift-platform} console as a cluster administrator.
+. Log in to the {openshift-platform} console as a user with {productname-short} administrator privileges.
 . In the *Administrator* perspective, click *Home* -> *API Explorer*.
 . In the search bar, enter `OdhDashboardConfig` to filter by kind.
 . Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-. Select the `redhat-ods-applications` project from the *Project* list.
+. Select the application namespace from the *Project* list.  
++
+`redhat-ods-applications` is the default application namespace.
 . Click the *Instances* tab.
 . Click the `odh-dashboard-config` instance to open the details page.
 . Click the *YAML* tab. 

--- a/modules/enabling-custom-images.adoc
+++ b/modules/enabling-custom-images.adoc
@@ -24,8 +24,8 @@ The visibility of the *Workbench images* menu item is controlled in the dashboar
 You need `cluster-admin` permissions to edit the dashboard configuration. 
 +
 ifdef::upstream[]
-For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-odh/#customizing-the-dashboard[Customizing the dashboard].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard[Customizing the dashboard].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]

--- a/modules/enabling-custom-images.adoc
+++ b/modules/enabling-custom-images.adoc
@@ -21,7 +21,7 @@ endif::[]
 +
 The visibility of the *Workbench images* menu item is controlled in the dashboard configuration, by the value of the `dashboardConfig: disableBYONImageStream` option. It is set to *false* (the *Workbench images* menu item is visible) by default. 
 +
-You need `cluster-admin` permissions to edit the dashboard configuration. 
+You need {productname-short} administrator permissions to edit the dashboard configuration. 
 +
 ifdef::upstream[]
 For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].

--- a/modules/enabling-the-model-catalog.adoc
+++ b/modules/enabling-the-model-catalog.adoc
@@ -39,14 +39,15 @@ endif::[]
 
 .Prerequisites
 
-* You have cluster administrator privileges for your {openshift-platform} cluster.
-* You have installed {productname-short}.
+* A cluster administrator has installed {productname-short}.
 ifdef::upstream[]
 * A cluster administrator has enabled the model registry component in your {productname-short} deployment. For more information, see link:{odhdocshome}/working-with-model-registries/#enabling-the-model-registry-component_model-registry[Enabling the model registry component].
 endif::[]
 ifndef::upstream[]
 * A cluster administrator has enabled the model registry component in your {productname-short} deployment. For more information, see link:{rhoaidocshome}{default-format-url}/enabling_the_model_registry_component/enabling-the-model-registry-component_model-registry-config[Enabling the model registry component].
 endif::[]
+* You have {productname-short} administrator privileges.
+
 
 .Procedure
 

--- a/modules/enabling-the-model-catalog.adoc
+++ b/modules/enabling-the-model-catalog.adoc
@@ -7,10 +7,10 @@
 Before data scientists in your organization can register, deploy, and customize models from the model catalog, you must enable the feature in {productname-short}. You can enable the model catalog feature by setting the `disableModelCatalog` dashboard configuration option to `false`. 
 
 ifdef::upstream[]
-For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-odh/#customizing-the-dashboard[Customizing the dashboard].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard[Customizing the dashboard].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 
 ifndef::upstream[]
@@ -51,10 +51,10 @@ endif::[]
 .Procedure
 
 ifdef::upstream[]
-. Follow the steps described in link:{odhdocshome}/managing-odh/#customizing-the-dashboard[Customizing the dashboard] to set the `disableModelCatalog` dashboard configuration option to `false`. 
+. Follow the steps described in link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard] to set the `disableModelCatalog` dashboard configuration option to `false`. 
 endif::[]
 ifndef::upstream[]
-. Follow the steps described in link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard[Customizing the dashboard] to set the `disableModelCatalog` dashboard configuration option to `false`. 
+. Follow the steps described in link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard] to set the `disableModelCatalog` dashboard configuration option to `false`. 
 endif::[]
 
 

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -4,16 +4,18 @@
 = Enabling the multi-model serving platform
 
 [role='_abstract']
-To use the multi-model serving platform, you must first enable the platform.
+To use the multi-model serving platform, you must first enable the platform. 
+The multi-model serving platform uses the ModelMesh component.
 
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the multi-model serving platform, which uses the ModelMesh component. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
+* The `spec.dashboardConfig.disableModelMesh` dashboard configuration option is set to `false` (the default).
++
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 
 .Procedure

--- a/modules/enabling-the-multi-model-serving-platform.adoc
+++ b/modules/enabling-the-multi-model-serving-platform.adoc
@@ -8,7 +8,13 @@ To use the multi-model serving platform, you must first enable the platform.
 
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the multi-model serving platform, which uses the ModelMesh component. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the multi-model serving platform, which uses the ModelMesh component. 
+ifndef::upstream[]
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+ifdef::upstream[]
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
 
 .Procedure
 . In the left menu of the {productname-short} dashboard, click *Settings* → *Cluster settings*.

--- a/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
+++ b/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
@@ -14,26 +14,22 @@ If you previously enabled the *NVIDIA NIM model serving platform* in {productnam
 endif::[]
 
 .Prerequisites
-* You have logged in to {productname-long} as an administrator.
+* You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 ifdef::upstream[]
 * You have enabled the single-model serving platform. You do not need to enable a preinstalled runtime. For more information about enabling the single-model serving platform, see link:{odhdocshome}/serving-models/#deploying-models-using-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
 endif::[]
 ifndef::upstream[]
 * You have enabled the single-model serving platform. You do not need to enable a preinstalled runtime. For more information about enabling the single-model serving platform, see link:{rhoaidocshome}{default-format-url}/serving_models/serving-large-models_serving-large-models#enabling-the-single-model-serving-platform_serving-large-models[Enabling the single-model serving platform^].
 endif::[]
-* The `disableNIMModelServing` {productname-short} dashboard configuration is set to `false`:
+* The `disableNIMModelServing` dashboard configuration option is set to `false`.
 +
-[source]
-----
-disableNIMModelServing: false
-----
-+
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+
 ifndef::upstream[]
 * You have enabled GPU support in {productname-short}. This includes installing the Node Feature Discovery operator and NVIDIA GPU Operators. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/specialized_hardware_and_driver_enablement/psap-node-feature-discovery-operator#installing-the-node-feature-discovery-operator_psap-node-feature-discovery-operator[Installing the Node Feature Discovery operator^] and link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/enabling_accelerators#enabling-nvidia-gpus_managing-rhoai[Enabling NVIDIA GPUs^].
 endif::[]
@@ -45,7 +41,6 @@ endif::[]
 * You have generated an NGC API key on the NGC portal. For more information, see link:https://docs.nvidia.com/ngc/gpu-cloud/ngc-user-guide/index.html#ngc-api-keys[NGC API keys].
 
 .Procedure
-. Log in to {productname-short}.
 . In the left menu of the {productname-short} dashboard, click *Applications* -> *Explore*.
 . On the *Explore* page, find the *NVIDIA NIM* tile.
 . Click *Enable* on the application tile.

--- a/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
+++ b/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
@@ -4,7 +4,7 @@
 = Enabling the NVIDIA NIM model serving platform
 
 [role="_abstract"]
-As an administrator, you can use the {productname-long} dashboard to enable the NVIDIA NIM model serving platform.
+As an {productname-short} administrator, you can use the {productname-long} dashboard to enable the NVIDIA NIM model serving platform.
 
 ifdef::self-managed[]
 [NOTE]

--- a/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
+++ b/modules/enabling-the-nvidia-nim-model-serving-platform.adoc
@@ -29,7 +29,7 @@ disableNIMModelServing: false
 ----
 +
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -9,12 +9,13 @@ When you have installed KServe, you can use the {productname-long} dashboard to 
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * You have installed KServe.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the single-model serving platform, which uses the KServe component. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
+* The `spec.dashboardConfig.disableKServe` dashboard configuration option is set to `false` (the default).
++
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
  
 .Procedure

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -9,8 +9,13 @@ When you have installed KServe, you can use the {productname-long} dashboard to 
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges.
 * You have installed KServe.
-* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the single-model serving platform, which uses the KServe component. For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-
+* Your cluster administrator has _not_ edited the {productname-short} dashboard configuration to disable the ability to select the single-model serving platform, which uses the KServe component. 
+ifndef::upstream[]
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
+ifdef::upstream[]
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+endif::[]
  
 .Procedure
 . Enable the single-model serving platform as follows:

--- a/modules/hiding-the-default-basic-workbench-application.adoc
+++ b/modules/hiding-the-default-basic-workbench-application.adoc
@@ -21,10 +21,10 @@ To hide the *Start basic workbench* tile so that it is no longer included in the
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
 ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
 endif::[]
 ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
 endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.

--- a/modules/hiding-the-default-basic-workbench-application.adoc
+++ b/modules/hiding-the-default-basic-workbench-application.adoc
@@ -20,12 +20,7 @@ To hide the *Start basic workbench* tile so that it is no longer included in the
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
-endif::[]
-ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
-endif::[]
+.. From the *Project* list, select the {productname-short} application namespace; the default is `{dbd-config-default-namespace}`.
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/hiding-the-default-basic-workbench-application.adoc
+++ b/modules/hiding-the-default-basic-workbench-application.adoc
@@ -10,17 +10,22 @@ To hide the *Start basic workbench* tile so that it is no longer included in the
 
 .Prerequisite
 
-* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have {productname-short} administrator privileges.
 
 
 .Procedure
 
-. Log in to the {openshift-platform} console as a cluster administrator.
+. Log in to the {openshift-platform} console as an {productname-short} administrator.
 . Open the dashboard configuration file:
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-.. Select the `redhat-ods-applications` project from the *Project* list.
+ifndef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+endif::[]
+ifdef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/making-lab-tuning-and-hardware-profiles-features-visible.adoc
+++ b/modules/making-lab-tuning-and-hardware-profiles-features-visible.adoc
@@ -7,14 +7,14 @@
 By default, hardware profiles and LAB-tuning features are hidden from the {productname-short} dashboard navigation menu and user interface. You must enable these features to access the *Model catalog*, *Model customization*, and *Hardware profiles* pages. 
 
 .Prerequisites
-* You have cluster administrator privileges for your {openshift-platform} cluster.
-* You have installed the required Operators and components for LAB-tuning. 
+* A cluster administrator has installed the required Operators and components for LAB-tuning. 
 ifdef::upstream[]
 * A cluster administrator has enabled the model registry component in your {productname-short} deployment. For more information, see link:{odhdocshome}/working-with-model-registries/#enabling-the-model-registry-component_model-registry[Enabling the model registry component].
 endif::[]
 ifndef::upstream[]
 * A cluster administrator has enabled the model registry component in your {productname-short} deployment. For more information, see link:{rhoaidocshome}{default-format-url}/enabling_the_model_registry_component/enabling-the-model-registry-component_model-registry-config[Enabling the model registry component].
 endif::[]
+* You have {productname-short} administrator privileges.
 
 .Procedure
 ifdef::upstream[]

--- a/modules/making-lab-tuning-and-hardware-profiles-features-visible.adoc
+++ b/modules/making-lab-tuning-and-hardware-profiles-features-visible.adoc
@@ -18,10 +18,10 @@ endif::[]
 
 .Procedure
 ifdef::upstream[]
-. Follow the steps described in link:{odhdocshome}/managing-odh/#customizing-the-dashboard[Customizing the dashboard] to set the following dashboard configuration options to `false`: 
+. Follow the steps described in link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard] to set the following dashboard configuration options to `false`: 
 endif::[]
 ifndef::upstream[]
-. Follow the steps described in link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard[Customizing the dashboard] to set the following dashboard configuration options to `false`: 
+. Follow the steps described in link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard] to set the following dashboard configuration options to `false`: 
 endif::[]
 +
 * `disableModelCatalog`: Set to `false` to enable the *Models* → *Model catalog* page in the dashboard.  

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -6,7 +6,7 @@
 [role='_abstract']
 By default, {productname-short} administrators can add applications to the {productname-short} dashboard *Application → Enabled* page.
 
-As a cluster administrator, you can disable the ability for {productname-short} administrators to add applications to the dashboard.
+As an {productname-short} administrator, you can disable the ability for {productname-short} administrators to add applications to the dashboard.
 
 ifndef::upstream[]
 *Note:* The *Start basic workbench* tile is enabled by default. To disable it, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#hiding-the-default-basic-workbench-application_dashboard[Hiding the default basic workbench application].
@@ -17,16 +17,21 @@ endif::[]
 
 .Prerequisite
 
-* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have {productname-short} administrator privileges.
 
 .Procedure
 
-. Log in to the {openshift-platform} console as a cluster administrator.
+. Log in to the {openshift-platform} console as an {productname-short} administrator.
 . Open the dashboard configuration file:
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-.. Select the `redhat-ods-applications` project from the *Project* list.
+ifndef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+endif::[]
+ifdef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -27,10 +27,10 @@ endif::[]
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
 ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
 endif::[]
 ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
 endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -26,12 +26,7 @@ endif::[]
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
-endif::[]
-ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
-endif::[]
+.. From the *Project* list, select the {productname-short} application namespace; the default is `{dbd-config-default-namespace}`.
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 
 .Dashboard feature configuration options
-[cols="28%,5%,67%", options="header"]
+[cols="28%,7%,65%", options="header"]
 |===
 | Feature configuration option | Default | Description
 | `spec.dashboardConfig.` +
@@ -66,7 +66,7 @@ Hardware profiles is a Technology Preview feature in this {productname-short} re
 | `spec.dashboardConfig.` +
 `disableInfo` | `false` | On the *Applications → Explore* page, when a user clicks on an application tile, an information panel opens with more details about the application. To disable the information panel for all applications on the *Applications → Explore* page , set the value to `true`.
 | `spec.dashboardConfig.` +
-`disableISVBadges` | `false` | Shows the label on a tile that indicates whether the application is *{org-name} managed*, *Partner managed*, or *Self-managed*. To hide these labels, set the value to `true`. 
+`disableISVBadges` | `false` | Shows the label on a tile that indicates whether the application is `{org-name} managed`, `Partner managed`, or `Self-managed`. To hide these labels, set the value to `true`. 
 | `spec.dashboardConfig.` +
 `disableKServe` | `false` | Enables the ability to select KServe as a model-serving platform. To disable this ability, set the value to `true`.
 | `spec.dashboardConfig.` +

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -5,7 +5,7 @@
 
 [role='_abstract']
 The {productname-short} dashboard includes a set of core features enabled by default that are designed to work for most scenarios. 
-Administrators can configure the {productname-short} dashboard from the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
+{productname-short} administrators can configure the {productname-short} dashboard from the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 
 
 If a dashboard configuration option is not included in the `OdhDashboardConfig` CR, the default value is used.
@@ -27,9 +27,9 @@ endif::[]
 
 
 .Dashboard feature configuration options
-[cols="32%,10%,58%","header"]
+[cols="28%,5%,67%", options="header"]
 |===
-| Feature configuration option | Default value | Description
+| Feature configuration option | Default | Description
 | `spec.dashboardConfig.` +
 `disableAcceleratorProfiles` | `false`| Shows the *Settings → Accelerator profiles* menu item in the dashboard navigation menu. To hide this menu item, set the value to `true`.
 
@@ -66,7 +66,7 @@ Hardware profiles is a Technology Preview feature in this {productname-short} re
 | `spec.dashboardConfig.` +
 `disableInfo` | `false` | On the *Applications → Explore* page, when a user clicks on an application tile, an information panel opens with more details about the application. To disable the information panel for all applications on the *Applications → Explore* page , set the value to `true`.
 | `spec.dashboardConfig.` +
-`disableISVBadges` | `false` | Shows the label on a tile that indicates whether the application is “{org-name} managed”, “Partner managed”, or “Self-managed”. To hide these labels, set the value to `true`. 
+`disableISVBadges` | `false` | Shows the label on a tile that indicates whether the application is *{org-name} managed*, *Partner managed*, or *Self-managed*. To hide these labels, set the value to `true`. 
 | `spec.dashboardConfig.` +
 `disableKServe` | `false` | Enables the ability to select KServe as a model-serving platform. To disable this ability, set the value to `true`.
 | `spec.dashboardConfig.` +
@@ -140,7 +140,8 @@ endif::[]
 `enablement` | `true` | Enables {productname-short} administrators to add applications to the {productname-short} dashboard *Applications* → *Enabled* page. To disable this ability, set the value to `false`.
 | `spec.groupsConfig` | No longer used | Read-only. To configure access to the {productname-short} dashboard, use the `spec.adminGroups` and `spec.allowedGroups` options in the {openshift-platform} `Auth` resource in the `services.platform.opendatahub.io` API group.
 | `spec.modelServerSizes` | `Small`, `Medium`, `Large` | Allows you to customize names and resources for model servers.
-| `spec.notebookController.enabled` | `true` | Controls the Notebook Controller behavior, such as whether it is enabled in the dashboard and which parts are visible.
+| `spec.notebookController.` +
+`enabled` | `true` | Shows the *Start basic workbench* tile in the *Applications* section, and the *Start basic workbench* button on the *Data science projects* page. To hide these items, set the value to `false`.
 | `spec.notebookSizes` | `Small`, `Medium`, `Large`, `X Large` | Allows you to customize names and resources for workbenches. 
 The Kubernetes-style sizes are shown in the drop-down menu that appears when launching a workbench with the Notebook Controller. 
 

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -14,6 +14,12 @@ To change the default behavior for such options, edit the `OdhDashboardConfig` C
 * To show the feature, set the value to `false`
 * To hide the feature, set the value to `true`
 
+ifdef::upstream[]
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#editing-the-dashboard-configuration_dashboard[Editing the dashboard configuration].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#editing-the-dashboard-configuration_dashboard[Editing the dashboard configuration].
+endif::[]
 
 ifndef::upstream[]
 [IMPORTANT]

--- a/modules/showing-hiding-information-about-available-applications.adoc
+++ b/modules/showing-hiding-information-about-available-applications.adoc
@@ -6,22 +6,27 @@
 [role='_abstract']
 You can view a list of available applications in the *Exploring applications* page of the {productname-short} dashboard. By default, the following information is provided for each application:
 
-* Any independent software vendor (ISV) application is indicated with a label on the tile indicating “{org-name} managed”, “Partner managed”, or “Self-managed”. As a cluster administrator, you can hide or show the labels. For example, if you are running a self-managed environment, you might want to show all available applications regardless of the support level. 
+* Any independent software vendor (ISV) application is indicated with a label on the tile indicating `{org-name} managed`, `Partner managed`, or `Self-managed`. As an {productname-short} administrator, you can hide or show the labels. For example, if you are running a self-managed environment, you might want to show all available applications regardless of the support level. 
 
 * When a user clicks on an application, an information panel appears and provides more information about the application, including links to quick starts or detailed documentation. You can disable or enable the appearance of application information panels.
 
 .Prerequisites
 
-* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have {productname-short} administrator privileges.
 
 .Procedure
 
-. Log in to the {openshift-platform} console as a cluster administrator.
+. Log in to the {openshift-platform} console as an {productname-short} administrator.
 . Open the dashboard configuration file:
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-.. Select the `redhat-ods-applications` project from the *Project* list.
+ifndef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+endif::[]
+ifdef::upstream[]
+.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/showing-hiding-information-about-available-applications.adoc
+++ b/modules/showing-hiding-information-about-available-applications.adoc
@@ -22,10 +22,10 @@ You can view a list of available applications in the *Exploring applications* pa
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
 ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `redhat-ods-applications`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
 endif::[]
 ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace (default: `odh`).
+.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
 endif::[]
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.

--- a/modules/showing-hiding-information-about-available-applications.adoc
+++ b/modules/showing-hiding-information-about-available-applications.adoc
@@ -21,12 +21,7 @@ You can view a list of available applications in the *Exploring applications* pa
 .. In the *Administrator* perspective, click *Home* -> *API Explorer*.
 .. In the search bar, enter `OdhDashboardConfig` to filter by kind.
 .. Click the `OdhDashboardConfig` custom resource (CR) to open the resource details page.
-ifndef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `redhat-ods-applications`.
-endif::[]
-ifdef::upstream[]
-.. From the *Project* list, select the {productname-short} application namespace; the default is `opendatahub`.
-endif::[]
+.. From the *Project* list, select the {productname-short} application namespace; the default is `{dbd-config-default-namespace}`.
 .. Click the *Instances* tab.
 .. Click the `odh-dashboard-config` instance to open the details page.
 .. Click the *YAML* tab. 

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -40,7 +40,7 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -40,10 +40,10 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 ====
 

--- a/modules/updating-a-model-server.adoc
+++ b/modules/updating-a-model-server.adoc
@@ -39,11 +39,11 @@ If project-scoped hardware profiles exist, the *Hardware profile* list includes 
 [IMPORTANT]
 ====
 By default, hardware profiles are hidden from appearing in the dashboard navigation menu and user interface. In addition, user interface components associated with the deprecated accelerator profiles functionality are still displayed. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu and the user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}. 
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 ====
 

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -18,10 +18,10 @@ disablePerformanceMetrics:false
 disableKServeMetrics:false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[] 
 * You have logged in to {productname-long}.
 ifndef::upstream[]

--- a/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
+++ b/modules/viewing-http-request-metrics-for-a-deployed-model.adoc
@@ -18,10 +18,10 @@ disablePerformanceMetrics:false
 disableKServeMetrics:false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[] 
 * You have logged in to {productname-long}.
 ifndef::upstream[]

--- a/modules/viewing-nvidia-nim-metrics-for-a-nim-model.adoc
+++ b/modules/viewing-nvidia-nim-metrics-for-a-nim-model.adoc
@@ -33,10 +33,10 @@ endif::[]
 disableKServeMetrics: false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 
 .Procedure

--- a/modules/viewing-nvidia-nim-metrics-for-a-nim-model.adoc
+++ b/modules/viewing-nvidia-nim-metrics-for-a-nim-model.adoc
@@ -33,10 +33,10 @@ endif::[]
 disableKServeMetrics: false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 
 .Procedure

--- a/modules/viewing-performance-metrics-for-a-nim-model.adoc
+++ b/modules/viewing-performance-metrics-for-a-nim-model.adoc
@@ -31,10 +31,10 @@ endif::[]
 disableKServeMetrics: false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 
 .Procedure

--- a/modules/viewing-performance-metrics-for-a-nim-model.adoc
+++ b/modules/viewing-performance-metrics-for-a-nim-model.adoc
@@ -31,10 +31,10 @@ endif::[]
 disableKServeMetrics: false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 
 .Procedure

--- a/modules/viewing-performance-metrics-for-deployed-model.adoc
+++ b/modules/viewing-performance-metrics-for-deployed-model.adoc
@@ -36,10 +36,10 @@ disablePerformanceMetrics:false
 disableKServeMetrics:false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 * You have deployed a model on the single-model serving platform by using a preinstalled runtime.
 +

--- a/modules/viewing-performance-metrics-for-deployed-model.adoc
+++ b/modules/viewing-performance-metrics-for-deployed-model.adoc
@@ -36,10 +36,10 @@ disablePerformanceMetrics:false
 disableKServeMetrics:false
 ----
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 * You have deployed a model on the single-model serving platform by using a preinstalled runtime.
 +

--- a/modules/working-with-hardware-profiles.adoc
+++ b/modules/working-with-hardware-profiles.adoc
@@ -19,10 +19,10 @@ In {productname-long}, you can schedule user workloads on worker nodes that have
 ====
 By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}.
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_openshift_ai/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-odh/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ====
 

--- a/modules/working-with-hardware-profiles.adoc
+++ b/modules/working-with-hardware-profiles.adoc
@@ -19,7 +19,7 @@ In {productname-long}, you can schedule user workloads on worker nodes that have
 ====
 By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}.
 ifndef::upstream[]
-For more information, see link:{rhoaidocshome}/html/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
 endif::[]
 ifdef::upstream[]
 For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].

--- a/modules/working-with-hardware-profiles.adoc
+++ b/modules/working-with-hardware-profiles.adoc
@@ -18,11 +18,11 @@ In {productname-long}, you can schedule user workloads on worker nodes that have
 [IMPORTANT]
 ====
 By default, this feature is hidden from appearing in the dashboard navigation menu. To show the *Settings -> Hardware profiles* option in the dashboard navigation menu, and other user interface components associated with hardware profiles, set the `disableHardwareProfiles` value to `false` in the `OdhDashboardConfig` custom resource (CR) in {openshift-platform}.
-ifndef::upstream[]
-For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
-endif::[]
 ifdef::upstream[]
-For more information, see link:{odhdocshome}/managing-resources/#ref-dashboard-configuration-options_dashboard[Dashboard configuration options].
+For more information about setting dashboard configuration options, see link:{odhdocshome}/managing-resources/#customizing-the-dashboard[Customizing the dashboard].
+endif::[]
+ifndef::upstream[]
+For more information about setting dashboard configuration options, see link:{rhoaidocshome}{default-format-url}/managing_resources/customizing-the-dashboard[Customizing the dashboard].
 endif::[]
 ====
 


### PR DESCRIPTION
Make the following changes: 

- [x] Update the spec.notebookController.enabled entry to clarify what it does in the UI
- [x] Update the prereqs to clarify that you need OpenShift AI admin access, not cluster admin access
- [x] Note that the default namespace might have a different name
- [x] Move the section to the Managing resources doc
- [x] Update all affected cross references. For example, search for "dashboard configuration". 
- [x] Check the use of quotation marks in the spec.dashboardConfig.disableISVBadges entry
- [x] Make the "Default value" column smaller (or put it in the last position) so users don't need to continuously scroll horizontally to read between the "Feature configuration option" and the "Description"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated and standardized URLs for dashboard configuration options and related references throughout the documentation to use new paths.
  * Clarified administrator roles by specifying "{productname-short} administrator" in relevant sections.
  * Improved table formatting and text clarity in configuration option references.
  * Adjusted documentation structure by moving the "customizing the dashboard" content to a different section.
  * Enhanced examples and prerequisites with context-sensitive namespace defaults and detailed YAML snippets for dashboard application management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->