### PR TITLE
New scenario for LM-Eval - LLM-as-a-Judge (custom metrics)

### DIFF
--- a/assemblies/lmeval-scenarios.adoc
+++ b/assemblies/lmeval-scenarios.adoc
@@ -18,4 +18,6 @@ include::modules/using-a-kserve-inference-service.adoc[leveloffset=+1]
 
 include::modules/setting-up-lmeval-s3-support.adoc[leveloffset=+1]
 
+include::modules/using-llm-as-a-judge-metrics-with-lmeval[leveloffset=+1]
+
 

--- a/assemblies/lmeval-scenarios.adoc
+++ b/assemblies/lmeval-scenarios.adoc
@@ -18,6 +18,6 @@ include::modules/using-a-kserve-inference-service.adoc[leveloffset=+1]
 
 include::modules/setting-up-lmeval-s3-support.adoc[leveloffset=+1]
 
-include::modules/using-llm-as-a-judge-metrics-with-lmeval[leveloffset=+1]
+include::modules/using-llm-as-a-judge-metrics-with-lmeval.adoc[leveloffset=+1]
 
 

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -45,9 +45,7 @@ In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to 
 
 | Custom LLM-as-judge metric
 | Uses Mistral-7B with your custom instructions
-
 |===
-
 
 .Procedure
 . Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, though the command line interface (CLI).
@@ -68,8 +66,8 @@ endif::[]
    opendatahub.io/managed:'false'
    }
  }'
-
 ----
+
 . Apply the following manifest through the CLI. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
 The YAML contains the following instructions:
 .. What model to evaluate.
@@ -225,8 +223,6 @@ taskList:
        limits:
          cpu: '2'
          memory: 16Gi
-
-
 ----
 
 .Verification

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -6,18 +6,18 @@ ifdef::context[:parent-context: {context}]
 
 [role='_abstract']
 
-You can use a large language model (LLM) as a human-like evaluator to assess the quality of outputs from another LLM.  This is known as LLM-as-a-Judge (LLMaaJ).
+You can use a large language model (LLM) to assess the quality of outputs from another LLM, known as LLM-as-a-Judge (LLMaaJ).
 
-It is especially useful when:
+You can use LLMaaJ to:
 
-* There is no clearly correct answer (for example, when assessing creative writing).
-* You want to judge quality (helpfulness, safety, depth), not just accuracy.
-* Traditional quantitative measures used to evaluate a model's performance (for example, `ROUGE` metrics) are not nuanced enough.
-* You want to test specific quality aspects of your model output.
+* Assess work with no clearly correct answer, such as creative writing.
+* Judge quality characteristics such as helpfulness, safety, and depth.
+* Augment traditional quantitative measures that are used to evaluate a model's performance (for example, `ROUGE` metrics).
+* Test specific quality aspects of your model output.
 
 Follow the custom quality assessment example below to learn more about using your own metrics criteria with LM-Eval to evaluate model responses.
 
-In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to see how our model (link:www.huggingface.co/google/flan-t5-small[flan-t5-small]) answers questions from MT-Bench, a standard benchmark. We use custom evaluation criteria and instructions from the link:www.huggingface.co/mistralai/Mistral-7B-Instruct-v0.2[Mistral-7B] model to rate the answers from 1-10, based on helpfulness, accuracy, and detail.
+This example uses link:www.unitxt.ai[Unitxt] to define custom metrics and to see how the model (link:www.huggingface.co/google/flan-t5-small[flan-t5-small]) answers questions from MT-Bench, a standard benchmark. Custom evaluation criteria and instructions from the link:www.huggingface.co/mistralai/Mistral-7B-Instruct-v0.2[Mistral-7B] model are used to rate the answers from 1-10, based on helpfulness, accuracy, and detail.
 
 
 .Prerequisites
@@ -35,7 +35,8 @@ In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to 
 | Parameter | Description
 
 | Custom template
-| Tells the judge how to rate (1-10 scale, what to look for).
+| Tells the judge to assign a score between 1 and 10 in a standardized format, based on specific criteria.
+
 
 | `processors.extract_mt_bench_rating_judgment`
 | Pulls the numerical rating from judge's response.
@@ -50,10 +51,10 @@ In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to 
 .Procedure
 . Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, through the command line interface (CLI).
 ifdef::upstream[]
-The operator `-n test` becomes `-n opendatahub`.
+The operator `test` becomes {dbd-config-default-namespace}.
 endif::[]
 ifndef::upstream[]
