### PR TITLE
Adding link checker script + GitHub CI

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,30 @@
+name: Check links
+
+on: [push, pull_request]
+
+jobs:
+  check-links:
+    name: Check links in modified AsciiDoc files
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Asciidoctor
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y asciidoctor
+
+      - name: Make scripts executable
+        run: |
+          chmod +x scripts/check-updated-books.sh scripts/check-book-links.sh
+
+      - name: Check links in updated books
+        shell: bash
+        run: |
+          # check-updated-books.sh finds master.adoc files that are directly
+          # or indirectly updated by the current PR and checks for 404s 
+          # in that book by passing the book to check-book-links.sh
+          scripts/check-updated-books.sh

--- a/scripts/.links_ignore
+++ b/scripts/.links_ignore
@@ -1,0 +1,35 @@
+# URL patterns to ignore during link checking
+# Format: Extended regex patterns (one per line)
+# Comment lines starting with # are ignored
+
+# Local/testing URLs
+^https?://0\.0\.0\.0
+^https?://localhost
+^https?://127\.0\.0\.1
+^https?://.*\.local($|/)
+
+# Example/placeholder domains
+^https?://([^/]*\.)?example\.(com|org)
+^https?://github\.com/example/
+
+# Internal/cluster services
+^https?://.*\.svc($|/)
+^https?://.*\.openshiftapps\.com
+
+# External services that require authentication or are unreliable
+^https?://([^/]*\.)?google\.com
+^https?://docs\.google\.com
+^https?://fonts\.googleapis\.com
+^https?://issues\.redhat\.com
+^https?://registry\.redhat\.io
+^https?://ieeexplore\.ieee\.org/
+
+# Test-specific URLs
+^https?://ds-pipeline-dspa-robert-tests
+^https?://mixtral-my-project\.apps\.my-cluster\.com
+
+# API endpoints
+/v1/chat/completions$
+
+# Documentation URLs to ignore
+^https://docs\.redhat\.com/en/documentation/red_hat_openshift_ai_cloud_service/

