### PR TITLE
Updates to some instances of v1alpha1 to v1

### DIFF
--- a/modules/configuring-trustyai-with-a-database.adoc
+++ b/modules/configuring-trustyai-with-a-database.adoc
@@ -122,7 +122,7 @@ If you already installed TrustyAI on a project, you can migrate the existing Tru
 +
 [source,subs="+quotes"]
 ----
-apiVersion: trustyai.opendatahub.io/v1alpha1
+apiVersion: trustyai.opendatahub.io/v1
 kind: TrustyAIService
 metadata:
   annotations:

--- a/modules/installing-trustyai-service-using-cli.adoc
+++ b/modules/installing-trustyai-service-using-cli.adoc
@@ -62,7 +62,7 @@ oc project my-project
 .Example CR file for TrustyAI using a database
 [source,subs="+quotes"]
 ----
-apiVersion: trustyai.opendatahub.io/v1alpha1
+apiVersion: trustyai.opendatahub.io/v1
 kind: TrustyAIService
 metadata:
   name: trustyai-service <1>
@@ -91,7 +91,7 @@ endif::[]
 .Example CR file for TrustyAI using a PVC
 [source,subs="+quotes"]
 ----
-apiVersion: trustyai.opendatahub.io/v1alpha1
+apiVersion: trustyai.opendatahub.io/v1
 kind: TrustyAIService
 metadata:
   name: trustyai-service <1>


### PR DESCRIPTION
Updates to some instances of v1alpha1 to v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all TrustyAIService examples to use apiVersion trustyai.opendatahub.io/v1 instead of v1alpha1.
  * Aligned installation and configuration guides with the current CRD version to prevent deprecation warnings.
  * Refreshed manifest snippets in CLI and configuration sections for consistency and accuracy.
  * No changes to steps or behavior; only API version strings were updated for clarity and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->