-The operator `-n test` becomes `-n redhat-ods-applications`.
+The operator `test` becomes {dbd-config-default-namespace}.
 endif::[]
 +
 [source, bash]
@@ -78,7 +79,7 @@ The YAML contains the following instructions:
 
 [NOTE]
 --
-You can put the YAML manifest into a file using a text editor and then apply it by using the command `oc apply -f file.yaml` either.
+You can also put the YAML manifest into a file using a text editor and then apply it by using the command `oc apply -f file.yaml`.
 --
 
 [source,YAML]

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -41,14 +41,14 @@ In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to 
 | Pulls the numerical rating from judge's response.
 
 | `formats.models.mistral.instruction`
-| Formats the prompts for the Mistral model,
+| Formats the prompts for the Mistral model.
 
 | Custom LLM-as-judge metric
 | Uses Mistral-7B with your custom instructions
 |===
 
 .Procedure
-. Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, though the command line interface (CLI).
+. Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, through the command line interface (CLI).
 ifdef::upstream[]
 The operator `-n test` becomes `-n opendatahub`.
 endif::[]
@@ -62,8 +62,8 @@ endif::[]
  -n test --type=merge -p '{
    "data": {
      "lmes-allow-online": "true",
-     "lmes-code-execution": "true"
-   opendatahub.io/managed:'false'
+     "lmes-code-execution": "true",
+   opendatahub.io/managed:"false"
    }
  }'
 ----
@@ -81,7 +81,7 @@ The YAML contains the following instructions:
 You can put the YAML manifest into a file using a text editor and then apply it by using the command `oc apply -f file.yaml` either.
 --
 
-[source,bash]
+[source,YAML]
 ----
 apiVersion: trustyai.opendatahub.io/v1alpha1
 kind: LMEvalJob
@@ -166,7 +166,7 @@ taskList:
        metrics:
        - ref: llmaaj_metric
    custom:
