### PR TITLE
Update to add link to task list in a Note

### DIFF
--- a/modules/lmeval-evaluation-job.adoc
+++ b/modules/lmeval-evaluation-job.adoc
@@ -9,6 +9,11 @@ LM-Eval service defines a new Custom Resource Definition (CRD) called `LMEvalJob
 
 To run an evaluation job, create an `LMEvalJob` object with the following information: `model`, `model arguments`, `task`, and `secret`. 
 
+[NOTE]
+--
+For a list of TrustyAI-supported tasks, see link:https://trustyai.org/docs/main/component-lm-eval#_lm_eval_task_support[LMEval task support]. 
+--
+
 After the `LMEvalJob` is created, the LM-Eval service runs the evaluation job.  The status and results of the `LMEvalJob` object update when the information is available.
 
 [NOTE]


### PR DESCRIPTION
Update to add a Note with a link to LMEval supported tasks list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a NOTE after “To run an evaluation job” with a link to TrustyAI-supported LMEval tasks, improving discoverability of available tasks for evaluations.
  * Clarifies guidance for users selecting tasks and running evaluations.
  * Presented as a non-intrusive AsciiDoc note for readability.
  * No changes to functionality, APIs, or data; purely editorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->