### PR TITLE
ENG-26898: Fixes broken or incorrectly formatted doclinks - Round 5

### DIFF
--- a/modules/viewing-audit-logs.adoc
+++ b/modules/viewing-audit-logs.adoc
@@ -9,7 +9,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/openshif
 
 ifdef::self-managed[]
 NOTE: In {org-name} OpenShift Service on Amazon Web Services with hosted control planes (ROSA HCP), audit logging is disabled by default because the Elasticsearch log store does not provide secure storage for audit logs. 
-To configure log forwarding, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/logging/index[Logging] section in the {openshift-platform} documentation.
+To configure log forwarding, see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/{rosa-latest-version}/html/logging/index[Logging] section in the {openshift-platform} documentation.
 endif::[]
 
 The following example shows how to use the {openshift-platform} audit logs to see the history of changes made (by users) to the DSC and DSCI custom resources.


### PR DESCRIPTION
ENG-26898: Fixes broken or incorrectly formatted doclinks - Round 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the audit log documentation to provide the correct link for configuring log forwarding in self-managed environments. The link now directs users to the appropriate Red Hat OpenShift Service on AWS (ROSA) logging documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->