### PR TITLE
Fix: Remove erroneous inclusion of MySQL support in TrustyAI Service docs

### DIFF
--- a/modules/configuring-trustyai-with-a-database.adoc
+++ b/modules/configuring-trustyai-with-a-database.adoc
@@ -5,7 +5,7 @@
 
 [role='_abstract']
 
-If you have a relational database in your {openshift-platform} cluster such as MySQL or MariaDB, you can configure TrustyAI to use your database instead of a persistent volume claim (PVC). Using a database instead of a PVC for storage can improve scalability, performance, and data management in TrustyAI. 
+If you have a MariaDB relational database in your {openshift-platform} cluster, you can configure TrustyAI to use your database instead of a persistent volume claim (PVC). Using a database instead of a PVC for storage can improve scalability, performance, and data management in TrustyAI.
 Provide TrustyAI with a database configuration secret before deployment. You can create a secret or specify the name of an existing Kubernetes secret within your project. 
 
 .Prerequisites
@@ -33,8 +33,6 @@ ifdef::upstream[]
 
 * The data scientist has created a project, as described in link:{odhdocshome}/working-on-projects/#creating-a-project_projects[Creating a project], that contains the models that the data scientist wants to monitor.  
 endif::[]
-
-* If you are configuring the TrustyAI service with an external MySQL database, your database must already be in your cluster and use at least MySQL version 5.x. However, {org-name} recommends that you use MySQL version 8.x. 
 
 * If you are configuring the TrustyAI service with a MariaDB database, your database must already be in your cluster and use MariaDB version 10.3 or later. However, {org-name} recommends that you use at least MariaDB version 10.5.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addresses https://redhat.atlassian.net/browse/RHOAIENG-54786 -

Right now, the TrustyAI service docs describes MySQL support, which is inaccurate for ODH and RHOAI. This PR clarifies that only MariaDB is supported.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
