### PR TITLE
RHOAI-33689 ose-oauth-proxy image update

### DIFF
--- a/modules/api-workbench-creating.adoc
+++ b/modules/api-workbench-creating.adoc
@@ -170,7 +170,7 @@ spec:
               name: oauth-config
             - mountPath: /etc/tls/private
               name: tls-certificates
-          image: 'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f10....401fee97fa4f4542b6b7c9bc46'
+          image: 'registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5'
           args:
             - '--provider=openshift'
             - '--https-address=:8443'


### PR DESCRIPTION
Updating the ose-oauth-proxy image reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Notebook YAML example to reference the latest supported OAuth Proxy container image (RHEL9), aligning with current platform standards and improving security and compatibility.
  - The example’s structure and other fields remain unchanged; behavior is unaffected.
  - No action required for existing deployments. Users copying the example should use the updated image reference to ensure consistency with supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->