### PR TITLE
UI update in OpenShift Cluster Manager

### DIFF
--- a/modules/allocating-additional-resources-to-data-science-users.adoc
+++ b/modules/allocating-additional-resources-to-data-science-users.adoc
@@ -23,9 +23,9 @@ endif::[]
 
 .Procedure
 . Log in to OpenShift Cluster Manager (link:https://console.redhat.com/openshift/[https://console.redhat.com/openshift/]).
-. Click *Clusters*.
+. Click *Cluster List*.
 +
-The *Clusters* page opens.
+The *Cluster List* page opens.
 . Click the name of the cluster you want to allocate additional resources to.
 . Click *Actions* -> *Edit node count*.
 . Select a *Machine pool* from the list.


### PR DESCRIPTION
Small update to UI in OpenShift Cluster Manager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated procedure text to reflect current UI labels: navigation now references “Cluster List” instead of “Clusters,” and the page title reads “The Cluster List page opens.”
  * Refined navigation instructions to match the latest interface while keeping the workflow unchanged (select a cluster, edit node count, choose a machine pool).
  * Ensures terminology consistency across steps, improving clarity for users following the allocation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->