### PR TITLE
ENG-24639: remove mlmd note from model registry docs

### DIFF
--- a/modules/creating-a-model-registry.adoc
+++ b/modules/creating-a-model-registry.adoc
@@ -15,18 +15,6 @@ ifndef::upstream[]
 * A cluster administrator has enabled the model registry component in your {productname-short} deployment. For more information, see link:{rhoaidocshome}{default-format-url}/enabling_the_model_registry_component/enabling-the-model-registry-component_model-registry-config[Enabling the model registry component].
 endif::[]
 * You have access to an external MySQL database which uses at least MySQL version 5.x. However, {org-name} recommends that you use MySQL version 8.x.
-+
-[NOTE]
-====
-The `mysql_native_password` authentication plugin is required for the ML Metadata component to successfully connect to your database. `mysql_native_password` is disabled by default in MySQL 8.4 and later. If your database uses MySQL 8.4 or later, you must update your MySQL deployment to enable the `mysql_native_password` plugin. 
-
-For more information about enabling the `mysql_native_password` plugin, see link:https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html[Native Pluggable Authentication] in the MySQL documentation.
-
-By default, the {openshift-platform} MySQL template uses the `caching_sha2_password` authentication plugin. If you used the {openshift-platform} template for MySQL, you must manually update it to use `mysql_native_password` for the model registry to connect to your database instance successfully. 
-ifndef::upstream[]
-For more information, see the link:https://access.redhat.com/solutions/7128249[Model registry fails to connect to MySQL database due to an authentication plugin mismatch] Knowledgebase solution. 
-endif::[]
-====
 
 .Procedure
 . From the {productname-short} dashboard, click *Settings* -> *Model registry settings*.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove note about mysql_native_password authentication plugin required for ML Metadata component from model registry docs. This note is no longer required because the ML Metadata component has been removed from model registry. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed information about the `mysql_native_password` authentication plugin requirement and related configuration instructions from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->