### PR TITLE
RHOAI-32514 remove TP note from Kubernetes DSP

### DIFF
--- a/modules/defining-a-pipeline-by-using-the-kubernetes-api.adoc
+++ b/modules/defining-a-pipeline-by-using-the-kubernetes-api.adoc
@@ -7,23 +7,6 @@
 
 You can define data science pipelines and pipeline versions by using the Kubernetes API, which stores them as custom resources in the cluster instead of the internal database. This approach makes it easier to use OpenShift GitOps (Argo CD) or similar tools to manage pipelines and pipeline versions, while still allowing you to manage them through the {productname-short} user interface (UI), API, and the Kubeflow Pipelines (`kfp`) Software Development Kit (SDK).
 
-ifndef::upstream[]
-[IMPORTANT]
-====
-ifdef::self-managed[]
-Defining pipeline versions by using the Kubernetes API is currently available in {productname-long} {vernum} as a Technology Preview feature.
-endif::[]
-ifdef::cloud-service[]
-Defining pipeline versions by using the Kubernetes API is currently available in {productname-long} as a Technology Preview feature.
-endif::[]
-Technology Preview features are not supported with {org-name} production service level agreements (SLAs) and might not be functionally complete.
-{org-name} does not recommend using them in production.
-These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-For more information about the support scope of {org-name} Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::[]
-
 .Prerequisites
 * You have previously created a data science project that is available and has a pipeline server (a `DataSciencePipelinesApplication` custom resource).
 * You have installed the OpenShift command-line interface (CLI).


### PR DESCRIPTION
Remove Tech Preview note from Kubernetes DSP feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced Technology Preview notices with a detailed, runnable procedure for using Kubernetes API storage for pipelines.
  - Added step-by-step workflow: login, configure the application to use Kubernetes API storage, and create Pipeline and PipelineVersion resources with YAML and oc apply.
  - Included verification commands to confirm resource creation.
  - Added a warning: switching to Kubernetes API storage hides existing database-backed pipelines in the UI/API; guidance provided to revert if needed.
  - Clarified prerequisites and labels applied after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->