### PR TITLE
RHOAIENG-34358: Update naming for kserve deployment modes

### DIFF
--- a/assemblies/deploying-models.adoc
+++ b/assemblies/deploying-models.adoc
@@ -14,9 +14,15 @@ include::modules/using-oci-containers-for-model-storage.adoc[leveloffset=+1]
 include::modules/storing-a-model-in-oci-image.adoc[leveloffset=+1]
 
 = Deploying models on the single-model serving platform
-You can use the single-model serving platform to deploy large models, such as large language models (LLMs). This platform is based on the KServe component. You can deploy models in either **advanced** or **standard mode**. Advanced mode uses {org-name} {openshift-platform} Serverless for serverless deployments, while standard mode uses KServe Raw Deployment and does not require serverless dependencies.
 
-On the single-model serving platform, each model is deployed from its own dedicated model server. This helps you to deploy, monitor, scale, and maintain large models that require more resources.
+The single-model serving platform deploys each model from its own dedicated model server. This architecture is ideal for deploying, monitoring, scaling, and maintaining large models that require more resources, such as large language models (LLMs).
+
+The platform is based on the KServe component and offers two deployment modes:
+
+* *Knative Serverless*: Uses {org-name} OpenShift Serverless for deployments that can automatically scale based on demand.
+
+* *KServe RawDeployment*: Uses a standard deployment method that does not require serverless dependencies.
+
 
 include::modules/about-kserve-deployment-modes.adoc[leveloffset=+1] 
 include::modules/deploying-models-on-the-single-model-serving-platform.adoc[leveloffset=+1] 

--- a/assemblies/deploying-models.adoc
+++ b/assemblies/deploying-models.adoc
@@ -19,10 +19,9 @@ The single-model serving platform deploys each model from its own dedicated mode
 
 The platform is based on the KServe component and offers two deployment modes:
 
-* *Knative Serverless*: Uses {org-name} OpenShift Serverless for deployments that can automatically scale based on demand.
-
 * *KServe RawDeployment*: Uses a standard deployment method that does not require serverless dependencies.
 
+* *Knative Serverless*: Uses {org-name} OpenShift Serverless for deployments that can automatically scale based on demand.
 
 include::modules/about-kserve-deployment-modes.adoc[leveloffset=+1] 
 include::modules/deploying-models-on-the-single-model-serving-platform.adoc[leveloffset=+1] 

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -6,7 +6,12 @@
 
 KServe offers two deployment modes for serving models. The default mode, *Knative Serverless*, is based on the open-source Knative project and provides powerful autoscaling capabilities. It integrates with {org-name} OpenShift Serverless and {org-name} OpenShift Service Mesh. Alternatively, the *KServe RawDeployment* mode offers a more traditional deployment method with fewer dependencies.
 
-Your initial configuration has long-term implications: a setup for *Knative Serverless* allows you to use both modes, while a setup for only *KServe RawDeployment* limits you to that mode. Use the following comparison to choose the option that best fits your requirements.
+Before you choose an option, understand how your initial configuration affects future deployments:
+
+* *If you configure for `Knative Serverless`*: You can use both `Knative Serverless` and `KServe RawDeployment` modes.
+* *If you configure for `KServe RawDeployment` only*: You can only use the `KServe RawDeployment` mode.
+
+Use the following comparison to choose the option that best fits your requirements.
 
 .Comparison of deployment modes
 [options="header", cols="1,2,2"]
@@ -30,7 +35,7 @@ a|
 * Does not support scaling to zero by default, which might result in higher costs during periods of low traffic.
 
 |Dependencies
-|Requires the {org-name} OpenShift Serverless Operator, {org-name} OpenShift Service Mesh, and Authorino.
+|Requires the {org-name} OpenShift Serverless Operator and {org-name} OpenShift Service Mesh. Authorino is required only if you enable token authentication and external routes.
 |Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Route`.
 
 |Configuration flexibility
@@ -44,6 +49,6 @@ a|
 |Setup complexity
 a|
 * Introduces additional complexity in setup and management.
-* Might require manual configuration if Serverless is already installed on the cluster.
+* Might require additional configuration; if Serverless is not already installed on the cluster, you must install and configure it.
 |Requires a simpler setup with fewer dependencies.
 |===

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -35,8 +35,11 @@ a|
 * Does not support scaling to zero by default, which might result in higher costs during periods of low traffic.
 
 |Dependencies
-|Requires the {org-name} OpenShift Serverless Operator and {org-name} OpenShift Service Mesh. Authorino is required only if you enable token authentication and external routes.
-|Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Horizontal Pod Scaler`.
+a| 
+* {org-name} OpenShift Serverless Operator
+* {org-name} OpenShift Service Mesh
+* Authorino. Only required only if you enable token authentication and external routes.
+a|None; uses standard Kubernetes resources such as `Deployment`, `Service`, and `Horizontal Pod Autoscaler`.
 
 |Configuration flexibility
 |Has some customization limitations inherited from Knative compared to raw Kubernetes deployments.
