### PR TITLE
Linking the new module on persistent storage classes and access modes 

### DIFF
--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -32,9 +32,11 @@ The *Add cluster storage* dialog opens.
 . From the *Storage class* list, select the type of cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the project.
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+ifndef::[upstream]
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
+endif::[]
 +
 . In the *Persistent storage size* section, specify a new size in gibibytes or mebibytes.
 . Optional: If you want to connect the cluster storage to an existing workbench:

--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -32,11 +32,14 @@ The *Add cluster storage* dialog opens.
 . From the *Storage class* list, select the type of cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the project.
-ifndef::[upstream]
+ifndef::upstream[]
 . For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+endif::[]
+ifdef::upstream[]
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 
+endif::[] 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
-endif::[]
 +
 . In the *Persistent storage size* section, specify a new size in gibibytes or mebibytes.
 . Optional: If you want to connect the cluster storage to an existing workbench:

--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -32,7 +32,7 @@ The *Add cluster storage* dialog opens.
 . From the *Storage class* list, select the type of cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the project.
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see __About persistent storage__. 
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 +

--- a/modules/adding-cluster-storage-to-your-data-science-project.adoc
+++ b/modules/adding-cluster-storage-to-your-data-science-project.adoc
@@ -33,11 +33,11 @@ The *Add cluster storage* dialog opens.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the project.
 ifndef::upstream[]
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage].  
 endif::[]
 ifdef::upstream[]
 . For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 
-endif::[] 
+endif::[]  
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 +

--- a/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
+++ b/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
@@ -33,9 +33,11 @@ The *Add cluster storage* dialog opens.
 .. Enter a *name* for the cluster storage.
 .. Optional: Enter a *description* for the cluster storage.
 .. Select the needed *storage class* for the cluster storage.
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+ifndef::[upstream]
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link: link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
+endif::[]
 +
 .. Under *Persistent storage size*, enter a size in gibibytes or mebibytes. 
 .. In the *Workbench connections* section, click *Add workbench*.

--- a/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
+++ b/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
@@ -33,7 +33,7 @@ The *Add cluster storage* dialog opens.
 .. Enter a *name* for the cluster storage.
 .. Optional: Enter a *description* for the cluster storage.
 .. Select the needed *storage class* for the cluster storage.
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see __About persistent storage__. 
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 +

--- a/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
+++ b/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
@@ -34,7 +34,7 @@ The *Add cluster storage* dialog opens.
 .. Optional: Enter a *description* for the cluster storage.
 .. Select the needed *storage class* for the cluster storage.
 ifndef::upstream[]
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 endif::[]
 ifdef::upstream[]
 .. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 

--- a/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
+++ b/modules/changing-the-storage-class-for-an-existing-cluster-storage-instance.adoc
@@ -33,11 +33,14 @@ The *Add cluster storage* dialog opens.
 .. Enter a *name* for the cluster storage.
 .. Optional: Enter a *description* for the cluster storage.
 .. Select the needed *storage class* for the cluster storage.
-ifndef::[upstream]
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link: link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+ifndef::upstream[]
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+endif::[]
+ifdef::upstream[]
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 
+endif::[]
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
-endif::[]
 +
 .. Under *Persistent storage size*, enter a size in gibibytes or mebibytes. 
 .. In the *Workbench connections* section, click *Add workbench*.

--- a/modules/configuring-storage-class-settings.adoc
+++ b/modules/configuring-storage-class-settings.adoc
@@ -27,7 +27,7 @@ The *Edit storage class details* dialog opens.
 
 . Optional: In the *Display Name* field, update the name for the storage class. This name is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
 . Optional: In the *Description* field, update the description for the storage class. This description is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see __About persistent storage__. 
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster administrator are available for selection.
 +

--- a/modules/configuring-storage-class-settings.adoc
+++ b/modules/configuring-storage-class-settings.adoc
@@ -27,9 +27,11 @@ The *Edit storage class details* dialog opens.
 
 . Optional: In the *Display Name* field, update the name for the storage class. This name is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
 . Optional: In the *Description* field, update the description for the storage class. This description is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+ifndef::[upstream]
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link: link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster administrator are available for selection.
+endif::[]
 +
 . Click *Save*.
 

--- a/modules/configuring-storage-class-settings.adoc
+++ b/modules/configuring-storage-class-settings.adoc
@@ -28,7 +28,7 @@ The *Edit storage class details* dialog opens.
 . Optional: In the *Display Name* field, update the name for the storage class. This name is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
 . Optional: In the *Description* field, update the description for the storage class. This description is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
 ifndef::upstream[]
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 endif::[]
 ifdef::upstream[]
 . For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 

--- a/modules/configuring-storage-class-settings.adoc
+++ b/modules/configuring-storage-class-settings.adoc
@@ -27,11 +27,14 @@ The *Edit storage class details* dialog opens.
 
 . Optional: In the *Display Name* field, update the name for the storage class. This name is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
 . Optional: In the *Description* field, update the description for the storage class. This description is used only in {productname-short} and does not impact the storage class within {openshift-platform}.
-ifndef::[upstream]
-. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link: link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
-+
-Only the access modes that have been enabled for the storage class by your cluster administrator are available for selection.
+ifndef::upstream[]
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 endif::[]
+ifdef::upstream[]
+. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 
+endif::[]
++
+Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 +
 . Click *Save*.
 

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -142,11 +142,14 @@ If you are using S3-compatible storage, add these recommended environment variab
 .. Select a *storage class* for the cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the workbench.
-ifndef::[upstream]
+ifndef::upstream[]
 .. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+endif::[]
+ifdef::upstream[]
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 
+endif::[]
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
-endif::[]
 .. Under *Persistent storage size*, enter a new size in gibibytes or mebibytes.
 * *Use existing persistent storage* to reuse existing storage and select the storage from the *Persistent storage* list. 
 

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -142,9 +142,11 @@ If you are using S3-compatible storage, add these recommended environment variab
 .. Select a *storage class* for the cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the workbench.
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+ifndef::[upstream]
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
+endif::[]
 .. Under *Persistent storage size*, enter a new size in gibibytes or mebibytes.
 * *Use existing persistent storage* to reuse existing storage and select the storage from the *Persistent storage* list. 
 

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -142,7 +142,7 @@ If you are using S3-compatible storage, add these recommended environment variab
 .. Select a *storage class* for the cluster storage.
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the workbench.
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see __About persistent storage__. 
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
 +
 Only the access modes that have been enabled for the storage class by your cluster and {productname-short} administrators are visible.
 .. Under *Persistent storage size*, enter a new size in gibibytes or mebibytes.

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -143,7 +143,7 @@ If you are using S3-compatible storage, add these recommended environment variab
 +
 NOTE: You cannot change the storage class after you add the cluster storage to the workbench.
 ifndef::upstream[]
-.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage]. 
+.. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{rhoaidocshome}{default-format-url}/managing_resources/managing-storage-classes#about-persistent-storage_resource-mgmt[About persistent storage].  
 endif::[]
 ifdef::upstream[]
 .. For storage classes that support multiple access modes, select an *Access mode* to define how the volume can be accessed. For more information, see link:{odhdocshome}/managing-resources/#about-persistent-storage_managing-resources[About persistent storage]. 


### PR DESCRIPTION
## Description
JIRA: https://issues.redhat.com/browse/RHOAIENG-27757

Small change that adds a link to the new module on persistent storage classes and access modes. This link was not included in the previous iterations of this work. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated references to "About persistent storage" with conditional direct hyperlinks tailored to the build context, improving clarity and navigation.  
  * Clarified visibility of access modes to reflect permissions granted by both cluster and product administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->