### PR TITLE
OCP minimum ver 4.15

### DIFF
--- a/_artifacts/document-attributes-global.adoc
+++ b/_artifacts/document-attributes-global.adoc
@@ -68,9 +68,9 @@ endif::[]
 :rhoaidocshome: https://docs.redhat.com/en/documentation/{url-productname-long}/{vernum}/
 :default-format-url: html
 :ocp-latest-version: 4.19
-:ocp-minimum-version: 4.14
+:ocp-minimum-version: 4.15
 :osd-latest-version: 4
 :rosa-latest-version: 4
-:os-latest-version: 1.33
+:os-latest-version: 1.36
 :rhelai-productname-long: Red{nbsp}Hat Enterprise Linux AI
 :rhelai-productname-short: RHEL AI

--- a/assemblies/managing-distributed-workloads.adoc
+++ b/assemblies/managing-distributed-workloads.adoc
@@ -10,23 +10,6 @@ ifdef::context[:parent-context: {context}]
 In {productname-short}, cluster administrators create Kueue resources to configure quota management for distributed workloads.
 Cluster administrators can optionally configure the CodeFlare Operator if they want to change its default behavior.
 
-ifdef::self-managed[]
-[NOTE]
-====
-The minimum version of {openshift-platform} that is compatible with Kueue 0.10.1 is 4.15. 
-If you deploy {productname-long} 2.18 or later on {openshift-platform} 4.14 or earlier, you must disable the API Priority and Fairness configuration for the Visibility API, as described in the link:https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#enabling-disabling-api-priority-and-fairness[Enabling/Disabling API Priority and Fairness] section in the Kueue _Cluster Administration_ guide.
-This modification is required because the `PriorityLevelConfiguration` API is incompatible with older {openshift-platform} versions.
-====
-endif::[]
-
-ifdef::cloud-service[]
-[NOTE]
-====
-You must disable the API Priority and Fairness configuration for the Visibility API, as described in the link:https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#enabling-disabling-api-priority-and-fairness[Enabling/Disabling API Priority and Fairness] section in the Kueue _Cluster Administration_ guide.
-====
-endif::[]
-
-
 include::modules/overview-of-kueue-resources.adoc[leveloffset=+1]
 include::modules/ref-example-kueue-resource-configurations.adoc[leveloffset=+1]
 include::modules/configuring-quota-management-for-distributed-workloads.adoc[leveloffset=+1]

--- a/modules/overview-of-distributed-workloads.adoc
+++ b/modules/overview-of-distributed-workloads.adoc
@@ -45,23 +45,6 @@ Manages remote Ray clusters on OpenShift for running distributed compute workloa
 
 Kueue::
 Manages quotas and how distributed workloads consume them, and manages the queueing of distributed workloads with respect to quotas
-ifdef::self-managed[]
-+
-[NOTE]
-====
-The minimum version of {openshift-platform} that is compatible with Kueue 0.10.1 is 4.15. 
-If you deploy {productname-long} 2.18 or later on {openshift-platform} 4.14 or earlier, you must disable the API Priority and Fairness configuration for the Visibility API, as described in the link:https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#enabling-disabling-api-priority-and-fairness[Enabling/Disabling API Priority and Fairness] section in the Kueue _Cluster Administration_ guide.
-This modification is required because the `PriorityLevelConfiguration` API is incompatible with older {openshift-platform} versions.
-====
-endif::[]
-ifdef::cloud-service[]
-+
-[NOTE]
-====
-You must disable the API Priority and Fairness configuration for the Visibility API, as described in the link:https://kubernetes.io/docs/concepts/cluster-administration/flow-control/#enabling-disabling-api-priority-and-fairness[Enabling/Disabling API Priority and Fairness] section in the Kueue _Cluster Administration_ guide.
-====
-endif::[]
-
 
 ifdef::upstream[]
 For information about installing these components, see link:{odhdocshome}/installing-open-data-hub/#installing-the-distributed-workloads-components_install[Installing the distributed workloads components].


### PR DESCRIPTION
Update OCP minimum version to 4.15, delete notes that are no longer applicable, and update OpenShift Serverless latest version to 1.36 