### PR TITLE
RHOAIENG-25115: Adding KEDA feature

### DIFF
--- a/assemblies/serving-large-models.adoc
+++ b/assemblies/serving-large-models.adoc
@@ -45,7 +45,7 @@ include::modules/viewing-performance-metrics-for-deployed-model.adoc[leveloffset
 include::modules/deploying-a-grafana-metrics-dashboard.adoc[leveloffset=+2]
 include::modules/deploying-vllm-gpu-metrics-dashboard-grafana.adoc[leveloffset=+2]
 include::modules/ref-grafana-metrics.adoc[leveloffset=+2]
-
+include::modules/configuring-metric-based-autoscaling.adoc[leveloffset=+2]
 == Optimizing model-serving runtimes
 
 You can optionally enhance the preinstalled model-serving runtimes available in {productname-short} to leverage additional benefits and capabilities, such as optimized inferencing, reduced latency, and fine-tuned resource allocation. 

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -41,7 +41,7 @@ spec:
           external:
             metric:
               backend: "prometheus"
-              serverAddress: "https://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9092"
+              serverAddress: "https://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9091"
               query: vllm:num_requests_waiting
             authenticationRef:
               name: openshift-monitoring-metrics-auth

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -53,9 +53,9 @@ spec:
             name: inference-prometheus-auth
           authModes: 
             - bearer
-            target:
-              type: Value
-              value: 2
+          target:
+            type: Value
+            value: 2
 ----
 +
 The example configuration sets up the inference service to autoscale between 1 and 5 replicas based on the number of requests waiting to be processed, as indicated by the `vllm:num_requests_waiting` metric.

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -1,12 +1,12 @@
 :_module-type: PROCEDURE
 
-[id="configuring-metric-based-autoscaling_{context}"]
-= Configuring metric-based autoscaling
+[id="configuring-metrics-based-autoscaling_{context}"]
+= Configuring metrics-based autoscaling
 
 [role="_abstract"]
 While Knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
 
-To setup autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
+To set up autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
@@ -21,7 +21,7 @@ The `odh-controller` automatically creates the `TriggerAuthentication`, `Service
 
 .Procedure
 
-. Log in to the OpenShift console as a cluster administrator.
+. Log in to the {openshift-platform} console as a cluster administrator.
 . In the *Administrator* perspective, click *Home* -> *Search*.
 . Select the project where you have deployed your model.
 . From the *Resources* dropdown menu, select *InferenceService*.
@@ -35,13 +35,13 @@ spec:
     # …
     minReplicas: 1
     maxReplicas: 5
-    autoScaling:
+    autoscaling:
       metrics:
         - type: External
           external:
             metric:
               backend: "prometheus"
-              serverAddress: "http://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9092"
+              serverAddress: "https://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9092"
               query: vllm:num_requests_waiting
             authenticationRef:
               name: openshift-monitoring-metrics-auth
@@ -55,4 +55,3 @@ The example configures the inference service to autoscale between 1-5 replicas b
 
 //[role="_additional-resources"]
 //.Additional resources
-// link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/monitoring/index[Monitoring]

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -41,7 +41,7 @@ spec:
   predictor:
     minReplicas: 1
     maxReplicas: 5
-    autoScaling:
+    autoscaling:
       metrics:
         - type: External
           external:
@@ -49,9 +49,10 @@ spec:
               backend: "prometheus"
               serverAddress: "https://thanos-querier.openshift-monitoring.svc:9092"
               query: vllm:num_requests_waiting
-            authenticationRef:
-              name: inference-prometheus-auth
-            authModes: bearer
+          authenticationRef:
+            name: inference-prometheus-auth
+          authModes: 
+            - bearer
             target:
               type: Value
               value: 2

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -4,13 +4,13 @@
 = Configuring metric-based autoscaling
 
 [role="_abstract"]
-While knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
+While Knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
 
-To setup autoscaling for your inference service in standard deployments, you must install and configure the Openshift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
+To setup autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
-* You have installed the CMA operator on your cluster. For more informatipn, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler].
+* You have installed the CMA operator on your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler].
 +
 [NOTE]
 ====
@@ -28,7 +28,7 @@ The `odh-controller` automatically creates the `TriggerAuthentication`, `Service
 . Click the `InferenceService` for your deployed model and then click *YAML*.
 . Under `spec.predictor`, define a metric-based autoscaling policy similar to the following example:
 +
-[source]
+[source,yaml]
 ----
 spec:
   predictor:
@@ -42,16 +42,16 @@ spec:
             metric:
               backend: "prometheus"
               serverAddress: "http://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9092"
-              query: vllm:num_requests_waiting 
+              query: vllm:num_requests_waiting
             authenticationRef:
               name: openshift-monitoring-metrics-auth
             target:
               type: Value
-              value: "2"
+              value: 2
 ----
 +
 The example configures the inference service to autoscale between 1-5 replicas based on the number of requests waiting to be processed, as determined by the `vllm:num_requests_waiting` metric.
-. Click *Save*
+. Click *Save*.
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -33,16 +33,15 @@ To set up autoscaling for your inference service in standard deployments, you mu
 ----
 kind: InferenceService
 metadata:
-  # ...
+  name: my-inference-service
+  namespace: my-namespace
   annotations:
-    # ...
     serving.kserve.io/autoscalerClass: keda
 spec:
   predictor:
-    # …
     minReplicas: 1
     maxReplicas: 5
-    autoscaling:
+    autoScaling:
       metrics:
         - type: External
           external:
@@ -51,9 +50,8 @@ spec:
               serverAddress: "https://thanos-querier.openshift-monitoring.svc:9092"
               query: vllm:num_requests_waiting
             authenticationRef:
-              authModes: bearer
-              authenticationRef:
-                name: inference-prometheus-auth
+              name: inference-prometheus-auth
+            authModes: bearer
             target:
               type: Value
               value: 2
@@ -62,5 +60,15 @@ spec:
 The example configuration sets up the inference service to autoscale between 1 and 5 replicas based on the number of requests waiting to be processed, as indicated by the `vllm:num_requests_waiting` metric.
 . Click *Save*.
 
+.Verification
+
+* Confirm that the KEDA `ScaledObject` resource is created and that the &minReplicaCount*, *maxReplicacount* and *Target* values match your configuration:
++
+[source, console]
+----
+oc get scaledobject -n <namespace>
+oc describe scaledobject <scaledobject-name> -n <namespace>
+---- 
+* Check
 //[role="_additional-resources"]
 //.Additional resources

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -4,9 +4,9 @@
 = Configuring metrics-based autoscaling
 
 [role="_abstract"]
-While Knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
+Knative-based autoscaling is not available in standard deployment mode. However, you can enable metrics-based autoscaling for an inference service in standard deployment mode. Metrics-based autoscaling helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
 
-To set up autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and Concurrency, to trigger autoscaling of your inference service. 
+To set up autoscaling for your inference service in standard deployments, install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then use various model runtime metrics available in OpenShift Monitoring to trigger autoscaling of your inference service, such as KVCache utilization, Time to First Token (TTFT), and Concurrency. 
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -51,8 +51,7 @@ spec:
               query: vllm:num_requests_waiting
           authenticationRef:
             name: inference-prometheus-auth
-          authModes: 
-            - bearer
+          authModes: bearer
           target:
             type: Value
             value: 2

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -63,12 +63,11 @@ The example configuration sets up the inference service to autoscale between 1 a
 
 .Verification
 
-* Confirm that the KEDA `ScaledObject` resource is created and that the `minReplicaCount`, `maxReplicacount` and `Target` values match your configuration:
+* Confirm that the KEDA `ScaledObject` resource is created:
 +
 [source, console]
 ----
 oc get scaledobject -n <namespace>
-oc describe scaledobject <scaledobject-name> -n <namespace>
 ---- 
 * Check
 //[role="_additional-resources"]

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -63,7 +63,7 @@ The example configuration sets up the inference service to autoscale between 1 a
 
 .Verification
 
-* Confirm that the KEDA `ScaledObject` resource is created and that the &minReplicaCount*, *maxReplicacount* and *Target* values match your configuration:
+* Confirm that the KEDA `ScaledObject` resource is created and that the `minReplicaCount`, `maxReplicacount` and `Target` values match your configuration:
 +
 [source, console]
 ----

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 While Knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
 
-To set up autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
+To set up autoscaling for your inference service in standard deployments, you must install and configure the OpenShift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and Concurrency, to trigger autoscaling of your inference service. 
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.
@@ -14,9 +14,10 @@ To set up autoscaling for your inference service in standard deployments, you mu
 +
 [NOTE]
 ====
-The `odh-controller` automatically creates the `TriggerAuthentication`, `ServiceAccount`, `Role`, `RoleBinding`, and `Secret` resources to allow CMA access to OpenShift Monitoring metrics.
+* You must configure the `KedaController` resource after installing the CMA operator. 
+* The `odh-controller` automatically creates the `TriggerAuthentication`, `ServiceAccount`, `Role`, `RoleBinding`, and `Secret` resources to allow CMA access to OpenShift Monitoring metrics. 
 ====
-* You have enabled User Workload Monitoring (UWM) for your cluster. For more information, see https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/monitoring/configuring-user-workload-monitoring[Configuring user workload monitoring].
+* You have enabled User Workload Monitoring (UWM) for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/monitoring/configuring-user-workload-monitoring[Configuring user workload monitoring].
 * You have deployed a model on the single-model serving platform in standard deployment mode.
 
 .Procedure
@@ -30,6 +31,12 @@ The `odh-controller` automatically creates the `TriggerAuthentication`, `Service
 +
 [source,yaml]
 ----
+kind: InferenceService
+metadata:
+  # ...
+  annotations:
+    # ...
+    serving.kserve.io/autoscalerClass: keda
 spec:
   predictor:
     # …
@@ -41,16 +48,18 @@ spec:
           external:
             metric:
               backend: "prometheus"
-              serverAddress: "https://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9091"
+              serverAddress: "https://thanos-querier.openshift-monitoring.svc:9092"
               query: vllm:num_requests_waiting
             authenticationRef:
-              name: openshift-monitoring-metrics-auth
+              authModes: bearer
+              authenticationRef:
+                name: inference-prometheus-auth
             target:
               type: Value
               value: 2
 ----
 +
-The example configures the inference service to autoscale between 1-5 replicas based on the number of requests waiting to be processed, as determined by the `vllm:num_requests_waiting` metric.
+The example configuration sets up the inference service to autoscale between 1 and 5 replicas based on the number of requests waiting to be processed, as indicated by the `vllm:num_requests_waiting` metric.
 . Click *Save*.
 
 //[role="_additional-resources"]

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -1,0 +1,58 @@
+:_module-type: PROCEDURE
+
+[id="configuring-metric-based-autoscaling_{context}"]
+= Configuring metric-based autoscaling
+
+[role="_abstract"]
+While knative-based autoscaling features are not available in standard deployment modes, you can enable metrics-based autoscaling for an inference service in these deployments. This capability helps you efficiently manage accelerator resources, lower operational costs, and ensure that your inference services meet performance requirements.
+
+To setup autoscaling for your inference service in standard deployments, you must install and configure the Openshift Custom Metrics Autoscaler (CMA), which is based on Kubernetes Event-driven Autoscaling (KEDA). You can then utilize various model runtime metrics available in OpenShift Monitoring, such as KVCache utilization, Time to First Token (TTFT), and concurrency, to trigger autoscaling of your inference service. 
+
+.Prerequisites
+* You have cluster administrator privileges for your {openshift-platform} cluster.
+* You have installed the CMA operator on your cluster. For more informatipn, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler].
++
+[NOTE]
+====
+The `odh-controller` automatically creates the `TriggerAuthentication`, `ServiceAccount`, `Role`, `RoleBinding`, and `Secret` resources to allow CMA access to OpenShift Monitoring metrics.
+====
+* You have enabled User Workload Monitoring (UWM) for your cluster. For more information, see https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/monitoring/configuring-user-workload-monitoring[Configuring user workload monitoring].
+* You have deployed a model on the single-model serving platform in standard deployment mode.
+
+.Procedure
+
+. Log in to the OpenShift console as a cluster administrator.
+. In the *Administrator* perspective, click *Home* -> *Search*.
+. Select the project where you have deployed your model.
+. From the *Resources* dropdown menu, select *InferenceService*.
+. Click the `InferenceService` for your deployed model and then click *YAML*.
+. Under `spec.predictor`, define a metric-based autoscaling policy similar to the following example:
++
+[source]
+----
+spec:
+  predictor:
+    # …
+    minReplicas: 1
+    maxReplicas: 5
+    autoScaling:
+      metrics:
+        - type: External
+          external:
+            metric:
+              backend: "prometheus"
+              serverAddress: "http://<thanos-service>.<monitoring-namespace>.svc.cluster.local:9092"
+              query: vllm:num_requests_waiting 
+            authenticationRef:
+              name: openshift-monitoring-metrics-auth
+            target:
+              type: Value
+              value: "2"
+----
++
+The example configures the inference service to autoscale between 1-5 replicas based on the number of requests waiting to be processed, as determined by the `vllm:num_requests_waiting` metric.
+. Click *Save*
+
+//[role="_additional-resources"]
+//.Additional resources
+// link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/monitoring/index[Monitoring]

--- a/modules/configuring-metric-based-autoscaling.adoc
+++ b/modules/configuring-metric-based-autoscaling.adoc
@@ -69,6 +69,6 @@ The example configuration sets up the inference service to autoscale between 1 a
 ----
 oc get scaledobject -n <namespace>
 ---- 
-* Check
+
 //[role="_additional-resources"]
 //.Additional resources


### PR DESCRIPTION
## Description
Adding the KEDA autoscaling feature to docs
## How Has This Been Tested?
Local build


## Preview
<img width="677" height="532" alt="Screenshot 2025-08-07 at 4 40 18 PM" src="https://github.com/user-attachments/assets/ac2e838a-173a-4ad0-8e60-d7626ddbd54d" />
<img width="777" height="846" alt="Screenshot 2025-08-07 at 4 43 56 PM" src="https://github.com/user-attachments/assets/58be5612-e7df-4ec6-b01c-9c5cffa93f3a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added documentation on configuring metric-based autoscaling for inference services in OpenShift environments without Knative autoscaling.
  * Step-by-step guide provided for setting up the Custom Metrics Autoscaler (CMA) and defining autoscaling policies based on external metrics.

* **Documentation**
  * Included a new procedure module in the "Monitoring model performance" section covering metric-based autoscaling setup and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->