-     templates:``
+     templates:
        - name: response_assessment.rating.mt_bench_single_turn
          value: |
            {

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -1,0 +1,234 @@
+:_module-type: PROCEDURE
+
+ifdef::context[:parent-context: {context}]
+[id="using-llm-as-a-judge-metrics-with-lmeval_{context}"]
+= Using LLM-as-a-Judge metrics with LM-Eval
+
+[role='_abstract']
+
+You can use a large language model (LLM) as a human-like evaluator to assess the quality of outputs from another LLM.  This is known as LLM-as-a-Judge (LLMaaJ).
+
+It is especially useful when:
+
+* There is no clearly correct answer (for example, when assessing creative writing).
+* You want to judge quality (helpfulness, safety, depth), not just accuracy.
+* Traditional quantitative measures used to evaluate a model's performance (for example, `ROUGE` metrics) are not nuanced enough.
+* You want to test specific quality aspects of your model output.
+
+Follow the custom quality assessment example below to learn more about using your own metrics criteria with LM-Eval to evaluate model responses.
+
+In this example, we use link:www.unitxt.ai[Unitxt] to define custom metrics, to see how our model (link:www.huggingface.co/google/flan-t5-small[flan-t5-small]) answers questions from MT-Bench, a standard benchmark. We use custom evaluation criteria and instructions from the link:www.huggingface.co/mistralai/Mistral-7B-Instruct-v0.2[Mistral-7B] model to rate the answers from 1-10, based on helpfulness, accuracy, and detail.
+
+
+.Prerequisites
+* You have logged in to {productname-long}.
+
+* Your cluster administrator has installed {productname-short} and enabled the TrustyAI service for the data science project where the models are deployed.
+
+* You are familiar with how to use Unitxt.
+
+* You have set the following parameters:
++
+.Parameters
+[cols="2,4"]
+|===
+| Parameter | Description
+
+| Custom template
+| Tells the judge how to rate (1-10 scale, what to look for).
+
+| `processors.extract_mt_bench_rating_judgment`
+| Pulls the numerical rating from judge's response.
+
+| `formats.models.mistral.instruction`
+| Formats the prompts for the Mistral model,
+
+| Custom LLM-as-judge metric
+| Uses Mistral-7B with your custom instructions
+
+|===
+
+
+.Procedure
+. Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, though the command line interface (CLI).
+ifdef::upstream[]
+The operator `-n test` becomes `-n opendatahub`.
+endif::[]
+ifndef::upstream[]
+The operator `-n test` becomes `-n redhat-ods-applications`.
+endif::[]
++
+[source, bash]
+----
+ oc patch configmap trustyai-service-operator-config
+ -n test --type=merge -p '{
+   "data": {
+     "lmes-allow-online": "true",
+     "lmes-code-execution": "true"
+   opendatahub.io/managed:'false'
+   }
+ }'
+
+----
+. Apply the following manifest through the CLI. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
+The YAML contains the following instructions:
+.. What model to evaluate.
+.. What data to use.
+.. How to format inputs and outputs.
+.. Which judge model to use.
+.. How to extract and log results.
+
+[NOTE]
+--
+You can put the YAML manifest into a file using a text editor and then apply it by using the command `oc apply -f file.yaml` either.
+--
+
+[source,bash]
+----
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: LMEvalJob
+metadata:
+ name: custom-eval
+ namespace: test
+spec:
+ allowOnline: true
+ allowCodeExecution: true
+ model: hf
+ modelArgs:
+   - name: pretrained
+     value: google/flan-t5-small 
+taskList:
+ taskRecipes:
+     - card:
+         custom: |
+           {
+               "__type__": "task_card",
+               "loader": {
+                   "__type__": "load_hf",
+                   "path": "OfirArviv/mt_bench_single_score_gpt4_judgement",
+                   "split": "train"
+               },
+               "preprocess_steps": [
+                   {
+                       "__type__": "rename_splits",
+                       "mapper": {
+                           "train": "test"
+                       }
+                   },
+                   {
+                       "__type__": "filter_by_condition",
+                       "values": {
+                           "turn": 1
+                       },
+                       "condition": "eq"
+                   },
+                   {
+                       "__type__": "filter_by_condition",
+                       "values": {
+                           "reference": "[]"
+                       },
+                       "condition": "eq"
+                   },
+                   {
+                       "__type__": "rename",
+                       "field_to_field": {
+                           "model_input": "question",
+                           "score": "rating",
+                           "category": "group",
+                           "model_output": "answer"
+                       }
+                   },
+                   {
+                       "__type__": "literal_eval",
+                       "field": "question"
+                   },
+                   {
+                       "__type__": "copy",
+                       "field": "question/0",
+                       "to_field": "question"
+                   },
+                   {
+                       "__type__": "literal_eval",
+                       "field": "answer"
+                   },
+                   {
+                       "__type__": "copy",
+                       "field": "answer/0",
+                       "to_field": "answer"
+                   }
+               ],
+               "task": "tasks.response_assessment.rating.single_turn",
+               "templates": [
+                   "templates.response_assessment.rating.mt_bench_single_turn"
+               ]
+           }
+       template:
+         ref: response_assessment.rating.mt_bench_single_turn
+       format: formats.models.mistral.instruction
+       metrics:
+       - ref: llmaaj_metric
+   custom:
+     templates:``
+       - name: response_assessment.rating.mt_bench_single_turn
+         value: |
+           {
+               "__type__": "input_output_template",
+               "instruction": "Please act as an impartial judge and evaluate the quality of the response provided by an AI assistant to the user question displayed below. Your evaluation should consider factors such as the helpfulness, relevance, accuracy, depth, creativity, and level of detail of the response. Begin your evaluation by providing a short explanation. Be as objective as possible. After providing your explanation, you must rate the response on a scale of 1 to 10 by strictly following this format: \"[[rating]]\", for example: \"Rating: [[5]]\".\n\n",
+               "input_format": "[Question]\n{question}\n\n[The Start of Assistant's Answer]\n{answer}\n[The End of Assistant's Answer]",
+               "output_format": "[[{rating}]]",
+               "postprocessors": [
+                   "processors.extract_mt_bench_rating_judgment"
+               ]
+           }
+     tasks:
+       - name: response_assessment.rating.single_turn
+         value: |
+           {
+               "__type__": "task",
+               "input_fields": {
+                   "question": "str",
+                   "answer": "str"
+               },
+               "outputs": {
+                   "rating": "float"
+               },
+               "metrics": [
+                   "metrics.spearman"
+               ]
+           }
+     metrics:
+       - name: llmaaj_metric
+         value: |
+           {
+               "__type__": "llm_as_judge",
+               "inference_model": {
+                   "__type__": "hf_pipeline_based_inference_engine",
+                   "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+                   "max_new_tokens": 256,
+                   "use_fp16": true
+               },
+               "template": "templates.response_assessment.rating.mt_bench_single_turn",
+               "task": "rating.single_turn",
+               "format": "formats.models.mistral.instruction",
+               "main_score": "mistral_7b_instruct_v0_2_huggingface_template_mt_bench_single_turn"
+           }
+ logSamples: true
+ pod:
+   container:
+     env:
+       - name: HF_TOKEN
+         valueFrom:
+           secretKeyRef:
+             name: hf-token-secret
+             key: token
+     resources:
+       limits:
+         cpu: '2'
+         memory: 16Gi
+
+
+----
+
+.Verification
+
+A processor extracts the numeric rating from the judge's natural language response. The final result is available as part of the LMEval Job Custom Resource (CR).

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -23,6 +23,8 @@ This example uses link:www.unitxt.ai[Unitxt] to define custom metrics and to see
 .Prerequisites
 * You have logged in to {productname-long}.
 
