### PR TITLE
RHOAIENG-29328: Correct 'using' > 'by using'

### DIFF
--- a/modules/overview-of-model-registries.adoc
+++ b/modules/overview-of-model-registries.adoc
@@ -40,7 +40,7 @@ To use model registries in {productname-short}, an {openshift-platform} cluster 
 
 After the model registry component is enabled, an {productname-short} administrator can create model registries in {productname-short} and grant model registry access to the data scientists that will work with them. For more information, see link:{rhoaidocshome}{default-format-url}/managing_model_registries[Managing model registries].
 
-Data scientists with access to a model registry can store, share, version, deploy, and track models using the model registry feature. For more information, see link:{rhoaidocshome}{default-format-url}/working_with_model_registries[Working with model registries]. 
+Data scientists with access to a model registry can store, share, version, deploy, and track models by using the model registry feature. For more information, see link:{rhoaidocshome}{default-format-url}/working_with_model_registries[Working with model registries]. 
 endif::[]
 
 With the addition of the model catalog feature, you can discover models that are available and ready for your organization to register, deploy, and customize. This functionality starts with connecting users with the Granite family of models, as well as the teacher and judge models used with the LAB-tuning workflow. 

--- a/working-with-model-registries.adoc
+++ b/working-with-model-registries.adoc
@@ -34,6 +34,6 @@ include::modules/deleting-a-model-registry.adoc[leveloffset=+1]
 
 = Working with model registries
 
-As a data scientist in {productname-short}, you can store, share, version, deploy, and track models using the model registry feature. 
+As a data scientist in {productname-short}, you can store, share, version, deploy, and track models by using the model registry feature. 
 
 include::assemblies/working-with-model-registries.adoc[leveloffset=+1]


### PR DESCRIPTION
replaces 'using' with 'by using'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified wording in multiple model registry documentation pages to improve readability (e.g., “using” to “by using”).
  - Applied updates consistently across relevant sections without altering links or surrounding content.
  - No functional or behavioral changes; purely editorial improvements for clearer understanding of model registry capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->