--- a/scripts/check-book-links.sh
+++ b/scripts/check-book-links.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Checks for invalid or broken links in HTML built from root adoc files using Asciidoctor and curl
+# Usage: ./check-book-links.sh [adoc file]
+# If no file is specified, runs on all adoc files in the root folder
+# Requires Bash 4.0+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "Error: This script requires Bash 4.0 or later" >&2
+    exit 1
+fi
+
+if ! asciidoctor -v >/dev/null 2>&1; then
+    echo "Error: Asciidoctor is not installed" >&2
+    exit 1
+fi
+
+# URL ignore patterns
+IGNORE_FILE="$(dirname "$0")/.links_ignore"
+IGNORE_PATTERNS=""
+
+# Read patterns, skipping empty lines and comments
+if [[ -f "$IGNORE_FILE" ]]; then
+    IGNORE_PATTERNS=$(grep -v '^#' "$IGNORE_FILE" | grep -v '^[[:space:]]*$' || true)
+fi
+
+export IGNORE_PATTERNS
+
+# shellcheck disable=SC2317  # called via bash -c / xargs
+check_url() {
+    local URL STATUS
+    # Strip . , ; : ) ] } but preserve URL-safe chars like + = & #
+    URL=$(echo "$1" | sed 's/[.,;:)\]}]*$//')
+
+    # Skip ignored URLs by checking against each pattern
+    if [[ -n "$IGNORE_PATTERNS" ]]; then
+        while IFS= read -r pattern; do
+            if [[ "$URL" =~ $pattern ]]; then
+                return 0
+            fi
+        done <<< "$IGNORE_PATTERNS"
+    fi
+
+    STATUS=$(curl -Ls -o /dev/null -w "%{http_code}" --max-time 5 --connect-timeout 2 "$URL")
+    if [[ "$STATUS" != "000" && "$STATUS" != "403" && ! "$STATUS" =~ ^(2|3)[0-9]{2}$ ]]; then
+        printf 'Invalid URL (HTTP status %s): \n\033[31m%s\033[0m\n' "$STATUS" "$URL"
+        return 1
+    fi
+}
+
+export -f check_url
+
+run_url_checks() {
+    local FILE="$1"
+    echo -e "\n\033[32mChecking: $FILE\033[0m"
+
+    # Extract HTTP(S) URLs from the rendered HTML
+    asciidoctor "$FILE" -a doctype=book -o - |
+        # Match URLs and special chars like + & # ~ etc. that are valid in URLs
+        grep -Eo '(http|https)://[a-zA-Z0-9./?=%_&+~#:@!$*,;-]*' |
+        sort -u |
+        xargs -P 10 -I{} bash -c 'check_url "$1"' _ '{}'
+}
+
+# Determine which files to check
+if [ $# -eq 0 ]; then
+    # No input file passed, check all root folder adoc files
+    mapfile -d '' FILES < <(find . -maxdepth 1 -name "*.adoc" -type f -print0)
+elif [ $# -eq 1 ]; then
+    # Check input file
+    FILES=("$1")
+fi
+
+BROKEN=0
+for FILE in "${FILES[@]}"; do
+    if ! run_url_checks "$FILE"; then
+        BROKEN=1
+    fi
+done
+
+if [ "$BROKEN" -ne 0 ]; then
+  exit 1
+else
+  echo -e "\n✅ \033[32mAll links are valid!\033[0m"
+fi

--- a/scripts/check-updated-books.sh
+++ b/scripts/check-updated-books.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Compiles a list of updated root adoc books in the current PR, and then checks each book for 404 errors using check-book-links.sh
+# Requires Bash 4.0+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "Error: This script requires Bash 4.0 or later" >&2
+    exit 1
+fi
+
+ERRORS=0
+
+FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc")
+
+MODULES=$(echo "$FILES" | grep '^modules/.*\.adoc$')
+ASSEMBLIES=$(echo "$FILES" | grep '^assemblies/.*\.adoc$')
+BOOKS=$(echo "$FILES" | grep -E '^[^/]+\.adoc$')
+
+UPDATED_BOOKS=()
+
+if [ -n "$MODULES" ]; then
+  # Check for books that include modified modules (directly or via assemblies)
+  while IFS= read -r module; do
+    # Find root adoc books that directly include the module
+    mapfile -t files < <(find . -maxdepth 1 -name "*.adoc" -type f -print0 2>/dev/null || true)
+    if [ ${#files[@]} -gt 0 ]; then
+      mapfile -t updated_books < <(grep -l "include::.*$(basename "$module")" "${files[@]}" 2>/dev/null || true)
+      UPDATED_BOOKS+=( "${updated_books[@]}" )
+    fi
+
+    # Find assemblies that include the module, then find root adoc books that include those assemblies
+    if [ -d assemblies ]; then
+      mapfile -t assembly_files < <(find assemblies -name "*.adoc" -type f -print0 2>/dev/null)
+      if [ ${#assembly_files[@]} -gt 0 ]; then
+        mapfile -t updated_assemblies < <(grep -l "include::.*$(basename "$module")" "${assembly_files[@]}" 2>/dev/null || true)
+        for assembly in "${updated_assemblies[@]}"; do
+          mapfile -t book_files < <(find . -maxdepth 1 -name "*.adoc" -type f -print0 2>/dev/null)
+          if [ ${#book_files[@]} -gt 0 ]; then
+            mapfile -t books_with_assembly < <(grep -l "$(basename "$assembly")" "${book_files[@]}" 2>/dev/null || true)
+            UPDATED_BOOKS+=( "${books_with_assembly[@]}" )
+          fi
+        done
+      fi
+    fi
+  done <<< "$MODULES"
+fi
+
+# Check for books that include modified assemblies
+if [ -n "$ASSEMBLIES" ]; then
+  while IFS= read -r assembly; do
+    mapfile -t book_files < <(find . -maxdepth 1 -name "*.adoc" -type f -print0 2>/dev/null || true)
+    if [ ${#book_files[@]} -gt 0 ]; then
+      mapfile -t books_with_modified_assembly < <(grep -l "$(basename "$assembly")" "${book_files[@]}" 2>/dev/null || true)
+      UPDATED_BOOKS+=( "${books_with_modified_assembly[@]}" )
+    fi
+  done <<< "$ASSEMBLIES"
+fi
+
+# Check for directly updated books
+if [ -n "$BOOKS" ]; then
+  while IFS= read -r book; do
+    UPDATED_BOOKS+=( "$book" )
+  done <<< "$BOOKS"
+fi
+
+if [ ${#UPDATED_BOOKS[@]} -eq 0 ]; then
+  echo "No modified books. Skipping link check."
+  exit 0
+fi
+
+# Remove duplicates from UPDATED_BOOKS
+mapfile -t UPDATED_BOOKS < <(printf '%s\n' "${UPDATED_BOOKS[@]}" | sort -u)
+
+# Check links in the compiled list of books
+for f in "${UPDATED_BOOKS[@]}"; do
+  if ! ./scripts/check-book-links.sh "$f"; then
+    ERRORS=1
+  fi
+done
+
+if [ "$ERRORS" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding link checker scripts + GitHub CI yml

Adds the same link checker scripts from downstream

Updates in this PR:

1. `check-updated-books.sh` - This is used in the CI to only review links in files that are modifed in the current PR. `check-updated-books.sh` calls `check-book-links.sh` for every book that it calculates is updated.
This hopefully reduces the noise for writers. **Only errors in currently modifed book are surfaced.** 

2. `check-book-links.sh` - This can be used locally by writers. Run it against a single book like this:
    ```
    check-book-links.sh self-managed-managing-resources/master.adoc   
    ```

3. `.links_ignore` (renamed from links.ignore) is organized a bit better and can be updated over time. For example, the `red_hat_openshift_ai_cloud_service` links are added to the ignore list.

4. The CI now runs against updated assemblies only. If we want to check the whole repo, just run `check-book-links.sh` locally without any input param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated link validation to the CI/CD pipeline that checks documentation links on every push and pull request, ensuring broken links are detected before changes are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->