### PR TITLE
Add note about rate limit on certain PVCs

### DIFF
--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -10,6 +10,11 @@ To configure how resources are claimed within your {productname-short} cluster, 
 
 //Users cannot access the basic workbench launcher or create a new workbench until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
+[NOTE] 
+====
+When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter the error, `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-back PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
+====
+
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 

--- a/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
+++ b/modules/configuring-the-default-pvc-size-for-your-cluster.adoc
@@ -10,11 +10,6 @@ To configure how resources are claimed within your {productname-short} cluster, 
 
 //Users cannot access the basic workbench launcher or create a new workbench until redeployment is complete. {org-name} recommends that administrators consider the impact of these restrictions when determining the best time to change the default PVC size.
 
-[NOTE] 
-====
-When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter the error, `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-back PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
-====
-
 .Prerequisites
 * You have logged in to {productname-short} as a user with {productname-short} administrator privileges. 
 

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -39,7 +39,7 @@ The *Deploy model* dialog opens.
 
 [NOTE] 
 ====
-When resizing a PersistentVolumeClaim (PVC) backed by Amazon EBS in {productname-short}, you may encounter `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least six hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the Amazon EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an Amazon EBS service limit that applies to all workloads using EBS-backed PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
+When resizing a PersistentVolumeClaim (PVC) backed by Amazon EBS in {productname-short}, you may encounter `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least six hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the Amazon EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an Amazon EBS service limit that applies to all workloads using EBS-backed PVCs.
 ====
 
 .. In the *Number of model server replicas to deploy* field, specify a value.

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -39,7 +39,7 @@ The *Deploy model* dialog opens.
 
 [NOTE] 
 ====
-When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-backed PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
+When resizing a PersistentVolumeClaim (PVC) backed by Amazon EBS in {productname-short}, you may encounter `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least six hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the Amazon EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an Amazon EBS service limit that applies to all workloads using EBS-backed PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
 ====
 
 .. In the *Number of model server replicas to deploy* field, specify a value.

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -36,6 +36,12 @@ The *Deploy model* dialog opens.
 .. In the *Model deployment name* field, enter a unique name for the deployment.
 .. From the *NVIDIA NIM* list, select the NVIDIA NIM model that you want to deploy. For more information, see link:https://docs.nvidia.com/nim/large-language-models/latest/supported-models.html[Supported Models^]
 .. In the *NVIDIA NIM storage size* field, specify the size of the cluster storage instance that will be created to store the NVIDIA NIM model.
+
+[NOTE] 
+====
+When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter the error, `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-back PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
+====
+
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.
 . From the *Hardware profile* list, select a hardware profile.

--- a/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-NVIDIA-NIM-model-serving-platform.adoc
@@ -39,7 +39,7 @@ The *Deploy model* dialog opens.
 
 [NOTE] 
 ====
-When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter the error, `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-back PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
+When resizing a PersistentVolumeClaim (PVC) backed by AWS EBS in {productname-short}, you may encounter `VolumeModificationRateExceeded: You've reached the maximum modification rate per volume limit.` To avoid this error, wait at least 6 hours between modifications per EBS volume. If you resize a PVC before the cooldown expires, the AWS EBS CSI driver (`ebs.csi.aws.com`) fails with this error. This error is an AWS EBS service limit that applies to all workloads using EBS-backed PVCs, and is not specific to NVIDIA NIM, KServe, or any application.
 ====
 
 .. In the *Number of model server replicas to deploy* field, specify a value.


### PR DESCRIPTION
## Description
Add note about rate limit

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a note about AWS EBS PVC resize errors (VolumeModificationRateExceeded): wait at least six hours between EBS volume resize operations to avoid failures from the Amazon EBS CSI driver; clarifies this is an AWS service limit affecting all EBS-backed PVCs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->