### PR TITLE
RHOAI-28003 Operator pods

### DIFF
--- a/modules/configuring-the-operator-logger.adoc
+++ b/modules/configuring-the-operator-logger.adoc
@@ -14,8 +14,8 @@ The following table shows the available log levels:
 | Log level | Stacktrace level | Verbosity | Output | Timestamp type 
 
 | `devel` or `development` | WARN | INFO | Console | Epoch timestamps 
-| `""`  (or no `logmode` value set)| ERROR | INFO | JSON | Human-readable timestamps 
-| `prod` or `production` | ERROR | INFO | JSON |Human-readable timestamps 
+| `""`  (or no `logmode` value set) | ERROR | INFO | JSON | Human-readable timestamps 
+| `prod` or `production` | ERROR | INFO | JSON | Human-readable timestamps 
 |===
 
 Logs that are set to `devel` or `development` generate in a plain text console format.
@@ -57,30 +57,38 @@ oc patch dsci default-dsci -p '{"spec":{"devFlags":{"logmode":"development"}}}' 
 * If you set the component log level to `devel` or `development`, logs generate more frequently and include logs at `WARN` level and above.
 * If you set the component log level to `prod` or `production`, or do not set a log level, logs generate less frequently and include logs at `ERROR` level or above.
 
-== Viewing the {productname-short} Operator log
+== Viewing the {productname-short} Operator logs
 
 ifdef::upstream[]
 . Log in to the OpenShift CLI.
-. Run the following command:
+. Run the following command to stream logs from all Operator pods:
 +
 [source]
 ----
-oc get pods -l name=opendatahub-operator -o name -n openshift-operators |  xargs -I {} oc logs -f {} -n openshift-operators
+for pod in $(oc get pods -l name=opendatahub-operator -n openshift-operators -o name); do
+  oc logs -f "$pod" -n openshift-operators &
+done
 ----
 +
-The operator pod log opens.
+The Operator pod logs open in your terminal.
++
+TIP: Press `Ctrl+C` to stop viewing. To fully stop all log streams, run `kill $(jobs -p)`.
 endif::[]
 
 ifndef::upstream[]
 . Log in to the OpenShift CLI.
-. Run the following command:
+. Run the following command to stream logs from all Operator pods:
 +
 [source]
 ----
-oc get pods -l name=rhods-operator -o name -n redhat-ods-operator |  xargs -I {} oc logs -f {} -n redhat-ods-operator
+for pod in $(oc get pods -l name=rhods-operator -n redhat-ods-operator -o name); do
+  oc logs -f "$pod" -n redhat-ods-operator &
+done
 ----
 +
-The operator pod log opens.
+The Operator pod logs open in your terminal.
++
+TIP: Press `Ctrl+C` to stop viewing. To fully stop all log streams, run `kill $(jobs -p)`.
 
-You can also view the operator pod log in the OpenShift Console, under *Workloads* -> *Deployments* -> *Pods* -> *`redhat-ods-operator`* -> *Logs*.
+You can also view each Operator pod log in the OpenShift Console by navigating to *Workloads* -> *Pods*, selecting the *redhat-ods-operator* project, clicking a pod name, and then clicking the *Logs* tab.
 endif::[]

--- a/modules/configuring-the-operator-logger.adoc
+++ b/modules/configuring-the-operator-logger.adoc
@@ -90,5 +90,5 @@ The Operator pod logs open in your terminal.
 +
 TIP: Press `Ctrl+C` to stop viewing. To fully stop all log streams, run `kill $(jobs -p)`.
 
-You can also view each Operator pod log in the OpenShift Console by navigating to *Workloads* -> *Pods*, selecting the *redhat-ods-operator* project, clicking a pod name, and then clicking the *Logs* tab.
+You can also view each Operator pod log in the {openshift-platform} console by navigating to *Workloads* -> *Pods*, selecting the *redhat-ods-operator* project, clicking a pod name, and then clicking the *Logs* tab.
 endif::[]

--- a/modules/overview-of-upgrading-odh.adoc
+++ b/modules/overview-of-upgrading-odh.adoc
@@ -31,7 +31,7 @@ NOTE: Workbench images are constructed externally; they are prebuilt images that
 ifdef::upstream[]
 [IMPORTANT]
 ====
-After upgrading from {productname-short} 2.19 to 2.20, existing instances of the model registry component are not updated, which causes the instance pods to use older images than the ones referenced by the operator pod.
+After upgrading from {productname-short} 2.19, existing instances of the model registry component are not updated, which causes the instance pods to use older images than the ones referenced by the operator pods.
 
 To resolve this issue, create a new instance of each existing model registry, using the same database configuration, and delete the old model registry instance. The new model registry instance contains all existing registered models and their metadata.
 ====

--- a/modules/requirements-for-upgrading-odh-v1.adoc
+++ b/modules/requirements-for-upgrading-odh-v1.adoc
@@ -64,7 +64,7 @@ $ oc patch $(oc get dsc -A -oname) --type='json' -p='[{"op": "replace", "path": 
 $ oc patch crd inferenceservices.serving.kserve.io --type=json -p='[{"op": "remove", "path": "/spec/conversion"}]'
 ----
 
-. Optionally, restart the Operator pod.
+. Optionally, restart the Operator pods.
 + 
 
 * If you deployed a model by using KServe in {productname-short} version 1, when you upgrade to version {vernum} the model does not automatically appear in the {productname-short} dashboard. To update the dashboard view, redeploy the model by using the {productname-short} dashboard.

--- a/modules/requirements-for-upgrading-odh-v2.adoc
+++ b/modules/requirements-for-upgrading-odh-v2.adoc
@@ -53,7 +53,7 @@ If you upgrade to {productname-short} 2.10.0 or later with data science pipeline
 
 *Recreate model registries*
 
-When you upgrade from {productname-short} 2.19 or earlier to {productname-short} 2.20 or later versions, existing instances of the model registry component are not updated, which causes the instance pods to use older images than the ones referenced by the operator pod.
+When you upgrade from {productname-short} 2.19 or earlier, existing instances of the model registry component are not updated, which causes the instance pods to use older images than the ones referenced by the operator pods.
 
 To resolve this issue, after upgrading, create a new instance of each existing model registry, using the same database configuration, and delete the old model registry instance. The new model registry instance contains all existing registered models and their metadata.
 


### PR DESCRIPTION
Updating single Operator pod references for more than one Operator pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and clarity in log level tables and instructions for viewing operator logs.
  * Enhanced instructions for streaming logs from multiple operator pods, including clearer guidance on stopping log viewing.
  * Generalized upgrade instructions by removing specific version references and correcting pluralization of "pods" for accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->