### PR TITLE
ENG-26898: Fixes broken or incorrectly formatted doclinks - Round 2

### DIFF
--- a/modules/adding-workbench-pod-tolerations.adoc
+++ b/modules/adding-workbench-pod-tolerations.adoc
@@ -33,10 +33,10 @@ endif::[]
 In {openshift-platform}, add a matching taint key (with any value) to the machine pools that you want to dedicate to workbenches. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
 
 ifdef::self-managed[]
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/{rosa-latest-version}/html/cluster_administration/manage-nodes-using-machine-pools#rosa-adding-taints_rosa-managing-worker-nodes[Adding taints to a machine pool].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/{rosa-latest-version}/html/cluster_administration/managing-compute-nodes-using-machine-pools#rosa-adding-taints_rosa-managing-worker-nodes[Adding taints to a machine pool].
 endif::[]
 ifdef::cloud-service[]
-For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/{osd-latest-version}/html/cluster_administration/nodes#rosa-adding-taints_osd-managing-worker-nodes[Adding taints to a machine pool].
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/{osd-latest-version}/html/cluster_administration/managing-compute-nodes-using-machine-pools#rosa-adding-taints_osd-managing-worker-nodes[Adding taints to a machine pool].
 endif::[]
 
 .Verification

--- a/modules/creating-a-drift-metric.adoc
+++ b/modules/creating-a-drift-metric.adoc
@@ -13,7 +13,7 @@ ifdef::upstream[]
 For information about the specific data drift metrics, see link:{odhdocshome}/monitoring-data-science-models/#using-drift-metrics_drift-monitoring[Using drift metrics]. 
 endif::[]
 
-For the complete list of TrustyAI metrics, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html[TrustyAI service API].
+For the complete list of TrustyAI metrics, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html[TrustyAI service API].
 
 //You can create a data drift metric for a model by using the {productname-short} dashboard or by using the OpenShift command-line interface (CLI).
 

--- a/modules/requesting-a-lime-explanation-using-cli.adoc
+++ b/modules/requesting-a-lime-explanation-using-cli.adoc
@@ -88,7 +88,7 @@ curl -sk -H "Authorization: Bearer ${TOKEN}" -X POST \
 *Payload structure*:
 
 `PredictionId`:: The inference ID.
-`config`:: The configuration for the LIME explanation, including `model` and `explainer` parameters. For more information, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters] and link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#LimeExplainerConfig[LIME explainer configuration parameters].
+`config`:: The configuration for the LIME explanation, including `model` and `explainer` parameters. For more information, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters] and link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#LimeExplainerConfig[LIME explainer configuration parameters].
 
 For example:
 
@@ -137,11 +137,11 @@ curl -sk -H "Authorization: Bearer ${TOKEN}" -X POST \
     }" \
     ${TRUSTYAI_ROUTE}/explainers/local/lime
 ----
-<1> Specifies configuration for the model. For more information about the model configuration options, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters].
+<1> Specifies configuration for the model. For more information about the model configuration options, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters].
 <2> Specifies the model server service URL. This field only accepts model servers in the same namespace as the TrustyAI service, with or without protocol or port number.
 +
 * `http[s]://service[:port]`
 * `service[:port]`
-<3> Specifies the configuration for the explainer. For more information about the explainer configuration parameters, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#LimeExplainerConfig[LIME explainer configuration parameters].
+<3> Specifies the configuration for the explainer. For more information about the explainer configuration parameters, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#LimeExplainerConfig[LIME explainer configuration parameters].
 
 //.Verification

--- a/modules/requesting-a-shap-explanation-using-cli.adoc
+++ b/modules/requesting-a-shap-explanation-using-cli.adoc
@@ -88,7 +88,7 @@ curl -sk -H "Authorization: Bearer ${TOKEN}" -X POST \
 *Payload structure*:
 
 `PredictionId`:: The inference ID.
-`config`:: The configuration for the SHAP explanation, including `model` and `explainer` parameters. For more information, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters] and link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#SHAPExplainerConfig[SHAP explainer configuration parameters].
+`config`:: The configuration for the SHAP explanation, including `model` and `explainer` parameters. For more information, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters] and link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#SHAPExplainerConfig[SHAP explainer configuration parameters].
 
 For example:
 
