### PR TITLE
Apply proper AsciiDoc note formatting

### DIFF
--- a/assemblies/prepare-your-data-for-ai-consumption.adoc
+++ b/assemblies/prepare-your-data-for-ai-consumption.adoc
@@ -22,7 +22,10 @@ With Kubeflow Pipelines (KFP), you can automate complex, multi-step Docling data
 
 With the KFP Software Development Kit (SDK), you can define custom components and stitch them together into a complete pipeline. The SDK allows you to fully control and automate Docling conversion tasks with specific parameters.
 
-*Note:* You can build a custom runtime image to ensure that all required Docling dependencies are present for pipeline execution. For information on how to run a Docling pipeline with a custom image see the link:https://github.com/opendatahub-io/data-processing/tree/main/kubeflow-pipelines[Docling Pipeline documentation].
+[NOTE]
+====
+You can build a custom runtime image to ensure that all required Docling dependencies are present for pipeline execution. For information on how to run a Docling pipeline with a custom image see the link:https://github.com/opendatahub-io/data-processing/tree/main/kubeflow-pipelines[Docling Pipeline documentation].
+====
 
 include::modules/explore-the-kubeflow-pipeline-examples.adoc[leveloffset=+1]
 

--- a/modules/accessing-the-dashboard.adoc
+++ b/modules/accessing-the-dashboard.adoc
@@ -20,7 +20,10 @@ ifndef::upstream[]
 .Verification
 * Confirm that you and your users can log in to {productname-short} by using the instance URL.
 
-*Note:* In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/logging-in_get-started#viewing-installed-components_get-started[Viewing installed components].
+[NOTE]
+====
+In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{rhoaidocshome}{default-format-url}/getting_started_with_{url-productname-long}/logging-in_get-started#viewing-installed-components_get-started[Viewing installed components].
+====
 
 [role="_additional-resources"]
 .Additional resources
@@ -42,5 +45,8 @@ ifdef::upstream[]
 .Verification
 * Confirm that you and your users can log in to the {productname-short} dashboard by using the URL.
 
-*Note:* In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#viewing-installed-components_get-started[Viewing installed {productname-short} components].
+[NOTE]
+====
+In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{odhdocshome}/getting-started-with-open-data-hub/#viewing-installed-components_get-started[Viewing installed {productname-short} components].
+====
 endif::[]

