### PR TITLE
Cherrypick Kueue workbench PR 2.24

### DIFF
--- a/modules/api-workbench-creating.adoc
+++ b/modules/api-workbench-creating.adoc
@@ -57,12 +57,14 @@ metadata:
     notebooks.kubeflow.org/last-activity: '2024-07-30T20:27:25Z'
   name: my-workbench # <5>
   namespace: my-data-science-project # <6>
+  labels:
+    kueue.x-k8s.io/queue-name: <local-queue-name> # <7>
 spec:
   template:
     spec:
       affinity: {}
       containers:
-        - resources: # <7>
+        - resources: # <8>
             limits:
               cpu: '2'
               memory: 8Gi
@@ -90,7 +92,7 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 1
-          env: # <8>
+          env: # <9>
             - name: NOTEBOOK_ARGS
               value: |-
                 --ServerApp.port=8888
@@ -125,9 +127,9 @@ spec:
               name: trusted-ca
               readOnly: true
               subPath: ca-bundle.crt
-          image: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-notebook:1.0' # <9>
+          image: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/my-custom-notebook:1.0' # <10>
           workingDir: /opt/app-root/src
-        - resources: # <10>
+        - resources: # <11>
             limits:
               cpu: 100m
               memory: 64Mi


### PR DESCRIPTION
Cherrypicked https://github.com/opendatahub-io/opendatahub-documentation/pull/949 for v2.24

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the example YAML guidance to include queueing Notebook Pods when Kueue is enabled, with a new introductory item about setting the queue label and a link to managing workloads with Kueue.
  * Reordered the example list to emphasize queuing prerequisites before deployment size, environment variables, Notebook image, and OAuth injection.
  * Added clarifications and cross-references; no changes to existing fields’ behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->