### PR TITLE
Reorganize RHOAI RAG documentation into llama stack

### DIFF
--- a/assemblies/deploying-a-rag-stack-in-a-data-science-project.adoc
+++ b/assemblies/deploying-a-rag-stack-in-a-data-science-project.adoc
@@ -17,7 +17,7 @@ To deploy the RAG stack in a data science project, complete the following tasks:
 * Ingest domain data into Milvus by running Docling in a data science pipeline or Jupyter notebook. This process keeps the embeddings synchronized with the source data.
 * Expose and secure the model endpoints.
 
-include::modules/activating-the-llama-stack-operator.adoc[leveloffset=+1]
+include::modules/overview-of-rag.adoc[leveloffset=+1]
 include::modules/deploying-a-llama-model-with-kserve.adoc[leveloffset=+1]
 include::modules/testing-your-vllm-model-endpoints.adoc[leveloffset=+1]
 include::modules/deploying-a-llamastackdistribution-instance.adoc[leveloffset=+1]

--- a/modules/overview-of-llama-stack.adoc
+++ b/modules/overview-of-llama-stack.adoc
@@ -1,7 +1,7 @@
 :_module-type: CONCEPT
 
-[id="working-with-llama-stack_{context}"]
-= Working with Llama Stack
+[id="overview-of-llama-stack_{context}"]
+= Overview of Llama Stack
 
 [role="_abstract"]
 Llama Stack is a unified AI runtime environment designed to simplify the deployment and management of generative AI workloads on {productname-short}. Llama Stack integrates LLM inference servers, vector databases, and retrieval services in a single stack, optimized for Retrieval-Augmented Generation (RAG) and agent-based AI workflows. In {openshift-platform}, the Llama Stack Operator manages the deployment lifecycle of these components, ensuring scalability, consistency, and integration with {productname-short} projects.

--- a/working-with-llama-stack.adoc
+++ b/working-with-llama-stack.adoc
@@ -1,7 +1,7 @@
 ---
 layout: docs
-title: Working with RAG
-permalink: /docs/working-with-rag
+title: Working with Llama Stack
+permalink: /docs/working-with-llama-stack
 custom_css: asciidoc.css
 ---
 //:self-managed:
@@ -13,8 +13,8 @@ include::_artifacts/document-attributes-global.adoc[]
 :compat-mode:
 :context: rag
 
-= Working with RAG
+= Working with Llama Stack
 
-include::modules/overview-of-rag.adoc[leveloffset=+1]
-include::modules/working-with-llama-stack.adoc[leveloffset=+1]
+include::modules/overview-of-llama-stack.adoc[leveloffset=+1]
+include::modules/activating-the-llama-stack-operator.adoc[leveloffset=+1]
 include::assemblies/deploying-a-rag-stack-in-a-data-science-project.adoc[leveloffset=+1]


### PR DESCRIPTION
**Description**

Llama stack is growing more as a platform in future versions of RHOAI, this PR reworks the existing RAG documentation. RAG is enabled with the Llama stack operator so I moved some of the sections around to display llama stack as the primary. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Renamed “Working with RAG” to “Working with Llama Stack,” updating titles and permalinks.
  * Updated overview title and anchor to “Overview of Llama Stack.”
  * Expanded the deployment guide with new sections on ingesting content, querying ingested content, preparing documents for retrieval, and search types.
  * Replaced an activation overview with a broader overview in the deployment flow.
  * Extended task sequencing to include additional ingest and search steps.
  * Ensured existing references remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->