### PR TITLE
Guardrail updates for 2.24

### DIFF
--- a/assemblies/configuring-the-guardrails-orchestrator-service.adoc
+++ b/assemblies/configuring-the-guardrails-orchestrator-service.adoc
@@ -30,7 +30,7 @@ The following sections describe how to deploy Guardrails Orchestrator and provid
 include::modules/deploying-the-guardrails-orchestrator-service.adoc[leveloffset=+1]
 include::modules/guardrails-orchestrator-parameters.adoc[leveloffset=+1]
 include::modules/guardrails-orchestrator-hap-scenario.adoc[leveloffset=+1]
-include::modules/guardrails-orchestrator-configuring-regex-guardrails-gateway.adoc[leveloffset=+1]
+include::modules/configuring-the-regex-detector-and-guardrails-gateway.adoc[leveloffset=+1]
 include::modules/guardrails-orchestrator-regex-using.adoc[leveloffset=+2]
 include::modules/guardrails-orchestrator-querying-using-guardrails-gateway.adoc[leveloffset=+2]
 include::modules/configuring-the-opentelemetry-exporter.adoc[leveloffset=+1]

--- a/modules/configuring-the-built-in-detector-and-guardrails-gateway.adoc
+++ b/modules/configuring-the-built-in-detector-and-guardrails-gateway.adoc
@@ -1,11 +1,11 @@
 :_module-type: PROCEDURE
 
 ifdef::context[:parent-context: {context}]
-[id="configuring-regex-guardrails-gateway_{context}"]
-= Configuring the regex detector and guardrails gateway
+[id="configuring-the-built-in-detector-and-guardrails-gateway_{context}"]
+= Configuring the built-in detector and guardrails gateway
 [role='_abstract']
 
-The regex detector and guardrails gateway are sidecar containers that you can deploy with the `GuardrailsOrchestrator` service, either individually or together. Use the `GuardrailsOrchestrator` custom resource (CR) to enable them.
+The built-in detectors and guardrails gateway are sidecar containers that you can deploy with the `GuardrailsOrchestrator` service, either individually or together. Use the `GuardrailsOrchestrator` custom resource (CR) to enable them. This example uses the regex built-in detector to demonstrate the process.
 
 .Prerequisites
 * You have cluster administrator privileges for your {openshift-platform} cluster.

--- a/modules/guardrails-orchestrator-parameters.adoc
+++ b/modules/guardrails-orchestrator-parameters.adoc
@@ -33,7 +33,7 @@ You can modify the following parameters for the `GuardrailsOrchestrator` CR obje
 
 |`routes` *(optional)* | The resulting endpoints for detections used with regex detectors
 
-|`enableRegexDetectors` *(optional)*| A boolean value to use to inject the regex detector sidecar container into the orchestrator pod. The regex detector is a lightweight HTTP server designed to parse text using predefined patterns or custom regular expressions.
+|`enableBuiltInDetectors` *(optional)*| A boolean value to inject the built-in detector sidecar container into the orchestrator pod. The  built-in detector is a lightweight HTTP server designed to perform detections based on predefined patterns or custom regular expressions.
 
 |`enableGuardrailsGateway` *(optional)*| A boolean value to enable controlled interaction with the orchestrator service by enforcing stricter access to its exposed endpoints. It provides a mechanism of configuring fixed detector pipelines, and then provides a unique `/v1/chat/completions` endpoint per configured detector pipeline.
 


### PR DESCRIPTION
Guardrail updates for 2.24 mainly to 7.2 and 7.3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to use “built-in detectors” (plural) instead of a regex-only detector, with examples demonstrating the regex built-in detector.
  * Renamed documented parameter from enableRegexDetectors to enableBuiltInDetectors and clarified that the built-in detector sidecar supports predefined patterns and custom regular expressions.
  * Reorganized orchestrator service configuration content for clarity; no behavioral changes.
  * Preserved existing usage and prerequisites; readers should now follow the updated built-in detectors terminology and parameter name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->