@@ -44,11 +47,9 @@ a|
 
 |Resource footprint
 |Larger, due to the additional dependencies required for serverless functionality.
-|Smaller resource footprint compared to `Knative Serverless` mode.
+|Smaller.
 
 |Setup complexity
-a|
-* Introduces additional complexity in setup and management.
-* Might require additional configuration; if Serverless is not already installed on the cluster, you must install and configure it.
+|Might require additional configuration in setup and management. If Serverless is not already installed on the cluster, you must install and configure it.
 |Requires a simpler setup with fewer dependencies.
 |===

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -4,9 +4,9 @@
 
 = About KServe deployment modes
 
-KServe offers two deployment modes for serving models. The default mode, `Knative Serverless`, is based on the open-source Knative project and provides powerful autoscaling capabilities. It integrates with {org-name} OpenShift Serverless and {org-name} OpenShift Service Mesh. Alternatively, the `KServe RawDeployment` mode offers a more traditional deployment method with fewer dependencies.
+KServe offers two deployment modes for serving models. The default mode, *Knative Serverless*, is based on the open-source Knative project and provides powerful autoscaling capabilities. It integrates with {org-name} OpenShift Serverless and {org-name} OpenShift Service Mesh. Alternatively, the *KServe RawDeployment* mode offers a more traditional deployment method with fewer dependencies.
 
-Your initial configuration has long-term implications: a setup for `Knative Serverless` allows you to use both modes, while a setup for only `KServe RawDeployment` limits you to that mode. Use the following comparison to choose the option that best fits your requirements.
+Your initial configuration has long-term implications: a setup for *Knative Serverless* allows you to use both modes, while a setup for only *KServe RawDeployment* limits you to that mode. Use the following comparison to choose the option that best fits your requirements.
 
 .Comparison of deployment modes
 [options="header", cols="1,2,2"]
@@ -26,8 +26,8 @@ a|
 * Scales up automatically based on request volume.
 * Supports scaling down to zero when idle to save costs.
 a|