@@ -134,11 +134,11 @@ curl -sk -H "Authorization: Bearer ${TOKEN}" -X POST \
     ${TRUSTYAI_ROUTE}/explainers/local/shap
 
 ----
-<1> Specifies configuration for the model. For more information about the model configuration options, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters].
+<1> Specifies configuration for the model. For more information about the model configuration options, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#ModelConfig[Model configuration parameters].
 <2> Specifies the model server service URL. This field only accepts model servers in the same namespace as the TrustyAI service, with or without protocol or port number.
 +
 * `http[s]://service[:port]`
 * `service[:port]`
-<3> Specifies the configuration for the explainer. For more information about the explainer configuration parameters, see link:https://trustyai-explainability.github.io/trustyai-site/main/trustyai-service-api-reference.html#SHAPExplainerConfig[SHAP explainer configuration parameters].
+<3> Specifies the configuration for the explainer. For more information about the explainer configuration parameters, see link:https://trustyai.org/docs/main/trustyai-service-api-reference.html#SHAPExplainerConfig[SHAP explainer configuration parameters].
 
 //.Verification

--- a/modules/viewing-audit-logs.adoc
+++ b/modules/viewing-audit-logs.adoc
@@ -8,7 +8,7 @@ Cluster administrators can use {openshift-platform} auditing to see changes made
 For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-view#audit-log-view[Viewing audit logs^] in the {openshift-platform} documentation.
 
 ifdef::self-managed[]
-NOTE: In {org-name} OpenShift Service on Amazon Web Services with hosted control planes (ROSA HCP), audit logging is disabled by default because the Elasticsearch log store does not provide secure storage for audit logs. To send the audit logs to Amazon CloudWatch, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/{rosa-latest-version}/html/logging/log-collection-and-forwarding#cluster-logging-collector-log-forward-cloudwatch_configuring-log-forwarding[Forwarding logs to Amazon CloudWatch].
+NOTE: In {org-name} OpenShift Service on Amazon Web Services with hosted control planes (ROSA HCP), audit logging is disabled by default because the Elasticsearch log store does not provide secure storage for audit logs. To send the audit logs to Amazon CloudWatch, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/{rosa-latest-version}/html/logging/logging-6-2#log6x-clf-6-2[Configuring log forwarding].
 endif::[]
 
 The following example shows how to use the {openshift-platform} audit logs to see the history of changes made (by users) to the DSC and DSCI custom resources.
@@ -25,7 +25,7 @@ The following example shows how to use the {openshift-platform} audit logs to se
 $ oc login __<openshift_cluster_url>__ -u __<admin_username>__ -p __<password>__
 ----
 
-. To access the full content of the changed custom resources, set the {openshift-platform} audit log policy to `WriteRequestBodies` or a more comprehensive profile. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-policy-config#configuring-audit-policy_audit-log-policy-config[About audit log policy profiles^].
+. To access the full content of the changed custom resources, set the {openshift-platform} audit log policy to `WriteRequestBodies` or a more comprehensive profile. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-policy-config#configuring-audit-policy_audit-log-policy-config[Configuring the audit log policy^].
 
 . Fetch the audit log files that are available for the relevant control plane nodes. For example:
 +
@@ -62,7 +62,7 @@ To configure the log retention time, see the link:https://docs.redhat.com/en/doc
 .Additional resources
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-view#audit-log-view[Viewing audit logs]
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-policy-config#configuring-audit-policy_audit-log-policy-config[About audit log policy profiles]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/security_and_compliance/audit-log-policy-config#configuring-audit-policy_audit-log-policy-config[Configuring the audit log policy]
 endif::[]
 
 ifdef::cloud-service[]


### PR DESCRIPTION
ENG-26898: Fixes broken or incorrectly formatted doclinks - Round 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated various documentation links to reflect new URLs for TrustyAI metrics, API references, and OpenShift audit log configuration.
  * Improved consistency in link text and updated references for adding taints to machine pools.
  * No changes were made to procedural instructions or functional content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->