### PR TITLE
Editing *Connected workbench* and *Mount folder name* to match the new UI

### DIFF
--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -38,8 +38,10 @@ Only the access modes that have been enabled for the storage class by your clust
 +
 . In the *Persistent storage size* section, specify a new size in gibibytes or mebibytes.
 . Optional: If you want to connect the cluster storage to an existing workbench:
-.. From the *Connected workbench* list, select a workbench.
-.. In the *Mount folder name* field, enter the name of storage directory.
+.. In the *Workbench connections* section, click *Add workbench*.
+.. In the *Name* field, select an existing workbench from the list.
+.. In the *Path format* field, select *Standard* if your storage directory begins with `/opt/app-root/src`, otherwise select *Custom*.
+.. In the *Mount path* field, enter the path to a model or directory within a container where a volume is mounted and accessible. The path must consist of lowercase alphanumeric characters or `-`. Use `/` to indicate subdirectories.
 . Click *Add storage*.
 
 .Verification

--- a/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
+++ b/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
@@ -38,8 +38,10 @@ The *Add cluster storage* dialog opens.
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 +
 .. Under *Persistent storage size*, enter a size in gibibytes or mebibytes. 
-.. Under *Connected workbench*, select the workbench with the storage class that you want to change.
-.. Under *Mount folder name*, enter a new storage directory for the cluster storage to mount to. For example, `backup`.
+.. In the *Workbench connections* section, click *Add workbench*.
+.. In the *Name* field, select an existing workbench from the list.
+.. In the *Path format* field, select *Standard* if your storage directory begins with `/opt/app-root/src`, otherwise select *Custom*.
+.. In the *Mount path* field, enter the path to a model or directory within a container where a volume is mounted and accessible. For example, `backup`.
 .. Click *Add storage*.
 
 . Copy the data from the existing cluster storage instance to the new cluster storage instance.

--- a/modules/updating-cluster-storage.adoc
+++ b/modules/updating-cluster-storage.adoc
@@ -41,9 +41,11 @@ The *Update cluster storage* page opens.
 +
 Note that you can only increase the storage size. Updating the storage size restarts the workbench and makes it unavailable for a period of time that is usually proportional to the size change.
 . Optional: If you want to connect the cluster storage to a different workbench:
-.. From the *Connected workbench* list, select the workbench.
-.. In the *Mount folder name* field, enter the name of storage directory.
-. Click *Update*.
+.. In the *Workbench connections* section, click *Add workbench*.
+.. In the *Name* field, select an existing workbench from the list.
+.. In the *Path format* field, select *Standard* if your storage directory begins with `/opt/app-root/src`, otherwise select *Custom*.
+.. In the *Mount path* field, enter the path to a model or directory within a container where a volume is mounted and accessible. The path must consist of lowercase alphanumeric characters or `-`. Use `/` to indicate subdirectories.
+. Click *Update storage*.
 
 If you increased the storage size, the workbench restarts and is unavailable for a period of time that is usually proportional to the size change.
 


### PR DESCRIPTION
## Description
This is a small change that emerged from adding new information about access modes in storage class docs. The change entails small edits for terms including "connected workbenches" and "mount folder" to new terms that match the current UI. A couple of new steps are also added to match fields in the way the current dialog box appears.  

Corresponding JIRA: https://issues.redhat.com/browse/RHOAIENG-28836

@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for connecting cluster storage to a workbench, introducing a clearer, step-by-step "Workbench connections" workflow.
  * Added options for selecting path formats and specifying mount paths with detailed character requirements.
  * Improved clarity and expanded configuration details in storage connection procedures across relevant documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->