-* Does not support automatic scaling.
-* Does not support scaling down to zero, which might result in higher costs during periods of low traffic.
+* No built-in autoscaling; you can configure Kubernetes Event-Driven Autoscaling (KEDA) or Horizontal Pod Autoscaler (HPA) on your deployment.
+* Does not support scaling to zero by default, which might result in higher costs during periods of low traffic.
 
 |Dependencies
 |Requires the {org-name} OpenShift Serverless Operator, {org-name} OpenShift Service Mesh, and Authorino.

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -39,8 +39,8 @@ a|
 |Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Route`.
 
 |Configuration flexibility
-|Has customization limitations inherited from Knative, such as when mounting multiple volumes.
-|Enables traditional pod configurations, such as mounting multiple volumes, which is not available using Knative.
+|Has some customization limitations inherited from Knative compared to raw Kubernetes deployments.
+|Provides full control over pod specifications because it uses standard Kubernetes `Deployment` resources.
 
 |Resource footprint
 |Larger, due to the additional dependencies required for serverless functionality.

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -36,7 +36,7 @@ a|
 
 |Dependencies
 |Requires the {org-name} OpenShift Serverless Operator and {org-name} OpenShift Service Mesh. Authorino is required only if you enable token authentication and external routes.
-|Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Route`.
+|Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Horizontal Pod Scaler`.
 
 |Configuration flexibility
 |Has some customization limitations inherited from Knative compared to raw Kubernetes deployments.

--- a/modules/about-kserve-deployment-modes.adoc
+++ b/modules/about-kserve-deployment-modes.adoc
@@ -1,52 +1,49 @@
 :_module-type: CONCEPT
 
 [id='about-kserve-deployment-modes_{context}']
+
 = About KServe deployment modes
 
-You can deploy models in either **advanced** or **standard** deployment mode.
+KServe offers two deployment modes for serving models. The default mode, `Knative Serverless`, is based on the open-source Knative project and provides powerful autoscaling capabilities. It integrates with {org-name} OpenShift Serverless and {org-name} OpenShift Service Mesh. Alternatively, the `KServe RawDeployment` mode offers a more traditional deployment method with fewer dependencies.
 
-Advanced deployment mode uses Knative Serverless. By default, KServe integrates with {org-name} OpenShift Serverless and Red Hat OpenShift Service Mesh to deploy models on the single-model serving platform. {org-name} Serverless is based on the open source link:https://knative.dev/docs/[Knative^] project and requires the {org-name} OpenShift Serverless Operator.
+Your initial configuration has long-term implications: a setup for `Knative Serverless` allows you to use both modes, while a setup for only `KServe RawDeployment` limits you to that mode. Use the following comparison to choose the option that best fits your requirements.
 
-Alternatively, you can use standard deployment mode, which uses KServe RawDeployment mode and does not require the {org-name} OpenShift Serverless Operator, {org-name} OpenShift Service Mesh, or Authorino. 
+.Comparison of deployment modes
+[options="header", cols="1,2,2"]
+|===
+|Criterion |`Knative Serverless` |`KServe RawDeployment`
 
-If you configure KServe for **advanced** deployment mode, you can set up your data science project to serve models in both **advanced** and **standard** deployment mode. However, if you configure KServe for only **standard** deployment mode, you can only use **standard** deployment mode.
+|Default mode
+|Yes
+|No
 
-There are both advantages and disadvantages to using each of these deployment modes:
+|Recommended use case
+|Most workloads.
+|Custom serving setups or models that must remain active.
 
-== Advanced mode
+|Autoscaling
+a|
+* Scales up automatically based on request volume.
+* Supports scaling down to zero when idle to save costs.
+a|
+* Does not support automatic scaling.
+* Does not support scaling down to zero, which might result in higher costs during periods of low traffic.
 
-Advantages:
+|Dependencies
+|Requires the {org-name} OpenShift Serverless Operator, {org-name} OpenShift Service Mesh, and Authorino.
+|Does not require additional dependencies. Uses standard Kubernetes resources like `Deployment`, `Service`, and `Route`.
 
-* Enables autoscaling based on request volume: 
-** Resources scale up automatically when receiving incoming requests.
-** Optimizes resource usage and maintains performance during peak times.
+|Configuration flexibility
+|Has customization limitations inherited from Knative, such as when mounting multiple volumes.
+|Enables traditional pod configurations, such as mounting multiple volumes, which is not available using Knative.
 
-* Supports scale down to and from zero using Knative:
-** Allows resources to scale down completely when there are no incoming requests.
-** Saves costs by not running idle resources.
+|Resource footprint
+|Larger, due to the additional dependencies required for serverless functionality.
+|Smaller resource footprint compared to `Knative Serverless` mode.
 
-Disadvantages:
-
-* Has customization limitations:
-** Serverless is backed by Knative and implicitly inherits the same design choices, such as when mounting multiple volumes.
-* Dependency on Knative for scaling:
-** Introduces additional complexity in setup and management compared to traditional scaling methods.
-* Cluster scoped component:
-** If the cluster already has Serverless configured, you must manually configure the cluster to make it work with {productname-short}.
-
-== Standard mode
-
-Advantages:
-
-* Enables deployment with Kubernetes resources, such as `Deployment`, `Service`, `Route`, and `Horizontal Pod Autoscaler`, without additional dependencies like {org-name} Serverless, {org-name} Service Mesh, and Authorino.
-** The resulting model deployment has a smaller resource footprint compared to advanced mode.
-
-* Enables traditional Deployment/Pod configurations, such as mounting multiple volumes, which is not available using Knative.
-** Beneficial for applications requiring complex configurations or multiple storage mounts.
-
-Disadvantages:
-
-* Does not support automatic scaling:
-** Does not support automatic scaling down to zero resources when idle.
-** Might result in higher costs during periods of low traffic.
-
+|Setup complexity
+a|
+* Introduces additional complexity in setup and management.
+* Might require manual configuration if Serverless is already installed on the cluster.
+|Requires a simpler setup with fewer dependencies.
+|===

--- a/modules/deploying-a-model-from-the-model-catalog.adoc
+++ b/modules/deploying-a-model-from-the-model-catalog.adoc
@@ -63,10 +63,10 @@ If project-scoped runtimes exist, the *Serving runtime* list includes subheading
 NOTE: The *Model framework* list shows only the frameworks that are supported by the model-serving runtime that you specified when you deployed your model.
 +
 ifndef::upstream[]
-. From the **Deployment mode** list, select *Standard* or *Advanced*. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
+. From the **Deployment mode** list, select *KServe RawDeployment* or *Knative Serverless*. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
 endif::[]
 ifdef::upstream[]
-. From the **Deployment mode** list, select *Standard* or *Advanced*. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
+. From the **Deployment mode** list, select *KServe RawDeployment* or *Knative Serverless*. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
 endif::[]
 .. In the *Number of model server replicas to deploy* field, specify a value.
 .. From the *Model server size* list, select a value.

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -105,10 +105,10 @@ The *Deploy model* dialog opens.
 If project-scoped runtimes exist, the *Serving runtime* list includes subheadings to distinguish between global runtimes and project-scoped runtimes.
 . From the *Model framework (name - version)* list, select a value.
 ifndef::upstream[]
-. From the **Deployment mode** list, select KServe RawDeployment or Knative Serverless. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/rhoai-user_rhoai-user#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
+. From the **Deployment mode** list, select *KServe RawDeployment* or *Knative Serverless*. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/rhoai-user_rhoai-user#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
 endif::[]
 ifdef::upstream[]
-. From the **Deployment mode** list, select KServe RawDeployment or Knative Serverless. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
+. From the **Deployment mode** list, select *KServe RawDeployment* or *Knative Serverless*. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
 endif::[]
 . In the *Number of model server replicas to deploy* field, specify a value.
 . The following options are only available if you have created a hardware profile:

--- a/modules/deploying-models-on-the-single-model-serving-platform.adoc
+++ b/modules/deploying-models-on-the-single-model-serving-platform.adoc
@@ -22,17 +22,17 @@ endif::[]
 * You have enabled the single-model serving platform.
 ifdef::self-managed[]
 ifndef::disconnected[]
-* (Advanced deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
+* (Knative Serverless deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
 endif::[]
 ifdef::disconnected[]
-* (Advanced deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
+* (Knative Serverless deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}_in_a_disconnected_environment/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
 endif::[]
 endif::[]
 ifdef::cloud-service[]
-* (Advanced deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
+* (Knative Serverless deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider. For more information, see link:{rhoaidocshome}{default-format-url}/installing_and_uninstalling_{url-productname-short}/installing-the-single-model-serving-platform_component-install#adding-an-authorization-provider_component-install[Adding an authorization provider for the single-model serving platform].
 endif::[]
 ifdef::upstream[]
-* (Advanced deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider.
+* (Knative Serverless deployments only) To enable token authentication and external model routes for deployed models, you have added Authorino as an authorization provider.
 endif::[]
 
 * You have created a data science project.
@@ -105,10 +105,10 @@ The *Deploy model* dialog opens.
 If project-scoped runtimes exist, the *Serving runtime* list includes subheadings to distinguish between global runtimes and project-scoped runtimes.
 . From the *Model framework (name - version)* list, select a value.
 ifndef::upstream[]
-. From the **Deployment mode** list, select standard or advanced. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
+. From the **Deployment mode** list, select KServe RawDeployment or Knative Serverless. For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/rhoai-user_rhoai-user#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
 endif::[]
 ifdef::upstream[]
-. From the **Deployment mode** list, select standard or advanced. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
+. From the **Deployment mode** list, select KServe RawDeployment or Knative Serverless. For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
 endif::[]
 . In the *Number of model server replicas to deploy* field, specify a value.
 . The following options are only available if you have created a hardware profile:

--- a/modules/enabling-the-single-model-serving-platform.adoc
+++ b/modules/enabling-the-single-model-serving-platform.adoc
@@ -23,7 +23,7 @@ endif::[]
 .. In the left menu, click *Settings* -> *Cluster settings*.
 .. Locate the *Model serving platforms* section.
 .. To enable the single-model serving platform for projects, select the *Single-model serving platform* checkbox.
-.. Select *Standard (No additional dependencies)* or *Advanced (Serverless and Service Mesh)* deployment mode. 
+.. Select *KServe RawDeployment* or *Knative Serverless* deployment mode. 
 +
 ifdef::upstream[]
 For more information about these deployment mode options, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].

--- a/modules/enabling-trustyai-kserve-integration.adoc
+++ b/modules/enabling-trustyai-kserve-integration.adoc
@@ -17,7 +17,7 @@ To use the TrustyAI service with *KServe RawDeployment* deployment mode, you mus
 
 [NOTE]
 --
-Advanced deployment mode does not require this additional setup. 
+*Knative Serverless* deployment mode does not require this additional setup. 
 --
 
 .Prerequisites

--- a/modules/enabling-trustyai-kserve-integration.adoc
+++ b/modules/enabling-trustyai-kserve-integration.adoc
@@ -1,11 +1,11 @@
 :_module-type: PROCEDURE
 
 [id='enabling-trustyai-kserve-integration_{context}']
-= Enabling TrustyAI Integration with standard model deployment
+= Enabling TrustyAI Integration with KServe RawDeployment
 
 [role='_abstract']
-TrustyAI can be used with standard and advanced model deployments. 
-Standard deployment mode is based on KServe RawDeployment and advanced deployment mode is based on KServe Serverless. 
+TrustyAI can be used with *Knative Serverless* and *KServe RawDeployment* deployment modes. 
+
 ifdef::upstream[]
 For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
 endif::[]
@@ -13,7 +13,7 @@ ifndef::upstream[]
 For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
 endif::[]
 
-To use the TrustyAI service with standard model deployments, you must first update the KServe ConfigMap, then create another ConfigMap in your model's namespace to hold the Certificate Authority (CA) certificate. 
+To use the TrustyAI service with *Knative Serverless* deployment mode, you must first update the KServe ConfigMap, then create another ConfigMap in your model's namespace to hold the Certificate Authority (CA) certificate. 
 
 [NOTE]
 --
@@ -24,7 +24,7 @@ Advanced deployment mode does not require this additional setup.
 * You have installed {productname-long}.
 * You have cluster administrator privileges for your {productname-short} cluster.
 * You have access to a data science cluster that has TrustyAI enabled.
-* You have enabled the model serving platform in either standard or advanced mode.
+* You have enabled the model serving platform in either *Knative Serveless* or *KServe RawDeployment* mode.
 
 .Procedure
 . Update the KServe ConfigMap (`inferenceservice-config`) in the {productname-short} UI:

--- a/modules/enabling-trustyai-kserve-integration.adoc
+++ b/modules/enabling-trustyai-kserve-integration.adoc
@@ -4,7 +4,7 @@
 = Enabling TrustyAI Integration with KServe RawDeployment
 
 [role='_abstract']
-TrustyAI can be used with *Knative Serverless* and *KServe RawDeployment* deployment modes. 
+TrustyAI can be used with *KServe RawDeployment* and *Knative Serverless* deployment modes. 
 
 ifdef::upstream[]
 For more information about deployment modes, see link:{odhdocshome}/deploying-models/#about-kserve-deployment-modes_odh-user[About KServe deployment modes].
@@ -24,7 +24,7 @@ Advanced deployment mode does not require this additional setup.
 * You have installed {productname-long}.
 * You have cluster administrator privileges for your {productname-short} cluster.
 * You have access to a data science cluster that has TrustyAI enabled.
-* You have enabled the model serving platform in either *Knative Serverless* or *KServe RawDeployment* mode.
+* You have enabled the model serving platform in either *KServe RawDeployment* or *Knative Serverless* mode.
 
 .Procedure
 . Update the KServe ConfigMap (`inferenceservice-config`) in the {productname-short} UI:

--- a/modules/enabling-trustyai-kserve-integration.adoc
+++ b/modules/enabling-trustyai-kserve-integration.adoc
@@ -13,7 +13,7 @@ ifndef::upstream[]
 For more information about deployment modes, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#about-kserve-deployment-modes_rhoai-user[About KServe deployment modes].
 endif::[]
 
-To use the TrustyAI service with *Knative Serverless* deployment mode, you must first update the KServe ConfigMap, then create another ConfigMap in your model's namespace to hold the Certificate Authority (CA) certificate. 
+To use the TrustyAI service with *KServe RawDeployment* deployment mode, you must first update the KServe ConfigMap, then create another ConfigMap in your model's namespace to hold the Certificate Authority (CA) certificate. 
 
 [NOTE]
 --
@@ -24,7 +24,7 @@ Advanced deployment mode does not require this additional setup.
 * You have installed {productname-long}.
 * You have cluster administrator privileges for your {productname-short} cluster.
 * You have access to a data science cluster that has TrustyAI enabled.
-* You have enabled the model serving platform in either *Knative Serveless* or *KServe RawDeployment* mode.
+* You have enabled the model serving platform in either *Knative Serverless* or *KServe RawDeployment* mode.
 
 .Procedure
 . Update the KServe ConfigMap (`inferenceservice-config`) in the {productname-short} UI:

--- a/modules/ref-dashboard-configuration-options.adoc
+++ b/modules/ref-dashboard-configuration-options.adoc
@@ -99,7 +99,7 @@ On the *Deploy model* dialog when using the single-model serving platform:
 
 &nbsp; &nbsp; &nbsp; - If the {org-name} OpenShift Serverless Operator and {org-name} OpenShift Service Mesh Operator are not installed, hides the *Deployment mode* list, and sets the deployment mode to *Standard*.
 
-To hide these deployment-mode lists and set the deployment mode to *Advanced* when using the single-model serving platform, set the `spec.dashboardConfig.disableKServeRaw` value to `true`.
+To hide these deployment-mode lists and set the deployment mode to *Knative Serverless* when using the single-model serving platform, set the `spec.dashboardConfig.disableKServeRaw` value to `true`.
 | `spec.dashboardConfig.` +
 `disableModelCatalog` | `true` | Hides the *Models → Model catalog* menu item in the dashboard navigation menu. 
 To show this menu item, set the value to `false`.

--- a/modules/using-a-hugging-face-prompt-injection-detector-with-the-guardrails-orchestrator.adoc
+++ b/modules/using-a-hugging-face-prompt-injection-detector-with-the-guardrails-orchestrator.adoc
@@ -25,10 +25,10 @@ These examples provided contain sample text that some people may find offensive,
 * You have downloaded and installed the OpenShift command-line interface (CLI). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI^].
 
 ifdef::upstream[]
-* You have configured KServe to deploy models in standard mode. For more information, see link:{odhdocshome}/serving-models/#deploying-models-using-the-single-model-serving-platform_serving-large-models[Deploying models on the single-model serving platform].
+* You have configured KServe to deploy models in *KServe RawDeployment* mode. For more information, see link:{odhdocshome}/serving-models/#deploying-models-using-the-single-model-serving-platform_serving-large-models[Deploying models on the single-model serving platform].
 endif::[]
 ifndef::upstream[]
-* You have configured KServe to deploy models in standard mode. For more information, see link:{rhoaidocshome}{default-format-url}/deploying_models/deploying_models_on_the_single_model_serving_platform#deploying-models-on-the-single-model-serving-platform_rhoai-user[Deploying models on the single-model serving platform].
+* You have configured KServe to deploy models in *KServe RawDeployment* mode. For more information, see link:{rhoaidocshome}{default-format-url}/deploying_models/rhoai-user_rhoai-user#deploying-models-on-the-single-model-serving-platform_rhoai-user[Deploying models on the single-model serving platform].
 endif::[]
 
 ifdef::upstream[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Advanced mode is now *Knative Serverless*
Standard mode is now *KServe RawDeployment*

Updated the naming in the docs as needed.

## How Has This Been Tested?
Local build

## Preview

<img width="536" height="663" alt="Screenshot 2025-09-25 at 1 58 57 PM" src="https://github.com/user-attachments/assets/8a274cdb-ffa9-4df1-91c7-243b20d9250e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed “Standard/Advanced” to “KServe RawDeployment/Knative Serverless” across deployment docs and UI guidance.
  * Replaced mode-centric prose with a concise side-by-side comparison table of deployment modes.
  * Updated titles, cross-references, prerequisites, and UI workflow text to match new terminology.
  * Added upstream-conditional guidance and dashboard/customization notes.
  * Expanded hardware/GPU notes and setup guidance for various accelerators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->