+* * You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI^].
+
 * Your cluster administrator has installed {productname-short} and enabled the TrustyAI service for the data science project where the models are deployed.
 
 * You are familiar with how to use Unitxt.
@@ -39,22 +41,28 @@ This example uses link:www.unitxt.ai[Unitxt] to define custom metrics and to see
 
 
 | `processors.extract_mt_bench_rating_judgment`
-| Pulls the numerical rating from judge's response.
+| Pulls the numerical rating from the judge's response.
 
 | `formats.models.mistral.instruction`
 | Formats the prompts for the Mistral model.
 
 | Custom LLM-as-judge metric
-| Uses Mistral-7B with your custom instructions
+| Uses Mistral-7B with your custom instructions.
 |===
 
 .Procedure
-. Update the TrustyAI configuration to allow online model access and code execution, by applying the following instructions to the test namespace, through the command line interface (CLI).
+. In a terminal window, if you are not already logged in to your OpenShift cluster as a cluster administrator, log in to the OpenShift CLI as shown in the following example:
++
+[source,subs="+quotes"]
+----
+$ oc login __<openshift_cluster_url>__ -u __<admin_username>__ -p __<password>__
+----
+. Update the TrustyAI configuration to allow online model access and code execution by applying the following instructions to the test namespace.
 ifdef::upstream[]
-The operator `test` becomes {dbd-config-default-namespace}.
+The operator `test` becomes `{dbd-config-default-namespace}`.
 endif::[]
 ifndef::upstream[]
-The operator `test` becomes {dbd-config-default-namespace}.
+The operator `test` becomes `{dbd-config-default-namespace}`.
 endif::[]
 +
 [source, bash]
@@ -69,9 +77,9 @@ endif::[]
  }'
 ----
 
-. Apply the following manifest through the CLI. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
+. Apply the following manifest using the `oc apply -f -` command. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
 The YAML contains the following instructions:
-.. What model to evaluate.
+.. Which model to evaluate.
 .. What data to use.
 .. How to format inputs and outputs.
 .. Which judge model to use.
@@ -79,7 +87,7 @@ The YAML contains the following instructions:
 
 [NOTE]
 --
-You can also put the YAML manifest into a file using a text editor and then apply it by using the command `oc apply -f file.yaml`.
+You can also put the YAML manifest into a file using a text editor and then apply it by using the `oc apply -f file.yaml` command.
 --
 
 [source,YAML]

--- a/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
+++ b/modules/using-llm-as-a-judge-metrics-with-lmeval.adoc
@@ -23,7 +23,7 @@ This example uses link:www.unitxt.ai[Unitxt] to define custom metrics and to see
 .Prerequisites
 * You have logged in to {productname-long}.
 
-* * You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI^].
+* You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI^].
 
 * Your cluster administrator has installed {productname-short} and enabled the TrustyAI service for the data science project where the models are deployed.
 
@@ -77,7 +77,7 @@ endif::[]
  }'
 ----
 
-. Apply the following manifest using the `oc apply -f -` command. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
+. Apply the following manifest by using the `oc apply -f -` command. The YAML content defines a custom evaluation job (`LMEvalJob`), the namespace, and the location of the model you want to evaluate.
 The YAML contains the following instructions:
 .. Which model to evaluate.
 .. What data to use.


### PR DESCRIPTION
New scenario for LM-Eval - LLM-as-a-Judge (custom metrics)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new procedure explaining how to use large language models as evaluators (LLM-as-a-Judge) with LM-Eval, including setup instructions, prerequisites, and a sample evaluation job configuration.
  * Extended scenario documentation to include the new LLM-as-a-Judge metrics procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->