### PR TITLE
RHOAIENG-30160_rev2: Adding module 

### DIFF
--- a/assemblies/configuring-your-model-serving-platform.adoc
+++ b/assemblies/configuring-your-model-serving-platform.adoc
@@ -12,6 +12,7 @@ As an {productname-short} administrator, you can enable your preferred serving p
 
 include::modules/about-model-serving.adoc[leveloffset=+1]
 include::modules/model-serving-runtimes.adoc[leveloffset=+1]
+include::modules/model-serving-runtimes-for-accelerators.adoc[leveloffset=+1]
 include::modules/ref-supported-runtimes.adoc[leveloffset=+2]
 include::modules/ref-tested-verified-runtimes.adoc[leveloffset=+2]
 

--- a/modules/model-serving-runtimes-for-accelerators.adoc
+++ b/modules/model-serving-runtimes-for-accelerators.adoc
@@ -1,7 +1,7 @@
-:_module-type: CONCEPT
+:_module-type: REFERENCE
 
-[id="using-accelerators-with-vllm_{context}"]
-= Using accelerators with vLLM
+[id="model-serving-runtimes-for-accelerators_{context}"]
+= Model-serving runtimes for accelerators
 
 [role="_abstract"]
 {productname-short} includes support for NVIDIA, AMD and Intel Gaudi accelerators. {productname-short} also includes preinstalled model-serving runtimes that provide accelerator support.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Local build



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a new section covering model-serving runtimes for accelerators within “About model-serving platforms.”
  - The new content appears in both the overview excerpt and the full documentation page.
  - Renamed the section to “Model-serving runtimes for accelerators.”
  - Updated anchors and metadata to align with reference-style documentation and support cross-references.
  - No functional or behavioral changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->