### PR TITLE
Update Red Hat Connectivity Link documentation URLs to version 1.3

### DIFF
--- a/modules/configuring-authentication-for-llmd.adoc
+++ b/modules/configuring-authentication-for-llmd.adoc
@@ -5,11 +5,11 @@
 
 [role='_abstract']
 
-{org-name} Connectivity Link provides Kubernetes-native authentication and authorization capabilities for {llmd} inference endpoints. Connectivity Link works with the gateway to intercept incoming traffic before it reaches the vLLM inference service, validating the requests based on authentication tokens and authorization policies. For more information about Connectivity Link concepts and capabilities, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html-single/introduction_to_connectivity_link/index[Introduction to Connectivity Link^].
+{org-name} Connectivity Link provides Kubernetes-native authentication and authorization capabilities for {llmd} inference endpoints. Connectivity Link works with the gateway to intercept incoming traffic before it reaches the vLLM inference service, validating the requests based on authentication tokens and authorization policies. For more information about Connectivity Link concepts and capabilities, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/discover[Introduction to Connectivity Link^].
 
 .Prerequisites
 
-* You have installed {org-name} Connectivity Link version 1.1.1 or later. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_connectivity_link_on_openshift[Installing Connectivity Link on OpenShift].
+* You have installed {org-name} Connectivity Link version 1.1.1 or later. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/installing_on_openshift_container_platform[Installing Connectivity Link on OpenShift Container Platform].
 * You have access to the OpenShift CLI (`oc`).
 * The ServiceAccount has permission to get the corresponding `LLMInferenceService` and you have generated a JSON web token (JWT).
 

--- a/modules/enabling-authentication-and-authorization-for-llm-inference-service.adoc
+++ b/modules/enabling-authentication-and-authorization-for-llm-inference-service.adoc
@@ -77,4 +77,4 @@ The request returns a `401 Unauthorized` response, confirming that unauthenticat
 [role='_additional-resources']
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/configuring_and_deploying_gateway_policies_with_connectivity_link/app-developer-workflow_rhcl[Override your Gateway policies for auth and rate limiting^]
+* link:https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/configuring_and_deploying_gateway_policies#app-developer-workflow_rhcl[Override your Gateway policies for auth and rate limiting^]


### PR DESCRIPTION
- Update introduction URL from html-single/introduction_to_connectivity_link to html/discover
- Update installation URL from installing_connectivity_link_on_openshift to installing_on_openshift_container_platform
- Update gateway policies URL from configuring_and_deploying_gateway_policies_with_connectivity_link to configuring_and_deploying_gateway_policies
- All URLs verified to return HTTP 200

Fixes broken documentation links in authentication and authorization modules.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Red Hat Connectivity Link documentation references from version 1.2 to 1.3.
  * Adjusted prerequisite links to reference OpenShift Container Platform documentation.
  * Updated anchor paths to reflect reorganized documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->