### PR TITLE
ENG-1840: Adding CA cert note to edit and create MR procs.

### DIFF
--- a/modules/creating-a-model-registry.adoc
+++ b/modules/creating-a-model-registry.adoc
@@ -58,6 +58,11 @@ endif::[]
 .. In the *Password* field, enter the password for the default user account.
 .. In the *Database* field, enter the database name.
 . Optional: Select the *Add CA certificate to secure database connection* to use a certificate with your database connection.
++
+[IMPORTANT]
+====
+If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate for the database.
+====
 .. Click *Use cluster-wide CA bundle* to use the `ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 .. Click *Use {productname-long} CA bundle* to use the `odh-ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 ifdef::upstream[]

--- a/modules/creating-a-model-registry.adoc
+++ b/modules/creating-a-model-registry.adoc
@@ -61,7 +61,7 @@ endif::[]
 +
 [IMPORTANT]
 ====
-If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate for the database.
+If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate.
 ====
 .. Click *Use cluster-wide CA bundle* to use the `ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 .. Click *Use {productname-long} CA bundle* to use the `odh-ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.

--- a/modules/editing-a-model-registry.adoc
+++ b/modules/editing-a-model-registry.adoc
@@ -38,6 +38,11 @@ endif::[]
 .. In the *Password* field, enter the password for the default user account.
 .. In the *Database* field, enter the database name.
 . Optional: Select the *Add CA certificate to secure database connection* to use a certificate with your database connection.
++
+[IMPORTANT]
+====
+If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate for the database.
+====
 .. Click *Use cluster-wide CA bundle* to use the `ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 .. Click *Use {productname-long} CA bundle* to use the `odh-ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 ifdef::upstream[]

--- a/modules/editing-a-model-registry.adoc
+++ b/modules/editing-a-model-registry.adoc
@@ -41,7 +41,7 @@ endif::[]
 +
 [IMPORTANT]
 ====
-If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate for the database.
+If your external database is configured to enforce Transport Layer Security (TLS), then you must add a Certificate Authority (CA) certificate.
 ====
 .. Click *Use cluster-wide CA bundle* to use the `ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.
 .. Click *Use {productname-long} CA bundle* to use the `odh-ca-bundle.crt` bundle in the `odh-trusted-ca-bundle` ConfigMap.


### PR DESCRIPTION
Adds a note about the need to add a CA certificate for the external database associated with your model registry instance if the DB is configured to enforce TLS.

@coderabbitai ignore