### PR TITLE
Fix incorrect field name RawDeploymentServiceConfig in KServe documentation

### DIFF
--- a/modules/deploying-models-on-single-node-openshift-using-kserve-raw-deployment-mode.adoc
+++ b/modules/deploying-models-on-single-node-openshift-using-kserve-raw-deployment-mode.adoc
@@ -77,7 +77,7 @@ For information about creating projects, see link:https://docs.redhat.com/en/doc
 ----
   kserve:
     defaultDeploymentMode: RawDeployment
-    RawDeploymentServiceConfig: Headed
+    rawDeploymentServiceConfig: Headed
     managementState: Managed
     serving:
       managementState: Removed
@@ -86,7 +86,7 @@ For information about creating projects, see link:https://docs.redhat.com/en/doc
 +
 [NOTE]
 ====
-The configuration shown uses `Headed` configuration for handling load balancing requests, which does not require a dedicated load balancer. For environments that have a dedicated load balancer to handle requests from outside the cluster, set `RawDeploymentServiceConfig` to `Headless`.
+The configuration shown uses `Headed` configuration for handling load balancing requests, which does not require a dedicated load balancer. For environments that have a dedicated load balancer to handle requests from outside the cluster, set `rawDeploymentServiceConfig` to `Headless`.
 ====
 +
 .. Click *Create*.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the documentation to use the correct field name `rawDeploymentServiceConfig` as defined in the CRD specification.

**Jira:** [RHAIRFE-471](https://issues.redhat.com/browse/RHAIRFE-471)

## Problem
The Red Hat OpenShift AI documentation shows an incorrect field name in the KServe configuration example:
- **Incorrect:** `RawDeploymentServiceConfig` (PascalCase)
- **Correct:** `rawDeploymentServiceConfig` (camelCase)

This causes users to get the error:
```
unknown field "RawDeploymentServiceConfig" in io.opendatahub.datasciencecluster.v1.DataScienceCluster.spec.components.kserve
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
