### PR TITLE
RHOAING-32257 Storage size note

### DIFF
--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -27,7 +27,7 @@ When resizing a PVC backed by AWS EBS in {productname-short}, you might see the 
 
 [source,terminal]
 ----
-"VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit. Wait at least 6 hours between modifications per EBS volume".
+VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit. Wait at least 6 hours between modifications per EBS volume.
 ----
 This is an AWS EBS service limit, not specific to NVIDIA NIM, KServe, or any application. 
 It applies to all workloads using EBS-backed PVCs. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a note about storage size after deployment is limited to once per 6 hours

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Verification note to “Configuring the default PVC size for your cluster” about the AWS EBS VolumeModificationRateExceeded error when resizing EBS-backed PVCs.
  * Clarifies this is an AWS service limit affecting all EBS-backed workloads, not specific to our stack.
  * Describes AWS EBS CSI driver behavior during the cooldown and includes the exact error message to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->