### PR TITLE
Adding find-unused.sh script

### DIFF
--- a/scripts/find-unused.sh
+++ b/scripts/find-unused.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/find-unused.sh
+#
+# Lists .adoc files in modules/ that are NOT referenced by AsciiDoc include:: statements.
+# Usage: scripts/find-unused.sh [--remove] [modules_dir] [repo_root]
+# Optionally removes unused files with --remove.
+
+set -e
+
+REMOVE=0
+# Parse optional flags before positional args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remove) REMOVE=1; shift ;;
+    --) shift; break ;;
+    -*) echo "Unknown option: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+MODULES_DIR="${1:-modules}"
+ROOT_DIR="${2:-.}"
+
+# Collect *.adoc files in modules/, ignore symlinks
+mapfile -d '' MODULE_FILES < <(find "$MODULES_DIR" -type f -name '*.adoc' -not -xtype l -print0)
+
+# Collect *.adoc files outside modules/ (don’t descend into modules/)
+mapfile -d '' SEARCH_FILES < <(find "$ROOT_DIR" -path "$MODULES_DIR" -prune -o -type f -name '*.adoc' -not -xtype l -print0)
+
+# Extract referenced module paths from include::...[] statements
+declare -A USED=()
+if ((${#SEARCH_FILES[@]})); then
+  while IFS= read -r ref; do
+    ref="${ref#./}"   # normalize leading ./
+    USED["$ref"]=1
+  done < <(
+    printf '%s\0' "${SEARCH_FILES[@]}" |
+      xargs -0r grep -h -o -E '^[[:space:]]*include::[^[]*modules/[^[]*\.adoc' |
+      sed -E 's/^[[:space:]]*include:://' |
+      sed -E 's#^\./##' |
+      LC_ALL=C sort -u
+  )
+fi
+
+# Report or remove unused modules
+unused=()
+for f in "${MODULE_FILES[@]}"; do
+  rel="${f#./}"
+  if [[ -z "${USED["$rel"]+y}" ]]; then
+    unused+=("$rel")
+  fi
+done
+
+if ((${#unused[@]})); then
+  echo -e "\nUnused modules:"
+  printf '%s\n' "${unused[@]}" | LC_ALL=C sort
+  if ((REMOVE)); then
+    echo -e "\nRemoved modules:"
+    rm -v "${unused[@]}"
+  fi
+else
+  echo "All module .adoc files are referenced."
+fi


### PR DESCRIPTION
This script lists .adoc files in `modules/` folder that are NOT referenced by AsciiDoc `include::` statements.

Unused modules:

```text
modules/about-kserve-deployment-modes.adoc
modules/about-the-NVIDIA-NIM-model-serving-platform.adoc
modules/about-the-model-serving-platform.adoc
modules/auth-on-llama-stack.adoc
modules/cleaning-up-resources.adoc
modules/configuring-the-built-in-detector-and-guardrails-gateway.adoc
modules/creating-a-bias-metric-using-cli.adoc
modules/creating-a-bias-metric-using-dashboard.adoc
modules/creating-a-drift-metric-using-cli.adoc
modules/deleting-a-bias-metric-using-cli.adoc
modules/deleting-a-bias-metric-using-dashboard.adoc
modules/deleting-a-deployed-model.adoc
modules/deleting-a-model-server.adoc
modules/deploying-models-using-the-single-model-serving-platform.adoc
modules/deploying-the-guardrails-orchestrator-service.adoc
modules/enabling-distributed-inference.adoc
modules/guardrails-orchestrator-parameters.adoc
modules/installing-kserve.adoc
modules/installing-trustyai-service-using-cli.adoc
modules/installing-trustyai-service-using-dashboard.adoc
modules/llama-stack-high-avail-and-auto.adoc
modules/making-features-available-for-real-time-inference.adoc
modules/nvidia-gpu-integration.adoc
modules/overview-of-kueue-resources.adoc
modules/overview-of-model-monitoring.adoc
modules/overview-pgvector-vector-databases.adoc
modules/ref-accelerator-metrics.adoc
modules/ref-cpu-metrics.adoc
modules/ref-vllm-metrics.adoc
modules/requesting-a-lime-explanation-using-cli.adoc
modules/requesting-a-shap-explanation-using-cli.adoc
modules/running-a-workload-with-a-kueue-hardware-profile.adoc
modules/stopping-starting-model.adoc
modules/updating-a-model-server.adoc
modules/updating-the-deployment-properties-of-a-deployed-model.adoc
modules/viewing-a-deployed-model.adoc
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a utility script to detect documentation modules that are not referenced elsewhere, listing unused files for review.
  * Provides an optional removal mode to delete unreferenced module files automatically and verbose output to confirm actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->