--- a/modules/adding-certificates-to-a-cluster-ca-bundle.adoc
+++ b/modules/adding-certificates-to-a-cluster-ca-bundle.adoc
@@ -8,7 +8,10 @@ You can add a self-signed certificate to a cluster-wide Certificate Authority (C
 
 When the cluster-wide CA bundle is updated, the Cluster Network Operator (CNO) automatically detects the change and injects the updated bundle into the `odh-trusted-ca-bundle` ConfigMap, making the certificate available to {productname-short} components.
 
-*Note:* By default, the management state for the Trusted CA bundle is `Managed` (that is, the `spec.trustedCABundle.managementState` field in the {productname-long} Operator's DSCI object is set to `Managed`). If you change this setting to `Unmanaged`, you must manually update the `odh-trusted-ca-bundle` ConfigMap to include the updated cluster-wide CA bundle.
+[NOTE]
+====
+By default, the management state for the Trusted CA bundle is `Managed` (that is, the `spec.trustedCABundle.managementState` field in the {productname-long} Operator's DSCI object is set to `Managed`). If you change this setting to `Unmanaged`, you must manually update the `odh-trusted-ca-bundle` ConfigMap to include the updated cluster-wide CA bundle.
+====
 
 ifdef::upstream[]
 Alternatively, you can add certificates to a custom CA bundle, as described in link:{odhdocshome}/installing-open-data-hub/#adding-certificates-to-a-custom-ca-bundle_certs[Adding certificates to a custom CA bundle].

--- a/modules/adding-feature-definitions-and-initializing-your-feature-store-instance.adoc
+++ b/modules/adding-feature-definitions-and-initializing-your-feature-store-instance.adoc
@@ -10,7 +10,10 @@ When you initialize the Feature Store instance, Feature Store completes the foll
 
 * Scans the Python files in your feature repository and finds all Feature Store object definitions, such as feature views, entities, and data sources.
 +
-*Note:* Feature Store reads all Python files recursively, including subdirectories, even if they do not contain feature definitions. For information on identifying Python files, such as imperative scripts that you want Feature Store to ignore, see _Specifying files to ignore_.
+[NOTE]
+====
+Feature Store reads all Python files recursively, including subdirectories, even if they do not contain feature definitions. For information on identifying Python files, such as imperative scripts that you want Feature Store to ignore, see _Specifying files to ignore_.
+====
 
 * Validates your feature definitions, for example, by checking for uniqueness of features within a feature view.
 
@@ -19,7 +22,10 @@ When you initialize the Feature Store instance, Feature Store completes the foll
 * Creates or updates all necessary Feature Store infrastructure. The exact infrastructure that Feature Store creates depends on the provider configuration that you have set in `feature_store.yaml`. 
 For example, when you specify `local` as your provider, Feature Store creates the infrastructure on the local cluster.
 +
-*Note:*  When you use a cloud provider, such as Google Cloud or Amazon Web Service, the `feast apply` command creates cloud infrastructure that might incur costs for your organization.
+[NOTE]
+====
+When you use a cloud provider, such as Google Cloud or Amazon Web Service, the `feast apply` command creates cloud infrastructure that might incur costs for your organization.
+====
 
 .Prerequisites
 

--- a/modules/api-custom-image-creating.adoc
+++ b/modules/api-custom-image-creating.adoc
@@ -8,7 +8,10 @@ You can create a custom image by using the `ImageStream` Custom Resource Definit
 
 In the following procedure, you configure an `ImageStream` CRD and use it to create the `ImageStream` Custom Resource (CR) that defines the custom image. The `ImageStream` CR provides a URL for the custom image, which you need when you want to use the custom image to configure a workbench.
 
-*Note:* The custom image that you create also becomes available in the {productname-short} dashboard so that your data scientist users can select it when they create a workbench.
+[NOTE]
+====
+The custom image that you create also becomes available in the {productname-short} dashboard so that your data scientist users can select it when they create a workbench.
+====
 
 .Prerequisites
 

--- a/modules/creating-a-project-workbench.adoc
+++ b/modules/creating-a-project-workbench.adoc
@@ -43,8 +43,11 @@ The resource name is what your resource is labeled in OpenShift.
 Valid characters include lowercase letters, numbers, and hyphens (-).
 The resource name cannot exceed 30 characters, and it must start with a letter and end with a letter or number.
 +
-*Note:* You cannot change the resource name after the workbench is created.
+[NOTE]
+====
+You cannot change the resource name after the workbench is created.
 You can edit only the display name and the description.
+====
 
 
 . Optional: In the *Description* field, enter a description for your workbench.

--- a/modules/creating-a-project.adoc
+++ b/modules/creating-a-project.adoc
@@ -34,8 +34,11 @@ The resource name is what your resource is labeled in OpenShift.
 Valid characters include lowercase letters, numbers, and hyphens (-).
 The resource name cannot exceed 30 characters, and it must start with a letter and end with a letter or number.
 +
-*Note:* You cannot change the resource name after the project is created.
+[NOTE]
+====
+You cannot change the resource name after the project is created.
 You can edit only the display name and the description.
+====
 
 . Optional: In the *Description* field, provide a project description.
 

--- a/modules/creating-feature-views.adoc
+++ b/modules/creating-feature-views.adoc
@@ -19,7 +19,10 @@ When you create a feature project, the `feature_repo` subfolder includes a Pytho
 
 To define new features, you can edit the code in the example file or add a new file to the feature repository.
 
-*Note:* Feature views only work with timestamped data. If your data does not contain timestamps, insert dummy timestamps. The following example shows how to create a table with dummy timestamps for PostgreSQL-based data:
+[NOTE]
+====
+Feature views only work with timestamped data. If your data does not contain timestamps, insert dummy timestamps. The following example shows how to create a table with dummy timestamps for PostgreSQL-based data:
+====
 
 [source,python]
 ----

--- a/modules/installing-odh-components.adoc
+++ b/modules/installing-odh-components.adoc
@@ -53,10 +53,13 @@ You can use the OpenShift web console to install specific components of {product
 
 .Verification
 . Select *Home* -> *Projects*, and then select the *opendatahub* project.
-. On the *Project details* page, click the *Workloads* tab and confirm that the {productname-short} core components are running. 
+. On the *Project details* page, click the *Workloads* tab and confirm that the {productname-short} core components are running.
 //For more information, see link:https://opendatahub.io/docs/tiered-components[Tiered Components].
 
-*Note:* In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{odhdocshome}/installing-open-data-hub/#viewing-installed-components_get-started[Viewing installed {productname-short} components].
+[NOTE]
+====
+In the {productname-long} dashboard, users can view the list of the installed {productname-short} components, their corresponding source (upstream) components, and the versions of the installed components, as described in link:{odhdocshome}/installing-open-data-hub/#viewing-installed-components_get-started[Viewing installed {productname-short} components].
+====
 
 .Next steps
 * Optional: link:{odhdocshome}/installing-open-data-hub/#configuring-pipelines-with-your-own-argo-workflows-instance_install[Configuring pipelines with your own Argo Workflows instance]

--- a/modules/making-features-available-for-real-time-inference.adoc
+++ b/modules/making-features-available-for-real-time-inference.adoc
@@ -7,7 +7,10 @@ To make features available for real-time inference for use by ML engineers and d
 
 Materialization ensures that the same features are available for both model training and real-time predictions, making your ML workflow robust and reproducible. The online store serves the latest features to models for online prediction. Data scientists on your team with access to your project can access the features in the online store.
 
-*Note:* Feature Store uses a "push" method for online serving. This means that the Feature Store pushes feature values to the online store, which reduces the latency of feature retrieval. This is more efficient than a "pull" method, where the model serving system would make a request to the Feature Store to retrieve feature values. 
+[NOTE]
+====
+Feature Store uses a "push" method for online serving. This means that the Feature Store pushes feature values to the online store, which reduces the latency of feature retrieval. This is more efficient than a "pull" method, where the model serving system would make a request to the Feature Store to retrieve feature values.
+====
 
 .Prerequisites
 

--- a/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
+++ b/modules/preventing-users-from-adding-applications-to-the-dashboard.adoc
@@ -9,10 +9,16 @@ By default, {productname-short} administrators can add applications to the {prod
 As an {productname-short} administrator, you can disable the ability for {productname-short} administrators to add applications to the dashboard.
 
 ifndef::upstream[]
-*Note:* The *Start basic workbench* tile is enabled by default. To disable it, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#hiding-the-default-basic-workbench-application_dashboard[Hiding the default basic workbench application].
+[NOTE]
+====
+The *Start basic workbench* tile is enabled by default. To disable it, see link:{rhoaidocshome}{default-format-url}/managing_openshift_ai/managing-applications-that-show-in-the-dashboard#hiding-the-default-basic-workbench-application_dashboard[Hiding the default basic workbench application].
+====
 endif::[]
 ifdef::upstream[]
-*Note:* The *Start basic workbench* tile is enabled by default. To disable it, see link:{odhdocshome}/managing-odh/#hiding-the-default-basic-workbench-application_dashboard[Hiding the default basic workbench application].
+[NOTE]
+====
+The *Start basic workbench* tile is enabled by default. To disable it, see link:{odhdocshome}/managing-odh/#hiding-the-default-basic-workbench-application_dashboard[Hiding the default basic workbench application].
+====
 endif::[]
 
 .Prerequisite

--- a/modules/viewing-connected-applications.adoc
+++ b/modules/viewing-connected-applications.adoc
@@ -19,7 +19,10 @@ The *Explore* page displays applications that are available for use with {produc
 
 . Click a tile for more information about the application or to access the *Enable* button.
 +
-*Note:* The *Enable* button is visible only if an application does not require an OpenShift Operator installation.
+[NOTE]
+====
+The *Enable* button is visible only if an application does not require an OpenShift Operator installation.
+====
 
 .Verification
 


### PR DESCRIPTION
`*Note:*` is not real markup. Updated all examples in repo to use full AsciiDoc `NOTE` formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized presentation of notes throughout documentation by converting inline formatting to consistent block-style note format for improved readability and visual hierarchy.

* **Style**
  * Applied uniform formatting standards to informational blocks across the documentation suite, ensuring consistent appearance and emphasizing key guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->