### PR TITLE
RHOAIENG-27581: Removing and updating instances of RH marketplace

### DIFF
--- a/modules/enabling-applications-connected.adoc
+++ b/modules/enabling-applications-connected.adoc
@@ -17,7 +17,6 @@ ifndef::upstream[]
 Deployments containing Operators installed from OperatorHub may not be fully supported by {org-name}.
 ====
 endif::[]
-* Installing the Operator for the application from {org-name} Marketplace (link:https://marketplace.redhat.com/en-us/documentation/operators[Install Operators]).
 ifdef::upstream,self-managed[]
 * Installing the application as an {install-package} to your {openshift-platform} cluster (link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]).
 endif::[]

--- a/modules/next-steps-getting-started.adoc
+++ b/modules/next-steps-getting-started.adoc
@@ -92,7 +92,7 @@ ifdef::upstream[]
 link:{odhdocshome}/working-with-connected-applications/[Working with connected applications]
 endif::[]
 +
-Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through https://catalog.redhat.com/en/partners[Red Hat partners] and https://www.ibm.com/partnerplus/directory/companies[IBM Partner Plus Directory].
+Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through link:https://catalog.redhat.com/en/partners[Red Hat partners] and link:https://www.ibm.com/partnerplus/directory/companies[IBM Partner Plus Directory].
 
 
 == Additional resources

--- a/modules/next-steps-getting-started.adoc
+++ b/modules/next-steps-getting-started.adoc
@@ -92,7 +92,7 @@ ifdef::upstream[]
 link:{odhdocshome}/working-with-connected-applications/[Working with connected applications]
 endif::[]
 +
-Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through Red Hat Marketplace.
+Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through  https://catalog.redhat.com/en/partners[Red Hat partners] and https://www.ibm.com/partnerplus/directory/companies[IBM Partner Plus Directory].
 
 
 == Additional resources

--- a/modules/next-steps-getting-started.adoc
+++ b/modules/next-steps-getting-started.adoc
@@ -92,7 +92,7 @@ ifdef::upstream[]
 link:{odhdocshome}/working-with-connected-applications/[Working with connected applications]
 endif::[]
 +
-Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through  https://catalog.redhat.com/en/partners[Red Hat partners] and https://www.ibm.com/partnerplus/directory/companies[IBM Partner Plus Directory].
+Extend your core {productname-short} solution with integrated third-party applications. Several leading AI/ML software technology partners, including Starburst, Intel AI Tools, and IBM are also available through https://catalog.redhat.com/en/partners[Red Hat partners] and https://www.ibm.com/partnerplus/directory/companies[IBM Partner Plus Directory].
 
 
 == Additional resources


### PR DESCRIPTION
## Description
JIRA: https://issues.redhat.com/browse/RHOAIENG-27581

RH Marketplace is no longer available as of 1 April 2025. The opendatahub-documentation repo had instances of the marketplace in two adoc files, and this PR removes/updates those references.  

- enabling-applications-connected.adoc
- next-steps-getting-started.adoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the OperatorHub/Marketplace installation option from application installation guidance; upstream/self-managed instructions remain.
  * Updated "Explore extensions" to link to partner directories (Red Hat partners and IBM Partner Plus Directory) instead of Red Hat Marketplace.
  * No functional or behavioral product changes—documentation-only updates related to installation and partner discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->